### PR TITLE
feat: full metrics coverage and key creation latency fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,302 @@
+# Garage Kubernetes Operator
+
+> **Agent Notes**: Reference /Users/rajsingh/Documents/GitHub/garage for Garage source code. Update this file with important learnings.
+
+A Kubernetes operator for [Garage](https://garagehq.deuxfleurs.fr/) - distributed S3-compatible object storage.
+UPSTREAM CODEBASE ../garage
+## Quick Reference
+
+### CRDs
+
+| CRD | Short | Description |
+|-----|-------|-------------|
+| `GarageCluster` | `gc` | Cluster deployment + multi-cluster federation |
+| `GarageBucket` | `gb` | Buckets with quotas, website hosting |
+| `GarageKey` | `gk` | S3 access keys with bucket permissions |
+| `GarageNode` | `gn` | Node layout (zone, capacity, gateway) |
+| `GarageAdminToken` | `gat` | Admin API tokens |
+
+### Development Commands
+
+```bash
+make dev-up        # Setup: kind + CRDs + operator
+make dev-test      # Apply test resources
+make dev-status    # View all garage resources
+make dev-logs      # Stream operator logs
+make dev-load      # Rebuild and reload operator
+make dev-run       # Run operator locally (debugging)
+make dev-down      # Tear down cluster
+```
+
+### Project Structure
+
+```
+api/v1alpha1/           # CRD types + webhooks
+internal/controller/    # Reconciliation logic
+internal/garage/        # Admin API client (v2)
+config/samples/         # Example CRs
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Kubernetes Cluster A                         │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │  Operator: Cluster | Bucket | Key | Node Controllers        │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+│  ┌───────────────────────────────────────────────────────────┐   │
+│  │     Garage Cluster (Zone: us-east-1) - 3 Pods             │   │
+│  └───────────────────────────────────────────────────────────┘   │
+└──────────────────────────────┬──────────────────────────────────┘
+                    Full Mesh RPC (port 3901)
+┌──────────────────────────────┼──────────────────────────────────┐
+│                     Kubernetes Cluster B                         │
+│  ┌───────────────────────────────────────────────────────────┐   │
+│  │     Garage Cluster (Zone: eu-west-1) - 3 Pods             │   │
+│  └───────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Multi-Cluster Federation
+
+### Key Concepts
+
+1. **Full Mesh Connectivity**: Every node must reach every other node on RPC port (3901)
+2. **Shared RPC Secret**: Same 32-byte hex secret across ALL clusters
+3. **Zones**: Labels for fault tolerance - Garage distributes replicas across zones
+4. **No Single Leader**: Layout is a CRDT that converges across nodes
+
+### Network Solutions
+
+**LoadBalancer per Node** (most reliable):
+```yaml
+publicEndpoint:
+  type: LoadBalancer
+  loadBalancer:
+    perNode: true
+```
+
+**NodePort** (cheaper):
+```yaml
+publicEndpoint:
+  type: NodePort
+  nodePort:
+    externalAddresses: ["node1.example.com", "node2.example.com"]
+    basePort: 30901
+```
+
+### Federation Setup
+
+1. Create shared RPC secret in ALL clusters:
+   ```bash
+   openssl rand -hex 32
+   kubectl create secret generic garage-rpc-secret --from-literal=rpc-secret=<secret>
+   ```
+
+2. Deploy GarageCluster in each cluster with same `rpcSecretRef`, unique `zone`
+
+3. Use `spec.remoteClusters` for automatic federation or `connect-nodes` annotation for manual
+
+---
+
+## Gateway Clusters
+
+Gateway nodes handle S3 API requests without storing data.
+
+```yaml
+apiVersion: garage.rajsingh.info/v1alpha1
+kind: GarageCluster
+metadata:
+  name: garage-gateway
+spec:
+  replicas: 5
+  gateway: true
+  connectTo:
+    clusterRef:
+      name: garage-storage
+```
+
+| Aspect | Storage Cluster | Gateway Cluster |
+|--------|-----------------|-----------------|
+| Workload | StatefulSet | StatefulSet |
+| Metadata PVC | 10Gi default | 1Gi default (node identity) |
+| Data PVC | 100Gi default | EmptyDir (no blocks) |
+| Layout capacity | From PVC size | null (gateway) |
+
+### Node Identity Persistence
+
+**Critical**: Garage nodes store their identity (Ed25519 keypair) in `metadata_dir/node_key`. This node ID is permanent and used for cluster membership. Gateway clusters use StatefulSet with a metadata PVC to preserve node identity across pod restarts. Without persistent metadata, each pod restart would generate a new node ID, causing stale nodes in the layout.
+
+---
+
+## Configuration Reference
+
+### GarageCluster Options
+
+| Category | Options |
+|----------|---------|
+| **Replication** | `factor` (1-7), `consistencyMode` (consistent/degraded/dangerous) |
+| **Storage** | Metadata/data PVCs, fsync, auto-snapshots |
+| **Database** | Engine (lmdb/sqlite/fjall), LMDB map size, Fjall block cache |
+| **Blocks** | Size, RAM buffer, compression, concurrent reads |
+| **APIs** | S3 (3900), K2V (3904), Web (3902), Admin (3903) |
+| **Network** | RPC port, public address, bootstrap peers |
+| **Logging** | Level (RUST_LOG format), syslog, journald |
+
+### Layout Policy
+
+| Policy | Behavior |
+|--------|----------|
+| `Auto` (default) | Auto-assign pods to layout using cluster zone. Capacity from PVC size. |
+| `Manual` | Create GarageNode resources for fine-grained control. |
+
+---
+
+## GarageBucket Features
+
+### Supported (via Admin API)
+
+Quotas, Website hosting (index/error docs), Global/Local aliases, Key permissions
+
+### NOT Supported (use S3 API directly)
+
+CORS rules, Lifecycle rules, Website redirectAll/routingRules
+
+---
+
+## Operational Annotations
+
+### GarageCluster (Implemented)
+
+| Annotation | Description |
+|------------|-------------|
+| `garage.rajsingh.info/force-layout-apply` | Force apply staged layout (set to `"true"`) |
+| `garage.rajsingh.info/connect-nodes` | Connect nodes: `"nodeId@addr:port,..."` (one-shot, removed after processing) |
+
+### Defined but NOT Implemented
+
+These annotations are defined as constants in `api/v1alpha1/condition_types.go` but have no controller logic:
+- `trigger-snapshot`, `pause-reconcile`, `trigger-repair`, `scrub-command` (GarageCluster)
+- `cleanup-mpu`, `cleanup-mpu-older-than` (GarageBucket)
+
+---
+
+## Admin API Client
+
+Uses Admin API **v2** at `internal/garage/client.go`.
+
+### Key Patterns
+
+- Auth: `Authorization: Bearer <prefix>.<secret>` (prefix is 24 hex chars)
+- Error helpers: `garage.IsNotFound(err)`, `garage.IsConflict(err)`, `garage.IsBadRequest(err)`
+- bootstrap_peers format: `<64-char-hex-node-id>@<hostname>:<port>` (addresses without node IDs are ignored)
+
+### SDK Evaluation (2026-04-12): Keep Hand-Crafted Client
+
+**Decision: Keep hand-crafted client.**
+
+Import test: `go get git.deuxfleurs.fr/garage-sdk/garage-admin-sdk-golang` succeeds (v0.0.0-20260106092213-694c0d66012a, hosted on `git.deuxfleurs.fr`). However, migrating adds risk with no meaningful benefit: our custom error helpers (`IsNotFound`, `IsConflict`, `IsBadRequest`) parse HTTP status codes directly and would need wrappers around SDK types, and the external forge is not a standard Go module proxy (no GOPROXY cache guarantee). The hand-crafted client covers all endpoints the operator actually uses.
+
+**Spec endpoints NOT covered by our client** (not needed by operator today):
+
+| Endpoint | OperationId | Notes |
+|----------|-------------|-------|
+| `GET /check` | CheckDomain | DNS check helper |
+| `GET /metrics` | Metrics | Prometheus scrape endpoint |
+| `GET /v2/GetAdminTokenInfo` | GetAdminTokenInfo | Token introspection |
+| `GET /v2/GetCurrentAdminTokenInfo` | GetCurrentAdminTokenInfo | Self-info |
+| `GET /v2/ListAdminTokens` | ListAdminTokens | |
+| `POST /v2/CreateAdminToken` | CreateAdminToken | Used by GarageAdminToken CRD (TBD) |
+| `POST /v2/DeleteAdminToken` | DeleteAdminToken | |
+| `POST /v2/UpdateAdminToken` | UpdateAdminToken | |
+| `POST /v2/GetBlockInfo` | GetBlockInfo | Block diagnostics |
+| `GET /v2/ListBlockErrors` | ListBlockErrors | |
+| `POST /v2/PurgeBlocks` | PurgeBlocks | |
+| `POST /v2/RetryBlockResync` | RetryBlockResync | |
+| `GET /v2/GetClusterStatistics` | GetClusterStatistics | Cluster-level stats |
+| `GET /v2/GetNodeInfo` | GetNodeInfo | Per-node info |
+| `GET /v2/GetNodeStatistics` | GetNodeStatistics | Per-node stats |
+| `GET /v2/InspectObject` | InspectObject | Object block map |
+| `POST /v2/PreviewClusterLayoutChanges` | PreviewClusterLayoutChanges | Dry-run layout |
+
+---
+
+## Known Limitations
+
+| Feature | Notes |
+|---------|-------|
+| CORS/Lifecycle/RoutingRules | Use S3 API directly |
+| Permission Revocation | Removing from spec doesn't revoke - use `DenyBucketKey` API |
+| TLS for APIs | External only - use service mesh or load balancer |
+| Hot-reload config | NOT supported - config changes require pod restart |
+
+---
+
+## Implementation Notes
+
+### Important Behaviors
+
+1. **Config changes require pod restart** - Garage reads config once at startup, SIGHUP ignored
+2. **Config hash annotation** - Changes trigger rolling restart via `garage.rajsingh.info/config-hash`
+3. **Credential sync** - Key controller uses `ShowSecretKey: true` to detect/fix credential drift
+4. **Layout conflicts** - Controller handles 409 Conflict with retry on next reconciliation
+5. **Single-node clusters** - Supported for multi-cluster federation (1 replica per K8s cluster)
+6. **Node identity in metadata_dir** - Garage stores `node_key` (Ed25519 private key) in `metadata_dir`. This file determines the node ID. Both storage and gateway clusters need persistent metadata to preserve node identity across restarts (see `garage/src/rpc/system.rs:gen_node_key`)
+
+### Port Defaults
+
+- RPC: 3901
+- S3: 3900
+- Admin: 3903
+- K2V: 3904
+- Web: 3902
+
+---
+
+## CI/CD
+
+| Workflow | Description |
+|----------|-------------|
+| `test.yml` | Unit tests |
+| `lint.yml` | golangci-lint |
+| `test-e2e.yml` | E2E tests with Kind |
+| `docker.yml` | Multi-arch images to `ghcr.io/rajsinghtech/garage-operator` |
+| `helm.yml` | Helm chart lint, verify CRDs, push to OCI registry |
+| `release.yml` | GitHub release with install.yaml |
+
+```bash
+# Install
+kubectl apply -f https://github.com/rajsinghtech/garage-operator/releases/latest/download/install.yaml
+
+# Release
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+---
+
+## TODOs
+
+### Unimplemented Annotations
+
+Several annotations are defined in `api/v1alpha1/condition_types.go` but have no controller logic:
+- `trigger-snapshot`, `pause-reconcile`, `trigger-repair`, `scrub-command` (GarageCluster)
+- `cleanup-mpu`, `cleanup-mpu-older-than` (GarageBucket)
+
+### E2E Test Gap: Credential Drift
+
+The e2e tests don't validate S3 operations work with generated credentials. Needed:
+1. Create GarageKey → Delete in Garage → Reconcile → Verify secret updated
+2. Verify S3 PUT/GET operations work with credentials
+
+### Web API (s3_web) Support
+
+Research Garage's Web API (port 3902) for static website hosting:
+1. Understand how `[s3_web]` config section works (root_domain, index docs)
+2. Determine if operator should expose web API configuration in GarageCluster spec
+3. Consider adding HTTPRoute templates for web-hosted buckets
+4. Investigate how website hosting interacts with GarageBucket's `website` field

--- a/charts/garage-operator/dashboards/garage-prometheus.json
+++ b/charts/garage-operator/dashboards/garage-prometheus.json
@@ -1007,6 +1007,118 @@
       "title": "Resync errored blocks",
       "type": "timeseries"
     }
