### PR TITLE
feat: operational annotations, e2e improvements, web API

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,57 @@ spec:
 
 Requires Kubernetes 1.23+. For production clusters, leave this unset (defaults to `Retain`) or set `whenScaled: Delete` only if you're confident scaled-down nodes won't need their data again.
 
+## Operational Annotations
+
+One-shot operational commands are triggered by setting annotations on the resource. The operator processes the annotation, acts, and removes it — so setting the annotation again re-triggers the operation.
+
+### GarageCluster
+
+| Annotation | Value | Action |
+|---|---|---|
+| `garage.rajsingh.info/pause-reconcile` | `"true"` | Suspend all reconciliation. The operator requeues every 5 minutes but makes no changes until the annotation is removed. |
+| `garage.rajsingh.info/trigger-snapshot` | `"true"` | Trigger a metadata database snapshot on all nodes (`POST /v2/CreateMetadataSnapshot`). Keeps the 2 most recent snapshots. |
+| `garage.rajsingh.info/trigger-repair` | repair type | Launch a repair operation on all nodes. Valid types: `Tables`, `Blocks`, `Versions`, `MultipartUploads`, `BlockRefs`, `BlockRc`, `Rebalance`, `Aliases`, `ClearResyncQueue`. |
+| `garage.rajsingh.info/scrub-command` | command | Control the block integrity scrub worker on all nodes. Valid commands: `start`, `pause`, `resume`, `cancel`. |
+| `garage.rajsingh.info/force-layout-apply` | `"true"` | Force-apply a staged layout version. |
+| `garage.rajsingh.info/connect-nodes` | `nodeId@addr:port,...` | Connect to external nodes (one-shot federation bootstrap). |
+
+**Example — trigger a full Tables repair:**
+```bash
+kubectl annotate garagecluster garage garage.rajsingh.info/trigger-repair=Tables
+```
+
+**Example — pause reconciliation for maintenance:**
+```bash
+# Pause
+kubectl annotate garagecluster garage garage.rajsingh.info/pause-reconcile=true
+# Resume
+kubectl annotate garagecluster garage garage.rajsingh.info/pause-reconcile- --overwrite
+```
+
+**Example — run and then pause a scrub:**
+```bash
+kubectl annotate garagecluster garage garage.rajsingh.info/scrub-command=start
+# Later...
+kubectl annotate garagecluster garage garage.rajsingh.info/scrub-command=pause
+```
+
+> **Note:** `trigger-repair: Scrub` is not supported — use `scrub-command: start` instead.
+
+### GarageBucket
+
+| Annotation | Value | Action |
+|---|---|---|
+| `garage.rajsingh.info/cleanup-mpu` | `"true"` | Delete incomplete multipart uploads older than the threshold (default: 24h). |
+| `garage.rajsingh.info/cleanup-mpu-older-than` | duration | Age threshold for MPU cleanup (e.g. `"12h"`, `"30m"`). Only used with `cleanup-mpu`. Defaults to `24h` if absent or invalid. |
+
+**Example — clean up stale uploads older than 48 hours:**
+```bash
+kubectl annotate garagebucket my-bucket \
+  garage.rajsingh.info/cleanup-mpu=true \
+  garage.rajsingh.info/cleanup-mpu-older-than=48h
+```
+
 ## Website Hosting
 
 Website hosting is **enabled by default** on every GarageCluster. Buckets with website hosting enabled are served at `<bucket>.<root-domain>` on port 3902.
@@ -503,7 +554,7 @@ If the cluster uses `metricsTokenSecretRef`, the generated ServiceMonitor will i
 
 ### PrometheusRules
 
