### PR TITLE
feat: add existingClaim support for storage volumes

### DIFF
--- a/api/v1alpha1/garagecluster_types.go
+++ b/api/v1alpha1/garagecluster_types.go
@@ -398,6 +398,12 @@ type DataStorageConfig struct {
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
 
+	// ExistingClaim uses an existing PVC instead of creating a new one.
+	// When set, size and storageClassName are ignored.
+	// The PVC must already exist and be compatible with the pod's requirements.
+	// +optional
+	ExistingClaim string `json:"existingClaim,omitempty"`
+
 	// Paths specifies multiple data directories with capacities
 	// For advanced multi-disk configurations
 	// +optional

--- a/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
@@ -2479,6 +2479,12 @@ spec:
                   data:
                     description: Data configures data block storage
                     properties:
+                      existingClaim:
+                        description: |-
+                          ExistingClaim uses an existing PVC instead of creating a new one.
+                          When set, size and storageClassName are ignored.
+                          The PVC must already exist and be compatible with the pod's requirements.
+                        type: string
                       paths:
                         description: |-
                           Paths specifies multiple data directories with capacities

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -2479,6 +2479,12 @@ spec:
                   data:
                     description: Data configures data block storage
                     properties:
+                      existingClaim:
+                        description: |-
+                          ExistingClaim uses an existing PVC instead of creating a new one.
+                          When set, size and storageClassName are ignored.
+                          The PVC must already exist and be compatible with the pod's requirements.
+                        type: string
                       paths:
                         description: |-
                           Paths specifies multiple data directories with capacities

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -25,6 +25,12 @@ import (
 	garagev1alpha1 "github.com/rajsinghtech/garage-operator/api/v1alpha1"
 )
 
+const (
+	metadataVolumeName = "metadata"
+	dataVolumeName     = "data"
+	testClusterName    = "test-cluster"
+)
+
 func TestResolveSecretConfig(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -353,15 +359,15 @@ func TestBuildVolumeClaimTemplates(t *testing.T) {
 			t.Errorf("got %d PVCs, want 2", len(pvcs))
 			return
 		}
-		if pvcs[0].Name != "metadata" {
-			t.Errorf("PVC[0] name = %q, want %q", pvcs[0].Name, "metadata")
+		if pvcs[0].Name != metadataVolumeName {
+			t.Errorf("PVC[0] name = %q, want %q", pvcs[0].Name, metadataVolumeName)
 		}
 		gotMetadataSize := pvcs[0].Spec.Resources.Requests[corev1.ResourceStorage]
 		if gotMetadataSize.String() != "10Gi" {
 			t.Errorf("Metadata size = %q, want %q", gotMetadataSize.String(), "10Gi")
 		}
-		if pvcs[1].Name != "data" {
-			t.Errorf("PVC[1] name = %q, want %q", pvcs[1].Name, "data")
+		if pvcs[1].Name != dataVolumeName {
+			t.Errorf("PVC[1] name = %q, want %q", pvcs[1].Name, dataVolumeName)
 		}
 		gotDataSize := pvcs[1].Spec.Resources.Requests[corev1.ResourceStorage]
 		if gotDataSize.String() != "100Gi" {
@@ -412,8 +418,8 @@ func TestBuildVolumeClaimTemplates(t *testing.T) {
 			t.Errorf("gateway cluster: got %d PVCs, want 1 (metadata only)", len(pvcs))
 			return
 		}
-		if pvcs[0].Name != "metadata" {
-			t.Errorf("PVC[0] name = %q, want %q", pvcs[0].Name, "metadata")
+		if pvcs[0].Name != metadataVolumeName {
+			t.Errorf("PVC[0] name = %q, want %q", pvcs[0].Name, metadataVolumeName)
 		}
 		gotMetadataSize := pvcs[0].Spec.Resources.Requests[corev1.ResourceStorage]
 		if gotMetadataSize.String() != "1Gi" {
@@ -450,4 +456,237 @@ func TestBuildVolumeClaimTemplates(t *testing.T) {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func TestBuildVolumeClaimTemplates_ExistingClaim(t *testing.T) {
+	t.Run("storage cluster - data existingClaim skips data PVC", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Storage: garagev1alpha1.StorageConfig{
+					Metadata: &garagev1alpha1.VolumeConfig{
+						Size: resource.MustParse("10Gi"),
+					},
+					Data: &garagev1alpha1.DataStorageConfig{
+						ExistingClaim: "my-existing-data-pvc",
+					},
+				},
+			},
+		}
+		pvcs := buildVolumeClaimTemplates(cluster)
+		if len(pvcs) != 1 {
+			t.Errorf("got %d PVCs, want 1 (metadata only)", len(pvcs))
+			return
+		}
+		if pvcs[0].Name != metadataVolumeName {
+			t.Errorf("PVC[0] name = %q, want %q", pvcs[0].Name, metadataVolumeName)
+		}
+	})
+
+	t.Run("storage cluster - metadata existingClaim skips metadata PVC", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Storage: garagev1alpha1.StorageConfig{
+					Metadata: &garagev1alpha1.VolumeConfig{
+						ExistingClaim: "my-existing-metadata-pvc",
+					},
+					Data: &garagev1alpha1.DataStorageConfig{
+						Size: ptrQuantity(resource.MustParse("100Gi")),
+					},
+				},
+			},
+		}
+		pvcs := buildVolumeClaimTemplates(cluster)
+		if len(pvcs) != 1 {
+			t.Errorf("got %d PVCs, want 1 (data only)", len(pvcs))
+			return
+		}
+		if pvcs[0].Name != dataVolumeName {
+			t.Errorf("PVC[0] name = %q, want %q", pvcs[0].Name, dataVolumeName)
+		}
+	})
+
+	t.Run("storage cluster - both existingClaims skips all PVCs", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Storage: garagev1alpha1.StorageConfig{
+					Metadata: &garagev1alpha1.VolumeConfig{
+						ExistingClaim: "my-existing-metadata-pvc",
+					},
+					Data: &garagev1alpha1.DataStorageConfig{
+						ExistingClaim: "my-existing-data-pvc",
+					},
+				},
+			},
+		}
+		pvcs := buildVolumeClaimTemplates(cluster)
+		if len(pvcs) != 0 {
+			t.Errorf("got %d PVCs, want 0 (both use existingClaim)", len(pvcs))
+		}
+	})
+
+	t.Run("gateway cluster - metadata existingClaim skips PVC", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Gateway: true,
+				Storage: garagev1alpha1.StorageConfig{
+					Metadata: &garagev1alpha1.VolumeConfig{
+						ExistingClaim: "my-existing-metadata-pvc",
+					},
+				},
+			},
+		}
+		pvcs := buildVolumeClaimTemplates(cluster)
+		if len(pvcs) != 0 {
+			t.Errorf("gateway cluster with existingClaim: got %d PVCs, want 0", len(pvcs))
+		}
+	})
+}
+
+func TestBuildVolumesAndMounts_ExistingClaim(t *testing.T) {
+	t.Run("storage cluster - data existingClaim creates PVC volume", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Storage: garagev1alpha1.StorageConfig{
+					Data: &garagev1alpha1.DataStorageConfig{
+						ExistingClaim: "my-existing-data-pvc",
+					},
+				},
+			},
+		}
+		cluster.Name = testClusterName
+		volumes, mounts := buildVolumesAndMounts(cluster)
+
+		// Check that data volume exists with PVC source
+		var dataVolume *corev1.Volume
+		for i := range volumes {
+			if volumes[i].Name == dataVolumeName {
+				dataVolume = &volumes[i]
+				break
+			}
+		}
+		if dataVolume == nil {
+			t.Error("data volume not found")
+			return
+		}
+		if dataVolume.PersistentVolumeClaim == nil {
+			t.Error("data volume should use PersistentVolumeClaim source")
+			return
+		}
+		if dataVolume.PersistentVolumeClaim.ClaimName != "my-existing-data-pvc" {
+			t.Errorf("data PVC claim name = %q, want %q", dataVolume.PersistentVolumeClaim.ClaimName, "my-existing-data-pvc")
+		}
+
+		// Verify mount still exists
+		var hasDataMount bool
+		for _, m := range mounts {
+			if m.Name == dataVolumeName {
+				hasDataMount = true
+				break
+			}
+		}
+		if !hasDataMount {
+			t.Error("data mount not found")
+		}
+	})
+
+	t.Run("storage cluster - metadata existingClaim creates PVC volume", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Storage: garagev1alpha1.StorageConfig{
+					Metadata: &garagev1alpha1.VolumeConfig{
+						ExistingClaim: "my-existing-metadata-pvc",
+					},
+				},
+			},
+		}
+		cluster.Name = testClusterName
+		volumes, mounts := buildVolumesAndMounts(cluster)
+
+		// Check that metadata volume exists with PVC source
+		var metadataVolume *corev1.Volume
+		for i := range volumes {
+			if volumes[i].Name == metadataVolumeName {
+				metadataVolume = &volumes[i]
+				break
+			}
+		}
+		if metadataVolume == nil {
+			t.Error("metadata volume not found")
+			return
+		}
+		if metadataVolume.PersistentVolumeClaim == nil {
+			t.Error("metadata volume should use PersistentVolumeClaim source")
+			return
+		}
+		if metadataVolume.PersistentVolumeClaim.ClaimName != "my-existing-metadata-pvc" {
+			t.Errorf("metadata PVC claim name = %q, want %q", metadataVolume.PersistentVolumeClaim.ClaimName, "my-existing-metadata-pvc")
+		}
+
+		// Verify mount still exists
+		var hasMetadataMount bool
+		for _, m := range mounts {
+			if m.Name == metadataVolumeName {
+				hasMetadataMount = true
+				break
+			}
+		}
+		if !hasMetadataMount {
+			t.Error("metadata mount not found")
+		}
+	})
+
+	t.Run("storage cluster - no existingClaim does not add PVC volumes", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Storage: garagev1alpha1.StorageConfig{},
+			},
+		}
+		cluster.Name = testClusterName
+		volumes, _ := buildVolumesAndMounts(cluster)
+
+		// Without existingClaim, metadata and data volumes come from VolumeClaimTemplates
+		// so buildVolumesAndMounts should NOT add them
+		for _, v := range volumes {
+			if v.Name == metadataVolumeName && v.PersistentVolumeClaim != nil {
+				t.Error("metadata volume should not have PVC source when no existingClaim")
+			}
+			if v.Name == dataVolumeName && v.PersistentVolumeClaim != nil {
+				t.Error("data volume should not have PVC source when no existingClaim")
+			}
+		}
+	})
+
+	t.Run("gateway cluster - uses EmptyDir for data regardless of existingClaim", func(t *testing.T) {
+		cluster := &garagev1alpha1.GarageCluster{
+			Spec: garagev1alpha1.GarageClusterSpec{
+				Gateway: true,
+				Storage: garagev1alpha1.StorageConfig{
+					Data: &garagev1alpha1.DataStorageConfig{
+						ExistingClaim: "should-be-ignored",
+					},
+				},
+			},
+		}
+		cluster.Name = "test-gateway"
+		volumes, _ := buildVolumesAndMounts(cluster)
+
+		var dataVolume *corev1.Volume
+		for i := range volumes {
+			if volumes[i].Name == dataVolumeName {
+				dataVolume = &volumes[i]
+				break
+			}
+		}
+		if dataVolume == nil {
+			t.Error("data volume not found for gateway cluster")
+			return
+		}
+		if dataVolume.EmptyDir == nil {
+			t.Error("gateway data volume should use EmptyDir, not PVC")
+		}
+	})
+}
+
+func ptrQuantity(q resource.Quantity) *resource.Quantity {
+	return &q
 }