+    ,{
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 33},
+      "id": 20,
+      "title": "Cluster Health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [
+            {"options": {"0": {"color": "red", "index": 0, "text": "Unhealthy"}, "1": {"color": "green", "index": 1, "text": "Healthy"}}, "type": "value"}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 34},
+      "id": 21,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "min(cluster_healthy{job=\"garage\"})", "legendFormat": "Healthy", "refId": "A"}],
+      "title": "Cluster Healthy",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [
+            {"options": {"0": {"color": "red", "index": 0, "text": "Unavailable"}, "1": {"color": "green", "index": 1, "text": "Available"}}, "type": "value"}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 34},
+      "id": 22,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "min(cluster_available{job=\"garage\"})", "legendFormat": "Available", "refId": "A"}],
+      "title": "Cluster Available",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 34},
+      "id": 23,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes_ok{job=\"garage\"}", "legendFormat": "OK {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "B"}
+      ],
+      "title": "Storage Nodes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 34},
+      "id": 24,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions_all_ok{job=\"garage\"}", "legendFormat": "All OK {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions_quorum{job=\"garage\"}", "legendFormat": "Quorum {{instance}}", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "C"}
+      ],
+      "title": "Partitions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 38},
+      "id": 25,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_connected_nodes{job=\"garage\"}", "legendFormat": "Connected {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_known_nodes{job=\"garage\"}", "legendFormat": "Known {{instance}}", "refId": "B"}
+      ],
+      "title": "Connected vs Known Nodes",
+      "type": "timeseries"
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 37,
@@ -1023,6 +1135,6 @@
   "timezone": "",
   "title": "Garage",
   "uid": "ys3pnpZ4k",
