### PR TITLE
fix(dashboard): replace __inputs with proper datasource template variable

### DIFF
--- a/charts/garage-operator/dashboards/garage-prometheus.json
+++ b/charts/garage-operator/dashboards/garage-prometheus.json
@@ -1,35 +1,5 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_DS_PROMETHEUS",
-      "label": "DS_PROMETHEUS",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "9.2.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -62,7 +32,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -140,7 +110,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum(rate(block_bytes_read{job=\"garage\"}[$__rate_interval])    )",
@@ -152,7 +122,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "-sum(rate(block_bytes_written{job=\"garage\"}[$__rate_interval])    )",
@@ -168,7 +138,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -246,7 +216,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -264,7 +234,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -342,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum(rate(web_request_counter {job=\"garage\"}[$__rate_interval]))",
@@ -358,7 +328,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -436,7 +406,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by (rpc_endpoint) (rate(rpc_netapp_request_counter {job=\"garage\"}[$__rate_interval]))",
@@ -452,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -530,7 +500,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -548,7 +518,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -626,7 +596,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by(status_code) (rate(web_error_counter {job=\"garage\"}[$__rate_interval]))",
@@ -642,7 +612,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -719,7 +689,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "block_resync_queue_length{job=\"garage\"}",
@@ -734,7 +704,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -811,7 +781,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by(table_name) (table_gc_todo_queue_length{job=\"garage\"})",
@@ -826,7 +796,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -903,7 +873,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by(table_name) (table_merkle_updater_todo_queue_length{job=\"garage\"})",
@@ -918,7 +888,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DS_PROMETHEUS}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -995,7 +965,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DS_PROMETHEUS}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "block_resync_errored_blocks{job=\"garage\"}",
@@ -1015,7 +985,7 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -1029,12 +999,12 @@
       "gridPos": {"h": 4, "w": 4, "x": 0, "y": 34},
       "id": 21,
       "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "min(cluster_healthy{job=\"garage\"})", "legendFormat": "Healthy", "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "min(cluster_healthy{job=\"garage\"})", "legendFormat": "Healthy", "refId": "A"}],
       "title": "Cluster Healthy",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -1048,12 +1018,12 @@
       "gridPos": {"h": 4, "w": 4, "x": 4, "y": 34},
       "id": 22,
       "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "min(cluster_available{job=\"garage\"})", "legendFormat": "Available", "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "min(cluster_available{job=\"garage\"})", "legendFormat": "Available", "refId": "A"}],
       "title": "Cluster Available",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1068,14 +1038,14 @@
       "id": 23,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes_ok{job=\"garage\"}", "legendFormat": "OK {{instance}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes_ok{job=\"garage\"}", "legendFormat": "OK {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "cluster_storage_nodes{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "B"}
       ],
       "title": "Storage Nodes",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1090,15 +1060,15 @@
       "id": 24,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions_all_ok{job=\"garage\"}", "legendFormat": "All OK {{instance}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions_quorum{job=\"garage\"}", "legendFormat": "Quorum {{instance}}", "refId": "B"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_partitions{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "C"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "cluster_partitions_all_ok{job=\"garage\"}", "legendFormat": "All OK {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "cluster_partitions_quorum{job=\"garage\"}", "legendFormat": "Quorum {{instance}}", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "cluster_partitions{job=\"garage\"}", "legendFormat": "Total {{instance}}", "refId": "C"}
       ],
       "title": "Partitions",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1113,8 +1083,8 @@
       "id": 25,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_connected_nodes{job=\"garage\"}", "legendFormat": "Connected {{instance}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "cluster_known_nodes{job=\"garage\"}", "legendFormat": "Known {{instance}}", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "cluster_connected_nodes{job=\"garage\"}", "legendFormat": "Connected {{instance}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "cluster_known_nodes{job=\"garage\"}", "legendFormat": "Known {{instance}}", "refId": "B"}
       ],
       "title": "Connected vs Known Nodes",
       "type": "timeseries"
@@ -1127,7 +1097,7 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1142,14 +1112,14 @@
       "id": 31,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{api_endpoint}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{api_endpoint}}", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{api_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (api_endpoint, le) (rate(api_s3_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{api_endpoint}}", "refId": "B"}
       ],
       "title": "S3 Request Latency",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1164,13 +1134,13 @@
       "id": 32,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (admin_endpoint) (rate(api_admin_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "{{admin_endpoint}}", "refId": "A"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (admin_endpoint) (rate(api_admin_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "{{admin_endpoint}}", "refId": "A"}
       ],
       "title": "Admin API Request Rate",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1185,8 +1155,8 @@
       "id": 33,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le) (rate(api_admin_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95", "refId": "B"}
       ],
       "title": "Admin API Latency",
       "type": "timeseries"
@@ -1199,7 +1169,7 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1214,14 +1184,14 @@
       "id": 41,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_read_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 read", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_write_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 write", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_read_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 read", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_write_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 write", "refId": "B"}
       ],
       "title": "Block Read/Write Latency",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1236,13 +1206,13 @@
       "id": 42,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "block_ram_buffer_free_kb{job=\"garage\"} * 1024", "legendFormat": "RAM buffer free {{instance}}", "refId": "A"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "block_ram_buffer_free_kb{job=\"garage\"} * 1024", "legendFormat": "RAM buffer free {{instance}}", "refId": "A"}
       ],
       "title": "Block RAM Buffer Free",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1257,8 +1227,8 @@
       "id": 43,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(block_delete_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Deletes/s", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(block_resync_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Resyncs/s", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum(rate(block_delete_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Deletes/s", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum(rate(block_resync_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "Resyncs/s", "refId": "B"}
       ],
       "title": "Block Operations",
       "type": "timeseries"
@@ -1271,7 +1241,7 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1286,14 +1256,14 @@
       "id": 51,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (rpc_endpoint) (rate(rpc_netapp_error_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "errors {{rpc_endpoint}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum(rate(rpc_timeout_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "timeouts", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (rpc_endpoint) (rate(rpc_netapp_error_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "errors {{rpc_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum(rate(rpc_timeout_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "timeouts", "refId": "B"}
       ],
       "title": "RPC Errors and Timeouts",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1308,8 +1278,8 @@
       "id": 52,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{rpc_endpoint}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{rpc_endpoint}}", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 {{rpc_endpoint}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (rpc_endpoint, le) (rate(rpc_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p95 {{rpc_endpoint}}", "refId": "B"}
       ],
       "title": "RPC Latency",
       "type": "timeseries"
@@ -1322,7 +1292,7 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1337,14 +1307,14 @@
       "id": 61,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_received{job=\"garage\"}[$__rate_interval]))", "legendFormat": "received {{table_name}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_sent{job=\"garage\"}[$__rate_interval]))", "legendFormat": "sent {{table_name}}", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_received{job=\"garage\"}[$__rate_interval]))", "legendFormat": "received {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_sync_items_sent{job=\"garage\"}[$__rate_interval]))", "legendFormat": "sent {{table_name}}", "refId": "B"}
       ],
       "title": "Table Sync Items",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1359,14 +1329,14 @@
       "id": 62,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_get_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "get {{table_name}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_put_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "put {{table_name}}", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_get_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "get {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (table_name) (rate(table_put_request_counter{job=\"garage\"}[$__rate_interval]))", "legendFormat": "put {{table_name}}", "refId": "B"}
       ],
       "title": "Table Get/Put Rate",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -1381,8 +1351,8 @@
       "id": 63,
       "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_get_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 get {{table_name}}", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_put_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 put {{table_name}}", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_get_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 get {{table_name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (table_name, le) (rate(table_put_request_duration{job=\"garage\"}[$__rate_interval])))", "legendFormat": "p99 put {{table_name}}", "refId": "B"}
       ],
       "title": "Table Request Latency",
       "type": "timeseries"
@@ -1393,7 +1363,19 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+    {
+      "current": {},
+      "hide": 0,
+      "includeAll": false,
+      "name": "DS_PROMETHEUS",
+      "options": [],
+      "query": "prometheus",
+      "refresh": 1,
+      "type": "datasource",
+      "label": "Datasource"
+    }
+    ]
   },
   "time": {
     "from": "now-6h",


### PR DESCRIPTION
Thanks @rajsinghtech for this operator! Super cool setup for my homelab.
This PR is something I stumbled upon when updating to 0.3.0, I currently have my own configmap defined with this exact fix. The least I can do is to propose that upstream, but feel free to discard this, if you don't like it.

---

Problem:

The dashboard JSON was exported from Grafana with an `__inputs` block, which causes a broken datasource reference when loaded via the **Grafana sidecar provisioning pattern** (ConfigMaps labeled for auto-discovery, including the operator's own `grafanaDashboard.enabled` feature).

The sidecar loads ConfigMap JSON directly without processing `__inputs`. Because Grafana adds a `DS_` prefix when substituting input variables, the unresolved reference becomes `${DS_DS_PROMETHEUS}` — a double prefix that doesn't match any datasource, resulting in a "Datasource not found" error on every panel.

Fix:

- Remove `__inputs` and `__requires` blocks (not used by sidecar provisioning)
- Replace all `${DS_DS_PROMETHEUS}` references with `${DS_PROMETHEUS}`
- Add `DS_PROMETHEUS` as a proper datasource template variable in `templating.list` (`type: datasource`, `query: prometheus`)

Compatibility:

| Loading method | Before | After |
|---|---|---|
| Grafana sidecar / ConfigMap provisioning | Broken (`${DS_DS_PROMETHEUS}` unresolved) | Works |
| `helm install` with `grafanaDashboard.enabled=true` | Broken (same reason) | Works |
| Manual UI import | Works (prompted at import time) | Works (datasource dropdown in dashboard header) |

The `DS_PROMETHEUS` template variable pattern is used by many community dashboards (Blocky, ArgoCD, etc.) and is the standard approach for sidecar-compatible dashboards.