-The Helm chart includes alerting rules for node availability, RPC error rate, block resync errors, and low disk space:
+The Helm chart includes alerting rules covering node availability, cluster health (quorum, partitions, disconnected nodes), RPC error rate, block resync errors, and low disk space:
 
 ```yaml
 # values.yaml

--- a/docs/superpowers/specs/2026-04-12-web-api-website-url-design.md
+++ b/docs/superpowers/specs/2026-04-12-web-api-website-url-design.md
@@ -1,0 +1,61 @@
+# Web API: Populate WebsiteURL Status
+
+**Date:** 2026-04-12
+**Status:** Approved
+
+## Goal
+
+Populate `GarageBucket.status.websiteUrl` when website hosting is enabled. The field is defined in the type but never set.
+
+## Background
+
+`GarageCluster.spec.webApi` is fully implemented: `[s3_web]` config is written, the port is exposed on the cluster Service, and `effectiveWebAPI()` computes the effective `rootDomain` (defaulting to `.<name>.<namespace>.svc`).
+
+`GarageBucket.spec.website` is also fully implemented: `enabled`, `indexDocument`, `errorDocument` are reconciled via the Admin API, and `status.websiteEnabled` / `status.websiteConfig` are populated.
+
+`status.websiteUrl` is the only gap — defined in the type, never assigned.
+
+Garage's web hosting is purely host-header based. With `root_domain = ".web.example.com"`, a request with `Host: mybucket.web.example.com` serves from the `mybucket` bucket. The URL for a bucket is therefore `{globalAlias}{rootDomain}`.
+
+HTTPRoute auto-provisioning is explicitly out of scope.
+
+## Change
+
+**File:** `internal/controller/garagebucket_controller.go`
+
+In `syncStatus`, after setting `bucket.Status.GlobalAlias` (line ~651), set `WebsiteURL`:
+
+```go
+if garageBucket.WebsiteAccess {
+    if w := effectiveWebAPI(cluster); w != nil {
+        bucket.Status.WebsiteURL = "http://" + bucket.Status.GlobalAlias + w.RootDomain
+    }
+} else {
+    bucket.Status.WebsiteURL = ""
+}
+```
+
+`effectiveWebAPI` is in the same package — no import needed. `cluster` is already in scope (fetched at reconcile start). `GlobalAlias` must be set before this block runs (it is, at line ~651).
+
+## Edge Cases
+
+- **Website disabled:** `WebsiteURL` is cleared to `""`.
+- **Web API disabled on cluster** (`webApi.disabled: true`): `effectiveWebAPI` returns nil, `WebsiteURL` stays empty.
+- **Cluster fetch error:** The bucket controller gates on `clusterErr` before reaching reconciliation, so `cluster` is always valid when this code runs.
+- **No global alias:** If `bucket.Status.GlobalAlias` is empty (bucket has no alias yet), the URL will be malformed. Guard: only set URL when `GlobalAlias != ""`.
+
+## Updated Change
+
+```go
+if garageBucket.WebsiteAccess {
+    if w := effectiveWebAPI(cluster); w != nil && bucket.Status.GlobalAlias != "" {
+        bucket.Status.WebsiteURL = "http://" + bucket.Status.GlobalAlias + w.RootDomain
+    }
+} else {
+    bucket.Status.WebsiteURL = ""
+}
+```
+
+## Scope
+
+Single file, ~5 lines added. No new types, no new dependencies, no API surface changes.

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -187,7 +187,7 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.updateStatus(ctx, bucket, "Error", err)
 	}
 
-	return r.updateStatusFromGarage(ctx, bucket, garageClient)
+	return r.updateStatusFromGarage(ctx, bucket, garageClient, cluster)
 }
 
 func (r *GarageBucketReconciler) reconcileBucket(ctx context.Context, bucket *garagev1alpha1.GarageBucket, garageClient *garage.Client) error {
@@ -583,7 +583,7 @@ func (r *GarageBucketReconciler) updateStatus(ctx context.Context, bucket *garag
 	return ctrl.Result{}, nil
 }
 
-func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, bucket *garagev1alpha1.GarageBucket, garageClient *garage.Client) (ctrl.Result, error) {
+func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, bucket *garagev1alpha1.GarageBucket, garageClient *garage.Client, cluster *garagev1alpha1.GarageCluster) (ctrl.Result, error) {
 	if bucket.Status.BucketID == "" {
 		return r.updateStatus(ctx, bucket, "Pending", nil)
 	}
@@ -650,6 +650,15 @@ func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, buc
 
 	if len(garageBucket.GlobalAliases) > 0 {
 		bucket.Status.GlobalAlias = garageBucket.GlobalAliases[0]
+	}
+
+	// Populate WebsiteURL if website is enabled
+	if garageBucket.WebsiteAccess {
+		if w := effectiveWebAPI(cluster); w != nil && bucket.Status.GlobalAlias != "" {
+			bucket.Status.WebsiteURL = "http://" + bucket.Status.GlobalAlias + w.RootDomain
+		}
+	} else {
+		bucket.Status.WebsiteURL = ""
 	}
 
 	// Update key status and collect local aliases, sorted for deterministic comparison

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -176,6 +176,12 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Handle one-shot operational annotations (cleanup-mpu, etc.)
+	if err := r.handleBucketAnnotations(ctx, bucket, garageClient); err != nil {
+		log.Error(err, "Failed to handle bucket annotation")
+		// Non-fatal: don't block normal reconciliation
+	}
+
 	// Reconcile the bucket
 	if err := r.reconcileBucket(ctx, bucket, garageClient); err != nil {
 		return r.updateStatus(ctx, bucket, "Error", err)
@@ -710,6 +716,58 @@ func formatBytes(bytes int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+// parseMPUOlderThan converts a duration string (e.g. "24h", "30m") to seconds.
+// Returns the default of 86400 (24h) for empty, invalid, or non-positive values.
+// Note: "d" suffix is not supported by time.ParseDuration; use "24h" instead.
+func parseMPUOlderThan(s string) uint64 {
+	const defaultSecs uint64 = 86400
+	if s == "" {
+		return defaultSecs
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return defaultSecs
+	}
+	return uint64(d.Seconds())
+}
+
+// handleBucketAnnotations processes one-shot operational annotations on GarageBucket.
+func (r *GarageBucketReconciler) handleBucketAnnotations(ctx context.Context, bucket *garagev1alpha1.GarageBucket, garageClient *garage.Client) error {
+	log := logf.FromContext(ctx)
+
+	if bucket.Annotations == nil {
+		return nil
+	}
+
+	if _, ok := bucket.Annotations[garagev1alpha1.AnnotationCleanupMPU]; !ok {
+		return nil
+	}
+
+	defer func() {
+		delete(bucket.Annotations, garagev1alpha1.AnnotationCleanupMPU)
+		delete(bucket.Annotations, garagev1alpha1.AnnotationCleanupMPUOlderThan)
+		if err := r.Update(ctx, bucket); err != nil {
+			log.Error(err, "Failed to remove cleanup-mpu annotations")
+		}
+	}()
+
+	if bucket.Status.BucketID == "" {
+		log.Info("cleanup-mpu: bucket not yet provisioned, skipping")
+		return nil
+	}
+
+	olderThan := parseMPUOlderThan(bucket.Annotations[garagev1alpha1.AnnotationCleanupMPUOlderThan])
+	result, err := garageClient.CleanupIncompleteUploads(ctx, bucket.Status.BucketID, olderThan)
+	if err != nil {
+		return fmt.Errorf("cleanup-mpu failed: %w", err)
+	}
+	log.Info("Incomplete multipart uploads cleaned up",
+		"bucketID", bucket.Status.BucketID,
+		"olderThanSecs", olderThan,
+		"uploadsDeleted", result.UploadsDeleted)
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -254,4 +255,27 @@ var _ = Describe("GarageBucket Controller", func() {
 
 func int64Ptr(i int64) *int64 {
 	return &i
+}
+
+func TestParseMPUOlderThan(t *testing.T) {
+	tests := []struct {
+		input string
+		want  uint64
+	}{
+		{"24h", 86400},
+		{"1h", 3600},
+		{"30m", 1800},
+		{"", 86400},    // empty → default
+		{"bad", 86400}, // invalid → default
+		{"7d", 86400},  // "d" not supported by time.ParseDuration → default
+		{"-1h", 86400}, // negative → default
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseMPUOlderThan(tt.input)
+			if got != tt.want {
+				t.Errorf("parseMPUOlderThan(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3768,6 +3768,89 @@ func (r *GarageClusterReconciler) handleOperationalAnnotations(ctx context.Conte
 		log.Info("Processed and removed skip-dead-nodes annotation")
 	}
 
+	// Build a Garage client if any API-calling annotations are set.
+	needsClient := cluster.Annotations[garagev1alpha1.AnnotationTriggerSnapshot] != "" ||
+		cluster.Annotations[garagev1alpha1.AnnotationTriggerRepair] != "" ||
+		cluster.Annotations[garagev1alpha1.AnnotationScrubCommand] != ""
+
+	var garageClient *garage.Client
+	if needsClient {
+		adminToken, err := r.getAdminToken(ctx, cluster)
+		if err != nil || adminToken == "" {
+			return fmt.Errorf("admin token required for operational annotation: %w", err)
+		}
+		adminPort := getAdminPort(cluster)
+		adminEndpoint := "http://" + svcFQDN(cluster.Name, cluster.Namespace, adminPort, r.ClusterDomain)
+		garageClient = garage.NewClient(adminEndpoint, adminToken)
+	}
+
+	// trigger-snapshot: triggers metadata snapshot on all nodes. Value must be "true".
+	if v, ok := cluster.Annotations[garagev1alpha1.AnnotationTriggerSnapshot]; ok {
+		if v != "true" {
+			log.Info("Ignoring invalid trigger-snapshot value (expected 'true')", "value", v)
+		} else if err := garageClient.CreateMetadataSnapshot(ctx, "*"); err != nil {
+			return fmt.Errorf("trigger-snapshot failed: %w", err)
+		} else {
+			log.Info("Metadata snapshot triggered on all nodes")
+		}
+		delete(cluster.Annotations, garagev1alpha1.AnnotationTriggerSnapshot)
+		if err := r.Update(ctx, cluster); err != nil {
+			return err
+		}
+	}
+
+	// trigger-repair: triggers a repair operation on all nodes.
+	// Valid values: Tables, Blocks, Versions, MultipartUploads, BlockRefs, BlockRc,
+	// Rebalance, Aliases, ClearResyncQueue. "Scrub" is rejected — use scrub-command.
+	if repairType, ok := cluster.Annotations[garagev1alpha1.AnnotationTriggerRepair]; ok {
+		validRepairTypes := map[string]bool{
+			garagev1alpha1.RepairTypeTables:           true,
+			garagev1alpha1.RepairTypeBlocks:           true,
+			garagev1alpha1.RepairTypeVersions:         true,
+			garagev1alpha1.RepairTypeMultipartUploads: true,
+			garagev1alpha1.RepairTypeBlockRefs:        true,
+			garagev1alpha1.RepairTypeBlockRc:          true,
+			garagev1alpha1.RepairTypeRebalance:        true,
+			garagev1alpha1.RepairTypeAliases:          true,
+			garagev1alpha1.RepairTypeClearResyncQueue: true,
+		}
+		if repairType == garagev1alpha1.RepairTypeScrub {
+			log.Info("trigger-repair: Scrub is not supported via this annotation; use scrub-command instead")
+		} else if !validRepairTypes[repairType] {
+			log.Info("Ignoring invalid trigger-repair value", "value", repairType)
+		} else if err := garageClient.LaunchRepair(ctx, "*", repairType); err != nil {
+			return fmt.Errorf("trigger-repair failed: %w", err)
+		} else {
+			log.Info("Repair operation launched on all nodes", "repairType", repairType)
+		}
+		delete(cluster.Annotations, garagev1alpha1.AnnotationTriggerRepair)
+		if err := r.Update(ctx, cluster); err != nil {
+			return err
+		}
+	}
+
+	// scrub-command: controls the scrub worker on all nodes.
+	// Valid values: start, pause, resume, cancel.
+	if cmd, ok := cluster.Annotations[garagev1alpha1.AnnotationScrubCommand]; ok {
+		validScrubCommands := map[string]bool{
+			garagev1alpha1.ScrubCommandStart:  true,
+			garagev1alpha1.ScrubCommandPause:  true,
+			garagev1alpha1.ScrubCommandResume: true,
+			garagev1alpha1.ScrubCommandCancel: true,
+		}
+		if !validScrubCommands[cmd] {
+			log.Info("Ignoring invalid scrub-command value", "value", cmd)
+		} else if err := garageClient.LaunchScrubCommand(ctx, "*", cmd); err != nil {
+			return fmt.Errorf("scrub-command failed: %w", err)
+		} else {
+			log.Info("Scrub command sent to all nodes", "command", cmd)
+		}
+		delete(cluster.Annotations, garagev1alpha1.AnnotationScrubCommand)
+		if err := r.Update(ctx, cluster); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -116,6 +116,12 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// pause-reconcile annotation: operator pauses all reconciliation until annotation is removed.
+	if v := cluster.Annotations[garagev1alpha1.AnnotationPauseReconcile]; v == "true" {
+		log.Info("Reconciliation paused via annotation")
+		return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
+	}
+
 	// Ensure RPC secret exists
 	if _, err := r.ensureRPCSecret(ctx, cluster); err != nil {
 		return r.updateStatus(ctx, cluster, "Error", err)

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -767,6 +767,90 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
+func TestEffectiveWebAPI(t *testing.T) {
+	tests := []struct {
+		name               string
+		cluster            *garagev1alpha1.GarageCluster
+		expectNonNil       bool
+		expectedRootDomain string
+		wantURL            string
+	}{
+		{
+			name: "default rootDomain when WebAPI spec is nil",
+			cluster: &garagev1alpha1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "garage", Namespace: "default"},
+				Spec:       garagev1alpha1.GarageClusterSpec{},
+			},
+			expectNonNil:       true,
+			expectedRootDomain: ".garage.default.svc",
+			wantURL:            "http://mybucket.garage.default.svc",
+		},
+		{
+			name: "returns nil when web API disabled",
+			cluster: &garagev1alpha1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "garage", Namespace: "default"},
+				Spec: garagev1alpha1.GarageClusterSpec{
+					WebAPI: &garagev1alpha1.WebAPIConfig{Disabled: true},
+				},
+			},
+			expectNonNil: false,
+		},
+		{
+			name: "uses custom rootDomain when set",
+			cluster: &garagev1alpha1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "garage", Namespace: "default"},
+				Spec: garagev1alpha1.GarageClusterSpec{
+					WebAPI: &garagev1alpha1.WebAPIConfig{RootDomain: ".web.example.com"},
+				},
+			},
+			expectNonNil:       true,
+			expectedRootDomain: ".web.example.com",
+			wantURL:            "http://mybucket.web.example.com",
+		},
+		{
+			name: "explicit Disabled: false with custom domain",
+			cluster: &garagev1alpha1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "mygarage", Namespace: "myns"},
+				Spec: garagev1alpha1.GarageClusterSpec{
+					WebAPI: &garagev1alpha1.WebAPIConfig{
+						Disabled:   false,
+						RootDomain: ".custom.local",
+					},
+				},
+			},
+			expectNonNil:       true,
+			expectedRootDomain: ".custom.local",
+			wantURL:            "http://mybucket.custom.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := effectiveWebAPI(tt.cluster)
+
+			if tt.expectNonNil {
+				if result == nil {
+					t.Errorf("effectiveWebAPI() = nil, want non-nil")
+					return
+				}
+				if result.RootDomain != tt.expectedRootDomain {
+					t.Errorf("RootDomain = %q, want %q", result.RootDomain, tt.expectedRootDomain)
+				}
+				if tt.wantURL != "" {
+					gotURL := "http://mybucket" + result.RootDomain
+					if gotURL != tt.wantURL {
+						t.Errorf("composed URL = %q, want %q", gotURL, tt.wantURL)
+					}
+				}
+			} else {
+				if result != nil {
+					t.Errorf("effectiveWebAPI() = %v, want nil", result)
+				}
+			}
+		})
+	}
+}
+
 func ptrQuantity(q resource.Quantity) *resource.Quantity {
 	return &q
 }

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -1262,6 +1262,23 @@ func (c *Client) LaunchRepair(ctx context.Context, nodeID, repairType string) er
 	return err
 }
 
+// LaunchScrubCommand sends a scrub control command to nodes.
+// The Garage API encodes scrub as {"repairType": {"scrub": "<command>"}} —
+// a nested object, unlike other repair types which use a plain string.
+// Valid commands: start, pause, resume, cancel.
+func (c *Client) LaunchScrubCommand(ctx context.Context, nodeID, command string) error {
+	type scrubType struct {
+		Scrub string `json:"scrub"`
+	}
+	type scrubRequest struct {
+		RepairType scrubType `json:"repairType"`
+	}
+	query := map[string]string{"node": nodeID}
+	req := scrubRequest{RepairType: scrubType{Scrub: command}}
+	_, err := c.doRequestWithQuery(ctx, http.MethodPost, "/v2/LaunchRepairOperation", query, req)
+	return err
+}
+
 // CreateMetadataSnapshot triggers a metadata snapshot on a node
 func (c *Client) CreateMetadataSnapshot(ctx context.Context, nodeID string) error {
 	query := map[string]string{"node": nodeID}

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package garage
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -584,4 +588,36 @@ func TestWorkerInfo_ThrottledState(t *testing.T) {
 
 func float32Ptr(v float32) *float32 {
 	return &v
+}
+
+func TestLaunchScrubCommand_RequestBody(t *testing.T) {
+	tests := []struct {
+		command  string
+		wantBody string
+	}{
+		{"start", `{"repairType":{"scrub":"start"}}`},
+		{"pause", `{"repairType":{"scrub":"pause"}}`},
+		{"resume", `{"repairType":{"scrub":"resume"}}`},
+		{"cancel", `{"repairType":{"scrub":"cancel"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			var gotBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBody, _ = io.ReadAll(r.Body)
+				if r.URL.Query().Get("node") != "*" {
+					t.Errorf("expected node=*, got %q", r.URL.Query().Get("node"))
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, "test-token")
+			_ = c.LaunchScrubCommand(context.Background(), "*", tt.command)
+
+			if string(gotBody) != tt.wantBody {
+				t.Errorf("body = %q, want %q", gotBody, tt.wantBody)
+			}
+		})
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -449,6 +449,10 @@ var _ = Describe("Gateway Cluster", Ordered, Label("gateway"), func() {
 	const storageClusterName = "storage-cluster"
 	const gatewayClusterName = "gateway-cluster"
 
+	// shared state for credential drift tests (set by Test 1, read by Test 2)
+	var driftBucketID string
+	var driftSecretRV string
+
 	BeforeAll(func() {
 		By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", namespace)
@@ -1055,6 +1059,237 @@ spec:
 				"-n", testNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 			cmd = exec.Command("kubectl", "delete", "garagebucket", "revoke-test-bucket",
+				"-n", testNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should recreate key and update secret when key is deleted in Garage", func() {
+			const driftBucketName = "drift-test-bucket"
+			const driftKeyName = "drift-test-key"
+			const adminToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+			By("creating drift test bucket")
+			bucketYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1alpha1
+kind: GarageBucket
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  clusterRef:
+    name: %s
+`, driftBucketName, testNamespace, storageClusterName)
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(bucketYAML)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create drift test bucket")
+
+			By("waiting for drift test bucket to be ready and recording its ID")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "garagebucket", driftBucketName,
+					"-n", testNamespace, "-o", "jsonpath={.status.bucketId}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "Bucket ID not yet set")
+				driftBucketID = output
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("creating drift test key with read+write on drift bucket")
+			keyYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1alpha1
+kind: GarageKey
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  clusterRef:
+    name: %s
+  bucketPermissions:
+    - bucketRef: %s
+      read: true
+      write: true
+`, driftKeyName, testNamespace, storageClusterName, driftBucketName)
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(keyYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create drift test key")
+
+			By("waiting for drift test key to be ready")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "garagekey", driftKeyName,
+					"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Ready"), "Key phase: %s", output)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("recording original access key ID")
+			cmd = exec.Command("kubectl", "get", "garagekey", driftKeyName,
+				"-n", testNamespace, "-o", "jsonpath={.status.accessKeyId}")
+			originalAccessKeyID, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(originalAccessKeyID).NotTo(BeEmpty(), "accessKeyId not set in status")
+
+			By("deleting the key from Garage admin API (simulating out-of-band deletion)")
+			curlCmd := fmt.Sprintf(
+				`curl -s -o /dev/null -w "%%{http_code}" -X POST `+
+					`-H 'Authorization: Bearer %s' `+
+					`-H 'Content-Type: application/json' `+
+					`-d '{"id":"%s"}' `+
+					`http://%s.%s.svc.cluster.local:3903/v2/DeleteKey`,
+				adminToken, originalAccessKeyID, storageClusterName, testNamespace,
+			)
+			Eventually(func(g Gomega) {
+				cleanupCmd := exec.Command("kubectl", "delete", "pod", "curl-drift-delete-key",
+					"-n", testNamespace, "--ignore-not-found", "--force", "--grace-period=0")
+				_, _ = utils.Run(cleanupCmd)
+
+				cmd := exec.Command("kubectl", "run", "curl-drift-delete-key", "--rm", "-i", "--restart=Never",
+					"-n", testNamespace,
+					"--image=docker.io/curlimages/curl:latest",
+					"--overrides", fmt.Sprintf(`{
+						"spec": {
+							"containers": [{
+								"name": "curl-drift-delete-key",
+								"image": "docker.io/curlimages/curl:latest",
+								"imagePullPolicy": "IfNotPresent",
+								"command": ["/bin/sh", "-c"],
+								"args": [%q],
+								"securityContext": {
+									"readOnlyRootFilesystem": true,
+									"allowPrivilegeEscalation": false,
+									"capabilities": {"drop": ["ALL"]},
+									"runAsNonRoot": true,
+									"runAsUser": 1000,
+									"seccompProfile": {"type": "RuntimeDefault"}
+								}
+							}]
+						}
+					}`, curlCmd))
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "curl pod failed: %s", output)
+				g.Expect(strings.TrimSpace(output)).To(Equal("204"),
+					"Expected HTTP 204 from DeleteKey, got: %s", output)
+			}, 1*time.Minute, 10*time.Second).Should(Succeed())
+
+			By("recording secret resourceVersion after confirmed deletion")
+			cmd = exec.Command("kubectl", "get", "secret", driftKeyName,
+				"-n", testNamespace, "-o", "jsonpath={.metadata.resourceVersion}")
+			driftSecretRV, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(driftSecretRV).NotTo(BeEmpty(), "Secret resourceVersion not set")
+
+			By("triggering immediate reconciliation by touching the GarageKey")
+			cmd = exec.Command("kubectl", "label", "--overwrite", "garagekey", driftKeyName,
+				"-n", testNamespace,
+				fmt.Sprintf("garage.rajsingh.info/reconcile-trigger=%d", time.Now().Unix()))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for operator to detect drift and update secret with new credentials")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secret", driftKeyName,
+					"-n", testNamespace, "-o", "jsonpath={.metadata.resourceVersion}")
+				currentRV, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(currentRV).NotTo(Equal(driftSecretRV),
+					"Secret resourceVersion unchanged — operator has not updated credentials yet")
+
+				cmd = exec.Command("kubectl", "get", "secret", driftKeyName,
+					"-n", testNamespace,
+					"-o", `go-template={{ index .data "access-key-id" | base64decode }}`)
+				newAccessKeyID, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(newAccessKeyID).NotTo(Equal(originalAccessKeyID),
+					"Access key ID unchanged — operator recreated same key ID unexpectedly")
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying GarageKey returns to Ready phase after drift recovery")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "garagekey", driftKeyName,
+					"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Ready"), "Key phase after recovery: %s", output)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("should successfully PUT and GET objects with credentials after drift recovery", func() {
+			const driftKeyName = "drift-test-key"
+			Expect(driftBucketID).NotTo(BeEmpty(), "driftBucketID not set — credential drift test must run first")
+
+			By("reading recovered credentials from the K8s secret")
+			cmd := exec.Command("kubectl", "get", "secret", driftKeyName,
+				"-n", testNamespace,
+				"-o", `go-template={{ index .data "access-key-id" | base64decode }}`)
+			accessKeyID, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(accessKeyID).NotTo(BeEmpty(), "access-key-id not in secret")
+
+			cmd = exec.Command("kubectl", "get", "secret", driftKeyName,
+				"-n", testNamespace,
+				"-o", `go-template={{ index .data "secret-access-key" | base64decode }}`)
+			secretAccessKey, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secretAccessKey).NotTo(BeEmpty(), "secret-access-key not in secret")
+
+			By("running S3 PUT then GET via aws-cli to verify recovered credentials work")
+			const testPayload = "drift-recovery-verified"
+			const testObject = "drift-test-object"
+			endpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:3900", storageClusterName, testNamespace)
+
+			s3Cmd := fmt.Sprintf(
+				`printf '%s' > /tmp/payload.txt && `+
+					`aws s3api put-object --endpoint-url %s --region garage --bucket %s --key %s --body /tmp/payload.txt && `+
+					`aws s3api get-object --endpoint-url %s --region garage --bucket %s --key %s /tmp/out.txt && `+
+					`cat /tmp/out.txt`,
+				testPayload, endpoint, driftBucketID, testObject,
+				endpoint, driftBucketID, testObject,
+			)
+
+			Eventually(func(g Gomega) {
+				cleanupCmd := exec.Command("kubectl", "delete", "pod", "drift-s3-verify",
+					"-n", testNamespace, "--ignore-not-found", "--force", "--grace-period=0")
+				_, _ = utils.Run(cleanupCmd)
+
+				// readOnlyRootFilesystem omitted: aws-cli writes credential cache to /tmp
+				cmd := exec.Command("kubectl", "run", "drift-s3-verify", "--rm", "-i", "--restart=Never",
+					"-n", testNamespace,
+					"--image=docker.io/amazon/aws-cli:latest",
+					"--overrides", fmt.Sprintf(`{
+						"spec": {
+							"containers": [{
+								"name": "drift-s3-verify",
+								"image": "docker.io/amazon/aws-cli:latest",
+								"imagePullPolicy": "IfNotPresent",
+								"command": ["/bin/sh", "-c"],
+								"args": [%q],
+								"env": [
+									{"name": "AWS_ACCESS_KEY_ID", "value": %q},
+									{"name": "AWS_SECRET_ACCESS_KEY", "value": %q},
+									{"name": "HOME", "value": "/tmp"}
+								],
+								"securityContext": {
+									"allowPrivilegeEscalation": false,
+									"capabilities": {"drop": ["ALL"]},
+									"runAsNonRoot": true,
+									"runAsUser": 1000,
+									"seccompProfile": {"type": "RuntimeDefault"}
+								}
+							}]
+						}
+					}`, s3Cmd, accessKeyID, secretAccessKey))
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "aws-cli pod failed: %s", output)
+				g.Expect(output).To(ContainSubstring(testPayload),
+					"GET output should contain PUT payload. Full output: %s", output)
+			}, 3*time.Minute, 30*time.Second).Should(Succeed())
+
+			By("cleaning up drift test resources")
+			cmd = exec.Command("kubectl", "delete", "garagekey", driftKeyName,
+				"-n", testNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "garagebucket", "drift-test-bucket",
 				"-n", testNamespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 		})


### PR DESCRIPTION
## Summary

- **Operational annotations** — implement 6 previously stub-only one-shot triggers:
  - `trigger-snapshot`: metadata snapshot on all nodes
  - `trigger-repair`: repair operation (Tables, Blocks, Versions, etc.)
  - `scrub-command`: block integrity scrub control (start/pause/resume/cancel)
  - `pause-reconcile`: suspend all reconciliation until removed
  - `cleanup-mpu` / `cleanup-mpu-older-than`: clean up stale multipart uploads on a GarageBucket
- **Client**: new `LaunchScrubCommand` for the nested scrub JSON body shape
- **Simplify**: align GarageBucket health gate with GarageCluster (Phase-only check)
- **Docs**: README Operational Annotations section with examples

## Planned additions (in this PR)

- [ ] E2E test improvements
- [ ] Web API (s3_web) support

## Test plan

- [ ] `make test` passes
- [ ] `helm lint` clean
- [ ] Set `trigger-snapshot: "true"` on a live cluster, verify annotation removed + snapshot created
- [ ] Set `cleanup-mpu: "true"` on a GarageBucket, verify stale uploads aborted
- [ ] Set `pause-reconcile: "true"`, verify no reconciliation activity for 5+ minutes