-  "version": 26,
+  "version": 27,
   "weekStart": ""
 }

--- a/charts/garage-operator/dashboards/garage-prometheus.json
+++ b/charts/garage-operator/dashboards/garage-prometheus.json
@@ -1119,6 +1119,274 @@
       "title": "Connected vs Known Nodes",
       "type": "timeseries"
     }
+    ,{
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 43},
+      "id": 30,
+      "title": "API Latency",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 44},
+      "id": 31,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{api_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{api_endpoint}}", "refId": "B"}
+      ],
+      "title": "S3 Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 44},
+      "id": 32,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (admin_endpoint) (rate(api_admin_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "{{admin_endpoint}}", "refId": "A"}
+      ],
+      "title": "Admin API Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 44},
+      "id": 33,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95", "refId": "B"}
+      ],
+      "title": "Admin API Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 53},
+      "id": 40,
+      "title": "Block Manager",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 54},
+      "id": 41,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_read_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 read", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_write_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 write", "refId": "B"}
+      ],
+      "title": "Block Read/Write Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 54},
+      "id": 42,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "block_ram_buffer_free_kb{job=\"garage\"} * 1024", "legendFormat": "RAM buffer free {{instance}}", "refId": "A"}
+      ],
+      "title": "Block RAM Buffer Free",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 54},
+      "id": 43,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(block_delete_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Deletes/s", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(block_resync_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Resyncs/s", "refId": "B"}
+      ],
+      "title": "Block Operations",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 63},
+      "id": 50,
+      "title": "RPC Details",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 64},
+      "id": 51,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (rpc_endpoint) (rate(rpc_netapp_error_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "errors {{rpc_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(rpc_timeout_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "timeouts", "refId": "B"}
+      ],
+      "title": "RPC Errors and Timeouts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 64},
+      "id": 52,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{rpc_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{rpc_endpoint}}", "refId": "B"}
+      ],
+      "title": "RPC Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 73},
+      "id": 60,
+      "title": "Table Sync",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 74},
+      "id": 61,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_received{job=\"garage\"}[$__rate_interval]))", "legendFormat": "received {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_sent{job=\"garage\"}[$__rate_interval]))", "legendFormat": "sent {{table_name}}", "refId": "B"}
+      ],
+      "title": "Table Sync Items",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 74},
+      "id": 62,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_get_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "get {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_put_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "put {{table_name}}", "refId": "B"}
+      ],
+      "title": "Table Get/Put Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 74},
+      "id": 63,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_get_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 get {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_put_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 put {{table_name}}", "refId": "B"}
+      ],
+      "title": "Table Request Latency",
+      "type": "timeseries"
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 37,
@@ -1135,6 +1403,6 @@
   "timezone": "",
   "title": "Garage",
   "uid": "ys3pnpZ4k",
