### PR TITLE
feat: implement skip-dead-nodes functionality for gateway clusters

### DIFF
--- a/api/v1alpha1/garagecluster_types.go
+++ b/api/v1alpha1/garagecluster_types.go
@@ -25,7 +25,7 @@ import (
 // GarageClusterSpec defines the desired state of GarageCluster
 type GarageClusterSpec struct {
 	// Image specifies the Garage container image to use
-	// +kubebuilder:default="dxflrs/garage:v2.1.0"
+	// +kubebuilder:default="dxflrs/garage:v2.2.0"
 	// +optional
 	Image string `json:"image,omitempty"`
 
@@ -653,6 +653,14 @@ type BlockConfig struct {
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MaxConcurrentReads *int `json:"maxConcurrentReads,omitempty"`
+
+	// MaxConcurrentWritesPerRequest is the maximum parallel block writes per PUT request.
+	// Higher values improve throughput but increase memory usage.
+	// Default: 3. Recommended: 10-30 for NVMe, 3-10 for HDD.
+	// Added in Garage v2.2.0.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	MaxConcurrentWritesPerRequest *int `json:"maxConcurrentWritesPerRequest,omitempty"`
 
 	// CompressionLevel is the zstd compression level
 	// 1-19: standard, 20-22: ultra, -1 to -99: fast, "none": disabled

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -103,6 +103,11 @@ func (in *BlockConfig) DeepCopyInto(out *BlockConfig) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.MaxConcurrentWritesPerRequest != nil {
+		in, out := &in.MaxConcurrentWritesPerRequest, &out.MaxConcurrentWritesPerRequest
+		*out = new(int)
+		**out = **in
+	}
 	if in.CompressionLevel != nil {
 		in, out := &in.CompressionLevel, &out.CompressionLevel
 		*out = new(string)

--- a/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
@@ -1066,6 +1066,14 @@ spec:
                       file reads
                     minimum: 1
                     type: integer
+                  maxConcurrentWritesPerRequest:
+                    description: |-
+                      MaxConcurrentWritesPerRequest is the maximum parallel block writes per PUT request.
+                      Higher values improve throughput but increase memory usage.
+                      Default: 3. Recommended: 10-30 for NVMe, 3-10 for HDD.
+                      Added in Garage v2.2.0.
+                    minimum: 1
+                    type: integer
                   ramBufferMax:
                     anyOf:
                     - type: integer
@@ -1609,7 +1617,7 @@ spec:
                   - Must specify connectTo to reference a storage cluster
                 type: boolean
               image:
-                default: dxflrs/garage:v2.1.0
+                default: dxflrs/garage:v2.2.0
                 description: Image specifies the Garage container image to use
                 type: string
               imagePullPolicy:

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -1066,6 +1066,14 @@ spec:
                       file reads
                     minimum: 1
                     type: integer
+                  maxConcurrentWritesPerRequest:
+                    description: |-
+                      MaxConcurrentWritesPerRequest is the maximum parallel block writes per PUT request.
+                      Higher values improve throughput but increase memory usage.
+                      Default: 3. Recommended: 10-30 for NVMe, 3-10 for HDD.
+                      Added in Garage v2.2.0.
+                    minimum: 1
+                    type: integer
                   ramBufferMax:
                     anyOf:
                     - type: integer
@@ -1609,7 +1617,7 @@ spec:
                   - Must specify connectTo to reference a storage cluster
                 type: boolean
               image:
-                default: dxflrs/garage:v2.1.0
+                default: dxflrs/garage:v2.2.0
                 description: Image specifies the Garage container image to use
                 type: string
               imagePullPolicy:

--- a/config/samples/cosi/garagecluster-e2e.yaml
+++ b/config/samples/cosi/garagecluster-e2e.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: garage-operator-system
 spec:
   replicas: 1
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
 
   replication:
     factor: 1

--- a/config/samples/garage_v1alpha1_garagecluster.yaml
+++ b/config/samples/garage_v1alpha1_garagecluster.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: garage-operator-system
 spec:
   replicas: 3
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
 
   replication:
     factor: 3
@@ -54,7 +54,7 @@ metadata:
   namespace: garage-operator-system
 spec:
   replicas: 3
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
 
   # Zone for this cluster - used for fault tolerance
   zone: us-east-1

--- a/config/samples/garage_v1alpha1_garagecluster_gateway.yaml
+++ b/config/samples/garage_v1alpha1_garagecluster_gateway.yaml
@@ -17,7 +17,7 @@ metadata:
   namespace: garage-operator-system
 spec:
   replicas: 2
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
 
   # Gateway mode - creates Deployment instead of StatefulSet, no PVCs
   gateway: true
@@ -63,7 +63,7 @@ metadata:
   namespace: edge-namespace
 spec:
   replicas: 3
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
 
   gateway: true
 
@@ -110,7 +110,7 @@ metadata:
   namespace: garage-operator-system
 spec:
   replicas: 2
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
 
   gateway: true
 

--- a/hack/e2e-cluster.sh
+++ b/hack/e2e-cluster.sh
@@ -1209,7 +1209,7 @@ metadata:
   namespace: $NAMESPACE
 spec:
   replicas: 1
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
   zone: test-zone
   replication:
     factor: 1

--- a/hack/e2e-multicluster.sh
+++ b/hack/e2e-multicluster.sh
@@ -345,7 +345,7 @@ metadata:
 spec:
   replicas: $replicas
   zone: $zone
-  image: "dxflrs/garage:v2.1.0"
+  image: "dxflrs/garage:v2.2.0"
   replication:
     factor: $replication_factor
     consistencyMode: consistent
@@ -1158,7 +1158,7 @@ metadata:
   namespace: $NAMESPACE
 spec:
   replicas: 1
-  image: "dxflrs/garage:v2.1.0"
+  image: "dxflrs/garage:v2.2.0"
   gateway: true
   replication:
     factor: 2

--- a/hack/test-resources.yaml
+++ b/hack/test-resources.yaml
@@ -23,7 +23,7 @@ spec:
   replicas: 3
 
   # Container image
-  image: dxflrs/garage:v2.1.0
+  image: dxflrs/garage:v2.2.0
 
   # Replication settings
   replication:

--- a/schemas/garagecluster_v1alpha1.json
+++ b/schemas/garagecluster_v1alpha1.json
@@ -900,6 +900,11 @@
               "minimum": 1,
               "type": "integer"
             },
+            "maxConcurrentWritesPerRequest": {
+              "description": "MaxConcurrentWritesPerRequest is the maximum parallel block writes per PUT request.\nHigher values improve throughput but increase memory usage.\nDefault: 3. Recommended: 10-30 for NVMe, 3-10 for HDD.\nAdded in Garage v2.2.0.",
+              "minimum": 1,
+              "type": "integer"
+            },
             "ramBufferMax": {
               "anyOf": [
                 {
@@ -1430,7 +1435,7 @@
           "type": "boolean"
         },
         "image": {
-          "default": "dxflrs/garage:v2.1.0",
+          "default": "dxflrs/garage:v2.2.0",
           "description": "Image specifies the Garage container image to use",
           "type": "string"
         },


### PR DESCRIPTION
- Added logic to skip dead nodes in gateway clusters to prevent them from getting stuck in the Draining state.
- Introduced handling for the skip-dead-nodes annotation to mark dead nodes as synced, allowing for smoother layout management.
- Enhanced layout history tracking to log warnings for stuck draining versions, indicating potential quorum issues.
- Updated Garage client with new methods for skipping dead nodes and retrieving layout history.