### PR TITLE
feat: add rpcBindAddress for IPv4-only cluster support

### DIFF
--- a/api/v1alpha1/garagecluster_types.go
+++ b/api/v1alpha1/garagecluster_types.go
@@ -428,6 +428,12 @@ type NetworkConfig struct {
 	// +kubebuilder:default=3901
 	RPCBindPort int32 `json:"rpcBindPort,omitempty"`
 
+	// RPCBindAddress is a custom bind address for the RPC server.
+	// Can be a TCP address (e.g., "0.0.0.0:3901", "[::]:3901").
+	// If set, this overrides RPCBindPort.
+	// +optional
+	RPCBindAddress string `json:"rpcBindAddress,omitempty"`
+
 	// RPCPublicAddr is the external address for other nodes to contact this node
 	// +optional
 	RPCPublicAddr string `json:"rpcPublicAddr,omitempty"`

--- a/api/v1alpha1/garagecluster_webhook.go
+++ b/api/v1alpha1/garagecluster_webhook.go
@@ -306,6 +306,13 @@ func (r *GarageCluster) validateDataStorageConfig(dsc *DataStorageConfig) error 
 
 // validateAPIs validates API configurations.
 func (r *GarageCluster) validateAPIs() error {
+	// Validate RPC bind address if specified
+	if r.Spec.Network.RPCBindAddress != "" {
+		if err := validateBindAddress(r.Spec.Network.RPCBindAddress, "network.rpcBindAddress"); err != nil {
+			return err
+		}
+	}
+
 	// Validate bind addresses if specified
 	if r.Spec.S3API != nil && r.Spec.S3API.BindAddress != "" {
 		if err := validateBindAddress(r.Spec.S3API.BindAddress, "s3Api"); err != nil {

--- a/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crds/garage.rajsingh.info_garageclusters.yaml
@@ -1737,6 +1737,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  rpcBindAddress:
+                    description: |-
+                      RPCBindAddress is a custom bind address for the RPC server.
+                      Can be a TCP address (e.g., "0.0.0.0:3901", "[::]:3901").
+                      If set, this overrides RPCBindPort.
+                    type: string
                   rpcBindOutgoing:
                     description: RPCBindOutgoing pre-binds outgoing sockets to same
                       IP

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -1737,6 +1737,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  rpcBindAddress:
+                    description: |-
+                      RPCBindAddress is a custom bind address for the RPC server.
+                      Can be a TCP address (e.g., "0.0.0.0:3901", "[::]:3901").
+                      If set, this overrides RPCBindPort.
+                    type: string
                   rpcBindOutgoing:
                     description: RPCBindOutgoing pre-binds outgoing sockets to same
                       IP

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -722,11 +722,15 @@ func writeSecurityConfig(config *strings.Builder, cluster *garagev1alpha1.Garage
 }
 
 func writeRPCConfig(config *strings.Builder, cluster *garagev1alpha1.GarageCluster) {
-	rpcPort := int32(3901)
-	if cluster.Spec.Network.RPCBindPort != 0 {
-		rpcPort = cluster.Spec.Network.RPCBindPort
+	if cluster.Spec.Network.RPCBindAddress != "" {
+		fmt.Fprintf(config, "rpc_bind_addr = \"%s\"\n", cluster.Spec.Network.RPCBindAddress)
+	} else {
+		rpcPort := int32(3901)
+		if cluster.Spec.Network.RPCBindPort != 0 {
+			rpcPort = cluster.Spec.Network.RPCBindPort
+		}
+		fmt.Fprintf(config, "rpc_bind_addr = \"[::]:%d\"\n", rpcPort)
 	}
-	fmt.Fprintf(config, "rpc_bind_addr = \"[::]:%d\"\n", rpcPort)
 	config.WriteString("rpc_secret_file = \"/secrets/rpc/rpc-secret\"\n")
 
 	if cluster.Spec.Network.RPCPublicAddr != "" {

--- a/schemas/garagecluster_v1alpha1.json
+++ b/schemas/garagecluster_v1alpha1.json
@@ -1541,6 +1541,10 @@
               },
               "type": "array"
             },
+            "rpcBindAddress": {
+              "description": "RPCBindAddress is a custom bind address for the RPC server.\nCan be a TCP address (e.g., \"0.0.0.0:3901\", \"[::]:3901\").\nIf set, this overrides RPCBindPort.",
+              "type": "string"
+            },
             "rpcBindOutgoing": {
               "description": "RPCBindOutgoing pre-binds outgoing sockets to same IP",
               "type": "boolean"


### PR DESCRIPTION
## Summary
- Adds `rpcBindAddress` field to `NetworkConfig`, allowing users to override the default `[::]:3901` RPC bind address
- Fixes IPv4-only clusters where the hardcoded IPv6 bind address fails
- Follows the same `bindAddress` pattern already used by S3, K2V, Web, and Admin APIs
- When `rpcBindAddress` is set, it overrides `rpcBindPort`

## Example

```yaml
spec:
  network:
    rpcBindAddress: "0.0.0.0:3901"  # IPv4-only cluster
```

Closes #38