-  "version": 27,
+  "version": 28,
   "weekStart": ""
 }

--- a/charts/garage-operator/dashboards/garage-prometheus.json
+++ b/charts/garage-operator/dashboards/garage-prometheus.json
@@ -439,7 +439,7 @@
             "uid": "${DS_DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (rpc_endpoint) (rate(rpc_request_counter {job=\"garage\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_endpoint) (rate(rpc_netapp_request_counter {job=\"garage\"}[$__rate_interval]))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{rpc_endpoint}}",

--- a/charts/garage-operator/templates/prometheusrules.yaml
+++ b/charts/garage-operator/templates/prometheusrules.yaml
@@ -24,9 +24,9 @@ spec:
 
         - alert: GarageHighRPCErrorRate
           expr: |
-            sum by (instance) (rate(rpc_request_counter{job="garage",status="error"}[5m]))
+            sum by (instance) (rate(rpc_netapp_request_counter{job="garage",status="error"}[5m]))
             /
-            sum by (instance) (rate(rpc_request_counter{job="garage"}[5m])) > 0.1
+            sum by (instance) (rate(rpc_netapp_request_counter{job="garage"}[5m])) > 0.1
           for: 10m
           labels:
             severity: warning

--- a/charts/garage-operator/templates/prometheusrules.yaml
+++ b/charts/garage-operator/templates/prometheusrules.yaml
@@ -63,4 +63,51 @@ spec:
           annotations:
             summary: "Low disk space on Garage node {{ "{{" }} $labels.instance {{ "}}" }}"
             description: "Garage node {{ "{{" }} $labels.instance {{ "}}" }} has less than 10% disk space remaining."