--- a/schemas/garagecluster_v1alpha1.json
+++ b/schemas/garagecluster_v1alpha1.json
@@ -2242,6 +2242,10 @@
             "data": {
               "description": "Data configures data block storage",
               "properties": {
+                "existingClaim": {
+                  "description": "ExistingClaim uses an existing PVC instead of creating a new one.\nWhen set, size and storageClassName are ignored.\nThe PVC must already exist and be compatible with the pod's requirements.",
+                  "type": "string"
+                },
                 "paths": {
                   "description": "Paths specifies multiple data directories with capacities\nFor advanced multi-disk configurations",
                   "items": {


### PR DESCRIPTION
## Summary
- Add `existingClaim` field to `DataStorageConfig` API for data storage
- Implement previously-defined but unimplemented `existingClaim` for metadata storage
- Skip `VolumeClaimTemplate` creation when `existingClaim` is specified
- Add PVC volume sources for existing claims in pod spec

## Usage

```yaml
apiVersion: garage.rajsingh.info/v1alpha1
kind: GarageCluster
metadata:
  name: my-cluster
spec:
  replicas: 3
  replication:
    factor: 3
  storage:
    metadata:
      existingClaim: my-existing-metadata-pvc  # Use existing PVC
    data:
      existingClaim: my-existing-data-pvc      # Use existing PVC
```

Closes #17