### PR TITLE
feat: allow custom key names in importKey secretRef

### DIFF
--- a/api/v1alpha1/garagekey_types.go
+++ b/api/v1alpha1/garagekey_types.go
@@ -98,9 +98,20 @@ type ImportKeyConfig struct {
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 
 	// SecretRef references a secret containing the credentials
-	// Secret should have keys: access-key-id, secret-access-key
+	// By default the secret should have keys: access-key-id, secret-access-key
+	// Use AccessKeyIDKey and SecretAccessKeyKey to override the key names
 	// +optional
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
+
+	// AccessKeyIDKey is the key in the secret that contains the access key ID
+	// Only used with SecretRef. Defaults to "access-key-id"
+	// +optional
+	AccessKeyIDKey string `json:"accessKeyIdKey,omitempty"`
+
+	// SecretAccessKeyKey is the key in the secret that contains the secret access key
+	// Only used with SecretRef. Defaults to "secret-access-key"
+	// +optional
+	SecretAccessKeyKey string `json:"secretAccessKeyKey,omitempty"`
 }
 
 // SecretTemplate configures the generated secret

--- a/api/v1alpha1/garagekey_webhook.go
+++ b/api/v1alpha1/garagekey_webhook.go
@@ -171,6 +171,11 @@ func (r *GarageKey) validateImportKey() error {
 		return nil
 	}
 
+	// accessKeyIdKey/secretAccessKeyKey only apply with secretRef
+	if ik.AccessKeyIDKey != "" || ik.SecretAccessKeyKey != "" {
+		return fmt.Errorf("importKey: accessKeyIdKey/secretAccessKeyKey can only be used with secretRef")
+	}
+
 	// If not using secretRef, both accessKeyId and secretAccessKey are required
 	if ik.AccessKeyID != "" || ik.SecretAccessKey != "" {
 		if ik.AccessKeyID == "" {

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
@@ -176,13 +176,24 @@ spec:
                   accessKeyId:
                     description: AccessKeyID is the existing access key ID
                     type: string
+                  accessKeyIdKey:
+                    description: |-
+                      AccessKeyIDKey is the key in the secret that contains the access key ID
+                      Only used with SecretRef. Defaults to "access-key-id"
+                    type: string
                   secretAccessKey:
                     description: SecretAccessKey is the existing secret access key
+                    type: string
+                  secretAccessKeyKey:
+                    description: |-
+                      SecretAccessKeyKey is the key in the secret that contains the secret access key
+                      Only used with SecretRef. Defaults to "secret-access-key"
                     type: string
                   secretRef:
                     description: |-
                       SecretRef references a secret containing the credentials
-                      Secret should have keys: access-key-id, secret-access-key
+                      By default the secret should have keys: access-key-id, secret-access-key
+                      Use AccessKeyIDKey and SecretAccessKeyKey to override the key names
                     properties:
                       name:
                         description: name is unique within a namespace to reference

--- a/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
@@ -176,13 +176,24 @@ spec:
                   accessKeyId:
                     description: AccessKeyID is the existing access key ID
                     type: string
+                  accessKeyIdKey:
+                    description: |-
+                      AccessKeyIDKey is the key in the secret that contains the access key ID
+                      Only used with SecretRef. Defaults to "access-key-id"
+                    type: string
                   secretAccessKey:
                     description: SecretAccessKey is the existing secret access key
+                    type: string
+                  secretAccessKeyKey:
+                    description: |-
+                      SecretAccessKeyKey is the key in the secret that contains the secret access key
+                      Only used with SecretRef. Defaults to "secret-access-key"
                     type: string
                   secretRef:
                     description: |-
                       SecretRef references a secret containing the credentials
-                      Secret should have keys: access-key-id, secret-access-key
+                      By default the secret should have keys: access-key-id, secret-access-key
+                      Use AccessKeyIDKey and SecretAccessKeyKey to override the key names
                     properties:
                       name:
                         description: name is unique within a namespace to reference

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -287,13 +287,21 @@ func (r *GarageKeyReconciler) importKey(ctx context.Context, key *garagev1alpha1
 		if importSecret.Data == nil {
 			return nil, "", fmt.Errorf("import secret %s has no data", key.Spec.ImportKey.SecretRef.Name)
 		}
-		accessKeyIDData, ok := importSecret.Data["access-key-id"]
-		if !ok {
-			return nil, "", fmt.Errorf("import secret %s missing access-key-id", key.Spec.ImportKey.SecretRef.Name)
+		akKey := "access-key-id"
+		skKey := "secret-access-key"
+		if key.Spec.ImportKey.AccessKeyIDKey != "" {
+			akKey = key.Spec.ImportKey.AccessKeyIDKey
 		}
-		secretKeyData, ok := importSecret.Data["secret-access-key"]
+		if key.Spec.ImportKey.SecretAccessKeyKey != "" {
+			skKey = key.Spec.ImportKey.SecretAccessKeyKey
+		}
+		accessKeyIDData, ok := importSecret.Data[akKey]
 		if !ok {
-			return nil, "", fmt.Errorf("import secret %s missing secret-access-key", key.Spec.ImportKey.SecretRef.Name)
+			return nil, "", fmt.Errorf("import secret %s missing %s", key.Spec.ImportKey.SecretRef.Name, akKey)
+		}
+		secretKeyData, ok := importSecret.Data[skKey]
+		if !ok {
+			return nil, "", fmt.Errorf("import secret %s missing %s", key.Spec.ImportKey.SecretRef.Name, skKey)
 		}
 		accessKeyID = string(accessKeyIDData)
 		secretKey = string(secretKeyData)

--- a/schemas/garagekey_v1alpha1.json
+++ b/schemas/garagekey_v1alpha1.json
@@ -122,12 +122,20 @@
               "description": "AccessKeyID is the existing access key ID",
               "type": "string"
             },
+            "accessKeyIdKey": {
+              "description": "AccessKeyIDKey is the key in the secret that contains the access key ID\nOnly used with SecretRef. Defaults to \"access-key-id\"",
+              "type": "string"
+            },
             "secretAccessKey": {
               "description": "SecretAccessKey is the existing secret access key",
               "type": "string"
             },
+            "secretAccessKeyKey": {
+              "description": "SecretAccessKeyKey is the key in the secret that contains the secret access key\nOnly used with SecretRef. Defaults to \"secret-access-key\"",
+              "type": "string"
+            },
             "secretRef": {
-              "description": "SecretRef references a secret containing the credentials\nSecret should have keys: access-key-id, secret-access-key",
+              "description": "SecretRef references a secret containing the credentials\nBy default the secret should have keys: access-key-id, secret-access-key\nUse AccessKeyIDKey and SecretAccessKeyKey to override the key names",
               "properties": {
                 "name": {
                   "description": "name is unique within a namespace to reference a secret resource.",


### PR DESCRIPTION
## Summary
- Adds `accessKeyIdKey` and `secretAccessKeyKey` to `importKey` so users can reference secrets with custom key names when importing existing credentials
- Defaults to `access-key-id` / `secret-access-key` for backwards compatibility
- Webhook rejects the key-name overrides when `secretRef` isn't set

Closes #67