+
+    - name: garage.cluster
+      rules:
+        - alert: GarageClusterUnhealthy
+          expr: cluster_healthy{job="garage"} == 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Garage cluster unhealthy on {{ "{{" }} $labels.instance {{ "}}" }}"
+            description: "Garage cluster is reporting unhealthy status for 2+ minutes. Data may be unavailable."
+
+        - alert: GarageClusterUnavailable
+          expr: cluster_available{job="garage"} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Garage cluster unavailable on {{ "{{" }} $labels.instance {{ "}}" }}"
+            description: "Garage cluster cannot serve requests (quorum lost) for 1+ minutes."
+
+        - alert: GarageStorageNodeDown
+          expr: cluster_storage_nodes_ok{job="garage"} < cluster_storage_nodes{job="garage"}
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Garage storage node(s) down on {{ "{{" }} $labels.instance {{ "}}" }}"
+            description: "Not all storage nodes are healthy."
+
+        - alert: GaragePartitionsDegraded
+          expr: cluster_partitions_all_ok{job="garage"} < cluster_partitions{job="garage"}
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Garage partitions degraded on {{ "{{" }} $labels.instance {{ "}}" }}"
+            description: "Not all replicas available for some partitions for 10+ minutes."
+
+        - alert: GarageNodeDisconnected
+          expr: cluster_layout_node_connected{job="garage"} == 0
+          for: 3m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Garage layout node disconnected"
+            description: "Node {{ "{{" }} $labels.id {{ "}}" }} has been disconnected for 3+ minutes."
 {{- end }}

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -103,12 +103,8 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// assignment is inconsistent (not all expected nodes are in the layout yet).
 	if !bucket.DeletionTimestamp.IsZero() {
 		// Allow deletions to proceed regardless of cluster health.
-	} else if cluster.Status.Phase != PhaseRunning || cluster.Status.Health == nil || !cluster.Status.Health.Healthy {
-		msg := "waiting for cluster layout to converge"
-		if cluster.Status.Health != nil {
-			msg = fmt.Sprintf("waiting for cluster layout to converge (%d/%d storage nodes ok)",
-				cluster.Status.Health.StorageNodesOK, cluster.Status.Health.StorageNodes)
-		}
+	} else if cluster.Status.Phase != PhaseRunning {
+		msg := "waiting for cluster to reach Running phase"
 		meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -103,12 +103,8 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Guard against calling the Garage API before the cluster layout has converged.
 	if !key.DeletionTimestamp.IsZero() {
 		// Allow deletions to proceed regardless of cluster health.
-	} else if cluster.Status.Phase != PhaseRunning || cluster.Status.Health == nil || !cluster.Status.Health.Healthy {
-		msg := "waiting for cluster layout to converge"
-		if cluster.Status.Health != nil {
-			msg = fmt.Sprintf("waiting for cluster layout to converge (%d/%d storage nodes ok)",
-				cluster.Status.Health.StorageNodesOK, cluster.Status.Health.StorageNodes)
-		}
+	} else if cluster.Status.Phase != PhaseRunning {
+		msg := "waiting for cluster to reach Running phase"
 		meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,
@@ -290,10 +286,11 @@ func (r *GarageKeyReconciler) findKeyByName(ctx context.Context, garageClient *g
 	}
 
 	if len(matches) > 1 {
-		log.Info("Multiple keys found with same name, cannot adopt automatically",
-			"name", keyName, "count", len(matches))
-		// Return nil to trigger creation of a new key - user should clean up duplicates
-		return nil, nil
+		log.Info("Multiple keys found with same name, adopting first match (likely multi-operator race)",
+			"name", keyName, "count", len(matches), "adoptingId", matches[0].ID)
+		// Adopt first match rather than creating another duplicate. With N operators racing
+		// to create the same named key, each successful creation adds a duplicate. Adopting
+		// the first prevents unbounded proliferation.
 	}
 
 	// Fetch full key info including secret

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -682,9 +682,7 @@ func resolveSecretConfig(key *garagev1alpha1.GarageKey) secretConfig {
 	if tmpl.AdditionalData != nil {
 		cfg.additionalData = tmpl.AdditionalData
 	}
-	if tmpl.Labels != nil {
-		maps.Copy(cfg.labels, tmpl.Labels)
-	}
+	maps.Copy(cfg.labels, tmpl.Labels)
 	if tmpl.Annotations != nil {
 		cfg.annotations = tmpl.Annotations
 	}

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"time"
 
@@ -682,9 +683,7 @@ func resolveSecretConfig(key *garagev1alpha1.GarageKey) secretConfig {
 		cfg.additionalData = tmpl.AdditionalData
 	}
 	if tmpl.Labels != nil {
-		for k, v := range tmpl.Labels {
-			cfg.labels[k] = v
-		}
+		maps.Copy(cfg.labels, tmpl.Labels)
 	}
 	if tmpl.Annotations != nil {
 		cfg.annotations = tmpl.Annotations

--- a/internal/monitoring/dashboards/garage-prometheus.json
+++ b/internal/monitoring/dashboards/garage-prometheus.json
@@ -1007,6 +1007,118 @@
       "title": "Resync errored blocks",
       "type": "timeseries"
     }
+    ,{
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 33},
+      "id": 20,
+      "title": "Cluster Health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [
+            {"options": {"0": {"color": "red", "index": 0, "text": "Unhealthy"}, "1": {"color": "green", "index": 1, "text": "Healthy"}}, "type": "value"}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 34},
+      "id": 21,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "min(cluster_healthy{job=\"garage\"})", "legendFormat": "Healthy", "refId": "A"}],
+      "title": "Cluster Healthy",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [
+            {"options": {"0": {"color": "red", "index": 0, "text": "Unavailable"}, "1": {"color": "green", "index": 1, "text": "Available"}}, "type": "value"}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 34},
+      "id": 22,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "min(cluster_available{job=\"garage\"})", "legendFormat": "Available", "refId": "A"}],
+      "title": "Cluster Available",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 34},
+      "id": 23,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes_ok{job=\"garage\"}", "legendFormat": "OK {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "B"}
+      ],
+      "title": "Storage Nodes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 34},
+      "id": 24,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions_all_ok{job=\"garage\"}", "legendFormat": "All OK {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions_quorum{job=\"garage\"}", "legendFormat": "Quorum {{instance}}", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "C"}
+      ],
+      "title": "Partitions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 38},
+      "id": 25,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_connected_nodes{job=\"garage\"}", "legendFormat": "Connected {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_known_nodes{job=\"garage\"}", "legendFormat": "Known {{instance}}", "refId": "B"}
+      ],
+      "title": "Connected vs Known Nodes",
+      "type": "timeseries"
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 37,
@@ -1023,6 +1135,6 @@
   "timezone": "",
   "title": "Garage",
   "uid": "ys3pnpZ4k",
