### PR TITLE
feat: add imageRepository field to override repo without tag

### DIFF
--- a/api/v1alpha1/garagecluster_types.go
+++ b/api/v1alpha1/garagecluster_types.go
@@ -24,10 +24,19 @@ import (
 
 // GarageClusterSpec defines the desired state of GarageCluster
 type GarageClusterSpec struct {
-	// Image specifies the Garage container image to use
+	// Image specifies the Garage container image to use.
+	// Takes precedence over imageRepository if both are set.
 	// +kubebuilder:default="dxflrs/garage:v2.2.0"
 	// +optional
 	Image string `json:"image,omitempty"`
+
+	// ImageRepository overrides just the repository portion of the default Garage image,
+	// preserving the default tag for automatic version upgrades.
+	// For example, setting this to "my-mirror/garage" with the default tag v2.2.0
+	// produces "my-mirror/garage:v2.2.0".
+	// Ignored if image is set.
+	// +optional
+	ImageRepository string `json:"imageRepository,omitempty"`
 
 	// ImagePullPolicy specifies the image pull policy
 	// +kubebuilder:default="IfNotPresent"

--- a/api/v1alpha1/garagenode_types.go
+++ b/api/v1alpha1/garagenode_types.go
@@ -84,6 +84,12 @@ type GarageNodeSpec struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
+	// ImageRepository overrides just the repository portion of the Garage image.
+	// If not specified, inherits from GarageCluster.
+	// Ignored if image is set.
+	// +optional
+	ImageRepository string `json:"imageRepository,omitempty"`
+
 	// Resources overrides compute resources for the Garage container.
 	// If not specified, inherits from GarageCluster.
 	// +optional

--- a/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
@@ -1618,7 +1618,9 @@ spec:
                 type: boolean
               image:
                 default: dxflrs/garage:v2.2.0
-                description: Image specifies the Garage container image to use
+                description: |-
+                  Image specifies the Garage container image to use.
+                  Takes precedence over imageRepository if both are set.
                 type: string
               imagePullPolicy:
                 default: IfNotPresent
@@ -1644,6 +1646,14 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              imageRepository:
+                description: |-
+                  ImageRepository overrides just the repository portion of the default Garage image,
+                  preserving the default tag for automatic version upgrades.
+                  For example, setting this to "my-mirror/garage" with the default tag v2.2.0
+                  produces "my-mirror/garage:v2.2.0".
+                  Ignored if image is set.
+                type: string
               k2vApi:
                 description: K2VAPI configures the K2V (key-value) API endpoint
                 properties:

--- a/charts/garage-operator/crds/garage.rajsingh.info_garagenodes.yaml
+++ b/charts/garage-operator/crds/garage.rajsingh.info_garagenodes.yaml
@@ -1109,6 +1109,12 @@ spec:
                   Image overrides the Garage container image.
                   If not specified, inherits from GarageCluster.
                 type: string
+              imageRepository:
+                description: |-
+                  ImageRepository overrides just the repository portion of the Garage image.
+                  If not specified, inherits from GarageCluster.
+                  Ignored if image is set.
+                type: string
               nodeId:
                 description: |-
                   NodeID is the public key of the Garage node.

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -1618,7 +1618,9 @@ spec:
                 type: boolean
               image:
                 default: dxflrs/garage:v2.2.0
-                description: Image specifies the Garage container image to use
+                description: |-
+                  Image specifies the Garage container image to use.
+                  Takes precedence over imageRepository if both are set.
                 type: string
               imagePullPolicy:
                 default: IfNotPresent
@@ -1644,6 +1646,14 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              imageRepository:
+                description: |-
+                  ImageRepository overrides just the repository portion of the default Garage image,
+                  preserving the default tag for automatic version upgrades.
+                  For example, setting this to "my-mirror/garage" with the default tag v2.2.0
+                  produces "my-mirror/garage:v2.2.0".
+                  Ignored if image is set.
+                type: string
               k2vApi:
                 description: K2VAPI configures the K2V (key-value) API endpoint
                 properties:

--- a/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
@@ -1109,6 +1109,12 @@ spec:
                   Image overrides the Garage container image.
                   If not specified, inherits from GarageCluster.
                 type: string
+              imageRepository:
+                description: |-
+                  ImageRepository overrides just the repository portion of the Garage image.
+                  If not specified, inherits from GarageCluster.
+                  Ignored if image is set.
+                type: string
               nodeId:
                 description: |-
                   NodeID is the public key of the Garage node.

--- a/config/samples/garage_v1alpha1_garagecluster.yaml
+++ b/config/samples/garage_v1alpha1_garagecluster.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   replicas: 3
   image: dxflrs/garage:v2.2.0
+  # Override repo only, keeps default tag for auto-upgrades:
+  # imageRepository: my-mirror/garage
 
   replication:
     factor: 3

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -153,13 +153,7 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 	stsName := node.Name
 
 	// Build merged pod config (cluster defaults + node overrides)
-	image := defaultGarageImage
-	if cluster.Spec.Image != "" {
-		image = cluster.Spec.Image
-	}
-	if node.Spec.Image != "" {
-		image = node.Spec.Image
-	}
+	image := mergeNodeImage(cluster.Spec.Image, cluster.Spec.ImageRepository, node.Spec.Image, node.Spec.ImageRepository)
 
 	resources := cluster.Spec.Resources
 	if node.Spec.Resources != nil {

--- a/schemas/garagecluster_v1alpha1.json
+++ b/schemas/garagecluster_v1alpha1.json
@@ -1436,7 +1436,7 @@
         },
         "image": {
           "default": "dxflrs/garage:v2.2.0",
-          "description": "Image specifies the Garage container image to use",
+          "description": "Image specifies the Garage container image to use.\nTakes precedence over imageRepository if both are set.",
           "type": "string"
         },
         "imagePullPolicy": {
@@ -1460,6 +1460,10 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "imageRepository": {
+          "description": "ImageRepository overrides just the repository portion of the default Garage image,\npreserving the default tag for automatic version upgrades.\nFor example, setting this to \"my-mirror/garage\" with the default tag v2.2.0\nproduces \"my-mirror/garage:v2.2.0\".\nIgnored if image is set.",
+          "type": "string"
         },
         "k2vApi": {
           "description": "K2VAPI configures the K2V (key-value) API endpoint",

--- a/schemas/garagenode_v1alpha1.json
+++ b/schemas/garagenode_v1alpha1.json
@@ -931,6 +931,10 @@
           "description": "Image overrides the Garage container image.\nIf not specified, inherits from GarageCluster.",
           "type": "string"
         },
+        "imageRepository": {
+          "description": "ImageRepository overrides just the repository portion of the Garage image.\nIf not specified, inherits from GarageCluster.\nIgnored if image is set.",
+          "type": "string"
+        },
         "nodeId": {
           "description": "NodeID is the public key of the Garage node.\nIf not specified, the operator will auto-discover from the pod.",
           "type": "string"


### PR DESCRIPTION
## Summary
- Adds `imageRepository` field to `GarageCluster` and `GarageNode` specs
- When set, combines with the default tag (e.g. `my-mirror/garage` → `my-mirror/garage:v2.2.0`)
- Full `image` field still takes precedence for backward compatibility
- GarageNode inherits from GarageCluster, with per-node override support

## Usage
```yaml
spec:
  # Option A: override just the repo, keep default tag for auto-upgrades
  imageRepository: my-mirror/garage

  # Option B: full override (existing behavior, takes precedence)
  # image: my-mirror/garage:v2.2.0
```

## Test plan
- [x] Unit tests for `resolveGarageImage` covering all priority combinations
- [x] `make lint` passes
- [x] `make test` passes
- [x] CRDs and JSON schemas regenerated

Closes #32