### PR TITLE
fix: don't add nodes without committed roles via federation

### DIFF
--- a/api/v1alpha1/garagecluster_types.go
+++ b/api/v1alpha1/garagecluster_types.go
@@ -47,8 +47,10 @@ type GarageClusterSpec struct {
 	// +required
 	Replication ReplicationConfig `json:"replication"`
 
-	// Storage configures storage settings for metadata and data
-	// Not required for gateway clusters (gateway: true)
+	// Storage configures storage settings for metadata and data.
+	// Optional - sensible defaults are provided:
+	// - Storage clusters: 10Gi metadata, 100Gi data
+	// - Gateway clusters: 1Gi metadata only (data uses EmptyDir)
 	// +optional
 	Storage StorageConfig `json:"storage,omitempty"`
 
@@ -201,8 +203,8 @@ type GarageClusterSpec struct {
 	// Gateway marks this cluster as a gateway-only cluster.
 	// Gateway clusters don't store data - they only handle API requests.
 	// When true:
-	// - Creates a Deployment instead of StatefulSet (no PVCs)
-	// - Storage config is ignored
+	// - Creates a StatefulSet with metadata PVC only (for node identity persistence)
+	// - Data storage uses EmptyDir (gateways don't store blocks)
 	// - Pods are registered as gateway nodes in the layout (capacity=null)
 	// - Must specify connectTo to reference a storage cluster
 	// +optional
@@ -1049,6 +1051,12 @@ type GarageClusterStatus struct {
 	// TotalNodes is the total nodes across all clusters (local + remote)
 	// +optional
 	TotalNodes int `json:"totalNodes,omitempty"`
+
+	// DrainingNodes is the count of nodes that are draining data from an older layout version.
+	// These nodes had a storage role in a previous layout and are migrating data to other nodes.
+	// A non-zero value indicates a layout transition is in progress.
+	// +optional
+	DrainingNodes int `json:"drainingNodes,omitempty"`
 
 	// ObservedGeneration is the last observed generation
 	// +optional

--- a/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
@@ -1603,8 +1603,8 @@ spec:
                   Gateway marks this cluster as a gateway-only cluster.
                   Gateway clusters don't store data - they only handle API requests.
                   When true:
-                  - Creates a Deployment instead of StatefulSet (no PVCs)
-                  - Storage config is ignored
+                  - Creates a StatefulSet with metadata PVC only (for node identity persistence)
+                  - Data storage uses EmptyDir (gateways don't store blocks)
                   - Pods are registered as gateway nodes in the layout (capacity=null)
                   - Must specify connectTo to reference a storage cluster
                 type: boolean
@@ -2463,8 +2463,10 @@ spec:
                 type: object
               storage:
                 description: |-
-                  Storage configures storage settings for metadata and data
-                  Not required for gateway clusters (gateway: true)
+                  Storage configures storage settings for metadata and data.
+                  Optional - sensible defaults are provided:
+                  - Storage clusters: 10Gi metadata, 100Gi data
+                  - Gateway clusters: 1Gi metadata only (data uses EmptyDir)
                 properties:
                   data:
                     description: Data configures data block storage
@@ -3531,6 +3533,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              drainingNodes:
+                description: |-
+                  DrainingNodes is the count of nodes that are draining data from an older layout version.
+                  These nodes had a storage role in a previous layout and are migrating data to other nodes.
+                  A non-zero value indicates a layout transition is in progress.
+                type: integer
               endpoints:
                 description: Endpoints contains service endpoints
                 properties:

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -1603,8 +1603,8 @@ spec:
                   Gateway marks this cluster as a gateway-only cluster.
                   Gateway clusters don't store data - they only handle API requests.
                   When true:
-                  - Creates a Deployment instead of StatefulSet (no PVCs)
-                  - Storage config is ignored
+                  - Creates a StatefulSet with metadata PVC only (for node identity persistence)
+                  - Data storage uses EmptyDir (gateways don't store blocks)
                   - Pods are registered as gateway nodes in the layout (capacity=null)
                   - Must specify connectTo to reference a storage cluster
                 type: boolean
@@ -2463,8 +2463,10 @@ spec:
                 type: object
               storage:
                 description: |-
-                  Storage configures storage settings for metadata and data
-                  Not required for gateway clusters (gateway: true)
+                  Storage configures storage settings for metadata and data.
+                  Optional - sensible defaults are provided:
+                  - Storage clusters: 10Gi metadata, 100Gi data
+                  - Gateway clusters: 1Gi metadata only (data uses EmptyDir)
                 properties:
                   data:
                     description: Data configures data block storage
@@ -3531,6 +3533,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              drainingNodes:
+                description: |-
+                  DrainingNodes is the count of nodes that are draining data from an older layout version.
+                  These nodes had a storage role in a previous layout and are migrating data to other nodes.
+                  A non-zero value indicates a layout transition is in progress.
+                type: integer
               endpoints:
                 description: Endpoints contains service endpoints
                 properties:

--- a/schemas/garagecluster_v1alpha1.json
+++ b/schemas/garagecluster_v1alpha1.json
@@ -1426,7 +1426,7 @@
           "additionalProperties": false
         },
         "gateway": {
-          "description": "Gateway marks this cluster as a gateway-only cluster.\nGateway clusters don't store data - they only handle API requests.\nWhen true:\n- Creates a Deployment instead of StatefulSet (no PVCs)\n- Storage config is ignored\n- Pods are registered as gateway nodes in the layout (capacity=null)\n- Must specify connectTo to reference a storage cluster",
+          "description": "Gateway marks this cluster as a gateway-only cluster.\nGateway clusters don't store data - they only handle API requests.\nWhen true:\n- Creates a StatefulSet with metadata PVC only (for node identity persistence)\n- Data storage uses EmptyDir (gateways don't store blocks)\n- Pods are registered as gateway nodes in the layout (capacity=null)\n- Must specify connectTo to reference a storage cluster",
           "type": "boolean"
         },
         "image": {
@@ -2232,7 +2232,7 @@
           "type": "object"
         },
         "storage": {
-          "description": "Storage configures storage settings for metadata and data\nNot required for gateway clusters (gateway: true)",
+          "description": "Storage configures storage settings for metadata and data.\nOptional - sensible defaults are provided:\n- Storage clusters: 10Gi metadata, 100Gi data\n- Gateway clusters: 1Gi metadata only (data uses EmptyDir)",
           "properties": {
             "data": {
               "description": "Data configures data block storage",
@@ -3213,6 +3213,10 @@
             "type"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "drainingNodes": {
+          "description": "DrainingNodes is the count of nodes that are draining data from an older layout version.\nThese nodes had a storage role in a previous layout and are migrating data to other nodes.\nA non-zero value indicates a layout transition is in progress.",
+          "type": "integer"
         },
         "endpoints": {
           "description": "Endpoints contains service endpoints",


### PR DESCRIPTION
## Summary
- Fix federation incorrectly adding gateway nodes as storage nodes
- Federation now only syncs nodes that already have a committed role
- Nodes without roles are left for their own cluster controller to add

## Problem
Federation was adding remote nodes that didn't have committed roles yet, defaulting them to 100Gi storage capacity. This caused gateway nodes to be added as storage nodes (with capacity) instead of gateways (capacity: null).

This resulted in:
- Gateway nodes showing `capacity: 107374182400` instead of `null`
- Wrong zone assignment for gateway nodes
- Cluster health showing "unavailable" due to stale nodes

## Solution
Skip nodes without committed roles during federation. Let each cluster's controller add its own nodes with the correct settings:
- Gateway clusters add their nodes with `capacity: nil`
- Storage clusters add their nodes with capacity from PVC size

## Test plan
- [x] Unit tests pass
- [ ] Deploy to cluster and verify gateway nodes have correct capacity
- [ ] Verify cluster health returns to "healthy"