### PR TITLE
fix(key): support cross-namespace bucket references in GarageKey

### DIFF
--- a/api/v1alpha1/garagekey_types.go
+++ b/api/v1alpha1/garagekey_types.go
@@ -186,9 +186,15 @@ type SecretTemplate struct {
 
 // BucketPermission grants access to a bucket
 type BucketPermission struct {
-	// BucketRef references the GarageBucket by name
+	// BucketRef references the GarageBucket by name in the same namespace as the GarageKey.
+	// Use BucketNamespace to reference a bucket in a different namespace.
 	// +optional
 	BucketRef string `json:"bucketRef,omitempty"`
+
+	// BucketNamespace is the namespace of the GarageBucket referenced by BucketRef.
+	// Defaults to the GarageKey's namespace if not set.
+	// +optional
+	BucketNamespace string `json:"bucketNamespace,omitempty"`
 
 	// BucketID references the bucket by its Garage ID
 	// +optional

--- a/api/v1alpha1/garagekey_webhook.go
+++ b/api/v1alpha1/garagekey_webhook.go
@@ -232,6 +232,9 @@ func (r *GarageKey) validateBucketPermissions() error {
 		if refs > 1 {
 			return fmt.Errorf("bucketPermissions[%d]: specify only one of bucketRef, bucketId, or globalAlias", i)
 		}
+		if perm.BucketNamespace != "" && perm.BucketRef == "" {
+			return fmt.Errorf("bucketPermissions[%d]: bucketNamespace requires bucketRef", i)
+		}
 
 		// Check for duplicates
 		if seen[refKey] {

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
@@ -105,8 +105,15 @@ spec:
                     bucketId:
                       description: BucketID references the bucket by its Garage ID
                       type: string
+                    bucketNamespace:
+                      description: |-
+                        BucketNamespace is the namespace of the GarageBucket referenced by BucketRef.
+                        Defaults to the GarageKey's namespace if not set.
+                      type: string
                     bucketRef:
-                      description: BucketRef references the GarageBucket by name
+                      description: |-
+                        BucketRef references the GarageBucket by name in the same namespace as the GarageKey.
+                        Use BucketNamespace to reference a bucket in a different namespace.
                       type: string
                     globalAlias:
                       description: GlobalAlias references the bucket by global alias

--- a/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
@@ -105,8 +105,15 @@ spec:
                     bucketId:
                       description: BucketID references the bucket by its Garage ID
                       type: string
+                    bucketNamespace:
+                      description: |-
+                        BucketNamespace is the namespace of the GarageBucket referenced by BucketRef.
+                        Defaults to the GarageKey's namespace if not set.
+                      type: string
                     bucketRef:
-                      description: BucketRef references the GarageBucket by name
+                      description: |-
+                        BucketRef references the GarageBucket by name in the same namespace as the GarageKey.
+                        Use BucketNamespace to reference a bucket in a different namespace.
                       type: string
                     globalAlias:
                       description: GlobalAlias references the bucket by global alias

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -611,16 +611,20 @@ func (r *GarageKeyReconciler) resolveBucketID(ctx context.Context, namespace str
 
 	if bucketPerm.BucketRef != "" {
 		bucketRef = bucketPerm.BucketRef
+		ns := namespace
+		if bucketPerm.BucketNamespace != "" {
+			ns = bucketPerm.BucketNamespace
+		}
 		bucket := &garagev1alpha1.GarageBucket{}
-		if err := r.Get(ctx, types.NamespacedName{Name: bucketPerm.BucketRef, Namespace: namespace}, bucket); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: bucketPerm.BucketRef, Namespace: ns}, bucket); err != nil {
 			if errors.IsNotFound(err) {
-				log.Info("Bucket not found, will retry", "bucketRef", bucketPerm.BucketRef)
+				log.Info("Bucket not found, will retry", "bucketRef", bucketPerm.BucketRef, "namespace", ns)
 				return "", bucketRef, true, nil
 			}
-			return "", bucketRef, false, fmt.Errorf("failed to get bucket %s: %w", bucketPerm.BucketRef, err)
+			return "", bucketRef, false, fmt.Errorf("failed to get bucket %s/%s: %w", ns, bucketPerm.BucketRef, err)
 		}
 		if bucket.Status.BucketID == "" {
-			log.Info("Bucket not yet created in Garage, will retry", "bucketRef", bucketPerm.BucketRef)
+			log.Info("Bucket not yet created in Garage, will retry", "bucketRef", bucketPerm.BucketRef, "namespace", ns)
 			return "", bucketRef, true, nil
 		}
 		return bucket.Status.BucketID, bucketRef, false, nil

--- a/internal/cosi/shadow.go
+++ b/internal/cosi/shadow.go
@@ -235,10 +235,10 @@ func (m *ShadowManager) CreateShadowKeyWithID(ctx context.Context, cosiName, acc
 	bucketPerms := make([]garagev1alpha1.BucketPermission, 0, len(permissions))
 	for _, perm := range permissions {
 		bucketPerms = append(bucketPerms, garagev1alpha1.BucketPermission{
-			BucketRef: perm.BucketID,
-			Read:      perm.Read,
-			Write:     perm.Write,
-			Owner:     perm.Owner,
+			BucketID: perm.BucketID,
+			Read:     perm.Read,
+			Write:    perm.Write,
+			Owner:    perm.Owner,
 		})
 	}
 

--- a/schemas/garagekey_v1alpha1.json
+++ b/schemas/garagekey_v1alpha1.json
@@ -43,8 +43,12 @@
                 "description": "BucketID references the bucket by its Garage ID",
                 "type": "string"
               },
+              "bucketNamespace": {
+                "description": "BucketNamespace is the namespace of the GarageBucket referenced by BucketRef.\nDefaults to the GarageKey's namespace if not set.",
+                "type": "string"
+              },
               "bucketRef": {
-                "description": "BucketRef references the GarageBucket by name",
+                "description": "BucketRef references the GarageBucket by name in the same namespace as the GarageKey.\nUse BucketNamespace to reference a bucket in a different namespace.",
                 "type": "string"
               },
               "globalAlias": {


### PR DESCRIPTION
## Summary

Fixes #98 — bucket permissions not applied when `GarageKey` is in a different namespace than its referenced `GarageBucket`.

- Adds optional `bucketNamespace` field to `BucketPermission`; when set, the controller looks up the `GarageBucket` in that namespace instead of defaulting to the `GarageKey`'s namespace
- Adds webhook validation rejecting `bucketNamespace` without `bucketRef`
- Fixes a bug in COSI shadow key creation that was incorrectly populating `BucketRef` with a Garage bucket ID — now correctly uses the `BucketID` field

Backwards compatible: existing `bucketRef: <name>` YAML works unchanged. Cross-namespace usage:

```
bucketPermissions:
  - bucketRef: testbucket
    bucketNamespace: garage-operator-system
    read: true
```