### PR TITLE
feat(controller): expand PVCs when spec requests larger size

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -164,6 +164,12 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.reconcilePDB(ctx, cluster); err != nil {
 			return r.updateStatus(ctx, cluster, "Error", err)
 		}
+
+		// Expand PVCs if spec requests a larger size than what was originally provisioned.
+		// StatefulSet VolumeClaimTemplates are immutable, so we patch PVCs directly.
+		if err := r.reconcilePVCExpansion(ctx, cluster); err != nil {
+			return r.updateStatus(ctx, cluster, "Error", err)
+		}
 	}
 
 	// Bootstrap cluster nodes if pods are running but cluster isn't formed
@@ -1871,6 +1877,60 @@ func (r *GarageClusterReconciler) reconcileStatefulSet(ctx context.Context, clus
 	existing.Spec.Template = sts.Spec.Template
 	log.Info("Updating StatefulSet", "name", stsName)
 	return r.Update(ctx, existing)
+}
+
+// reconcilePVCExpansion expands existing PVCs when the spec requests a larger size.
+// StatefulSet VolumeClaimTemplates are immutable in Kubernetes, so resizing requires
+// patching the individual PVC objects directly.
+func (r *GarageClusterReconciler) reconcilePVCExpansion(ctx context.Context, cluster *garagev1alpha1.GarageCluster) error {
+	log := logf.FromContext(ctx)
+
+	replicas := cluster.Spec.Replicas
+	if replicas == 0 {
+		replicas = 3
+	}
+
+	if !isMetadataEmptyDir(cluster) {
+		desiredSize := buildMetadataPVC(cluster).Spec.Resources.Requests[corev1.ResourceStorage]
+		for i := int32(0); i < replicas; i++ {
+			pvcName := fmt.Sprintf("metadata-%s-%d", cluster.Name, i)
+			if err := r.maybeExpandPVC(ctx, log, cluster.Namespace, pvcName, desiredSize); err != nil {
+				return err
+			}
+		}
+	}
+
+	if !cluster.Spec.Gateway && !isDataEmptyDir(cluster) {
+		desiredSize := buildDataPVC(cluster).Spec.Resources.Requests[corev1.ResourceStorage]
+		for i := int32(0); i < replicas; i++ {
+			pvcName := fmt.Sprintf("data-%s-%d", cluster.Name, i)
+			if err := r.maybeExpandPVC(ctx, log, cluster.Namespace, pvcName, desiredSize); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *GarageClusterReconciler) maybeExpandPVC(ctx context.Context, log logr.Logger, namespace, pvcName string, desiredSize resource.Quantity) error {
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: namespace}, pvc); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	currentSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if desiredSize.Cmp(currentSize) <= 0 {
+		return nil
+	}
+
+	log.Info("Expanding PVC", "name", pvcName, "namespace", namespace, "from", currentSize.String(), "to", desiredSize.String())
+	patch := client.MergeFrom(pvc.DeepCopy())
+	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = desiredSize
+	return r.Patch(ctx, pvc, patch)
 }
 
 // cleanupOldDeployment removes the old Deployment that was used for gateway clusters


### PR DESCRIPTION
## Summary

- StatefulSet `VolumeClaimTemplates` are immutable in Kubernetes, so changes to `spec.storage.metadata.size` or `spec.storage.data.size` have no effect on already-provisioned PVCs
- Adds `reconcilePVCExpansion` which runs after `reconcileStatefulSet` and patches any PVC whose current capacity is less than the desired size from the spec
- Handles both metadata and data PVCs, skipping EmptyDir and gateway-specific cases

## Motivation

Robbinsdale Garage metadata PVC is at 9.1% free (92 MB / 1 GiB) and Ottawa is at 3.7% (38 MB / 1 GiB). The `GarageCluster` spec already requests `3Gi` but the operator was silently ignoring the size change on existing clusters.

## Test plan

- [ ] Verify existing PVC with size < spec gets patched to the larger size on reconcile
- [ ] Verify PVCs already at or above spec size are not touched
- [ ] Verify missing PVCs (not yet created) are handled gracefully (IsNotFound skipped)
- [ ] Verify gateway clusters only expand metadata PVCs (not data)
- [ ] Verify EmptyDir clusters skip expansion entirely