-  "version": 26,
+  "version": 27,
   "weekStart": ""
 }

--- a/internal/monitoring/dashboards/garage-prometheus.json
+++ b/internal/monitoring/dashboards/garage-prometheus.json
@@ -1119,6 +1119,274 @@
       "title": "Connected vs Known Nodes",
       "type": "timeseries"
     }
+    ,{
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 43},
+      "id": 30,
+      "title": "API Latency",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 44},
+      "id": 31,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{api_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{api_endpoint}}", "refId": "B"}
+      ],
+      "title": "S3 Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 44},
+      "id": 32,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (admin_endpoint) (rate(api_admin_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "{{admin_endpoint}}", "refId": "A"}
+      ],
+      "title": "Admin API Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 44},
+      "id": 33,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95", "refId": "B"}
+      ],
+      "title": "Admin API Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 53},
+      "id": 40,
+      "title": "Block Manager",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 54},
+      "id": 41,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_read_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 read", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_write_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 write", "refId": "B"}
+      ],
+      "title": "Block Read/Write Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 54},
+      "id": 42,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "block_ram_buffer_free_kb{job=\"garage\"} * 1024", "legendFormat": "RAM buffer free {{instance}}", "refId": "A"}
+      ],
+      "title": "Block RAM Buffer Free",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 54},
+      "id": 43,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(block_delete_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Deletes/s", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(block_resync_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Resyncs/s", "refId": "B"}
+      ],
+      "title": "Block Operations",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 63},
+      "id": 50,
+      "title": "RPC Details",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 64},
+      "id": 51,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (rpc_endpoint) (rate(rpc_netapp_error_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "errors {{rpc_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(rpc_timeout_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "timeouts", "refId": "B"}
+      ],
+      "title": "RPC Errors and Timeouts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 64},
+      "id": 52,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{rpc_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{rpc_endpoint}}", "refId": "B"}
+      ],
+      "title": "RPC Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 73},
+      "id": 60,
+      "title": "Table Sync",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 74},
+      "id": 61,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_received{job=\"garage\"}[$__rate_interval]))", "legendFormat": "received {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_sent{job=\"garage\"}[$__rate_interval]))", "legendFormat": "sent {{table_name}}", "refId": "B"}
+      ],
+      "title": "Table Sync Items",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 74},
+      "id": 62,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_get_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "get {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_put_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "put {{table_name}}", "refId": "B"}
+      ],
+      "title": "Table Get/Put Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 74},
+      "id": 63,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_get_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 get {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_put_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 put {{table_name}}", "refId": "B"}
+      ],
+      "title": "Table Request Latency",
+      "type": "timeseries"
+    }
   ],
   "refresh": "30s",
   "schemaVersion": 37,
@@ -1135,6 +1403,6 @@
   "timezone": "",
   "title": "Garage",
   "uid": "ys3pnpZ4k",
-  "version": 27,
+  "version": 28,
   "weekStart": ""
 }

--- a/internal/monitoring/dashboards/garage-prometheus.json
+++ b/internal/monitoring/dashboards/garage-prometheus.json
@@ -439,7 +439,7 @@
             "uid": "${DS_DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (rpc_endpoint) (rate(rpc_request_counter {job=\"garage\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_endpoint) (rate(rpc_netapp_request_counter {job=\"garage\"}[$__rate_interval]))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{rpc_endpoint}}",


### PR DESCRIPTION
## Summary

- **Fix broken RPC alert** — `rpc_request_counter` → `rpc_netapp_request_counter` in PrometheusRule and dashboard; the `GarageHighRPCErrorRate` alert was silently a no-op
- **Add cluster health monitoring** — 5 new alerts (`GarageClusterUnhealthy`, `GarageClusterUnavailable`, `GarageStorageNodeDown`, `GaragePartitionsDegraded`, `GarageNodeDisconnected`) + Cluster Health dashboard row covering all 11 `cluster_*` metrics
- **Reduce GarageKey creation latency** — fixes two bugs causing ~2.5 min provisioning time with 3 operators: (1) `findKeyByName` multiple-match now adopts first key instead of creating infinite duplicates; (2) health gate relaxed to `Phase == Running` only, removing unnecessary wait cycles during federated startup
- **Complete dashboard metrics pass** — adds API latency (S3 p95/p99, Admin API), Block Manager (read/write latency, RAM buffer, ops), RPC Details (errors, timeouts, latency), and Table Sync rows; grows from ~14 to ~44 of 50 Garage metrics covered
- **SDK evaluation** — evaluated `garage-admin-sdk-golang`; documented decision to keep hand-crafted client (external forge supply-chain risk, custom error helpers integration cost)

## Test plan

- [ ] `make test` passes
- [ ] `helm lint charts/garage-operator` clean
- [ ] Verify `GarageHighRPCErrorRate` alert fires correctly in Prometheus
- [ ] Verify Cluster Health dashboard row shows green stats on a healthy cluster
- [ ] Create a new StorageStack and confirm GarageKey reaches Ready in <30s (vs ~2.5 min before)
- [ ] Import dashboard JSON into Grafana and verify new rows render without errors