### PR TITLE
fix(controller): use net.JoinHostPort for IPv6-safe address formatting

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -2416,7 +2416,7 @@ func discoverNodes(ctx context.Context, pods []corev1.Pod, adminToken string, ad
 	nodes := make([]bootstrapNodeInfo, 0, len(pods))
 
 	for _, pod := range pods {
-		endpoint := fmt.Sprintf("http://%s:%d", pod.Status.PodIP, adminPort)
+		endpoint := adminEndpoint(pod.Status.PodIP, adminPort)
 		garageClient := garage.NewClient(endpoint, adminToken)
 
 		status, err := garageClient.GetClusterStatus(ctx)
@@ -2491,7 +2491,7 @@ func discoverNodes(ctx context.Context, pods []corev1.Pod, adminToken string, ad
 // findReachableClient finds the first reachable admin endpoint
 func findReachableClient(ctx context.Context, nodes []bootstrapNodeInfo, adminToken string, adminPort int32) *garage.Client {
 	for _, node := range nodes {
-		endpoint := fmt.Sprintf("http://%s:%d", node.podIP, adminPort)
+		endpoint := adminEndpoint(node.podIP, adminPort)
 		garageClient := garage.NewClient(endpoint, adminToken)
 		if _, err := garageClient.GetClusterHealth(ctx); err == nil {
 			return garageClient
@@ -2507,14 +2507,14 @@ func connectNodes(ctx context.Context, nodes []bootstrapNodeInfo, adminToken str
 	// Have each node tell the cluster about all other nodes
 	// This ensures IP address changes propagate to all nodes
 	for _, sourceNode := range nodes {
-		endpoint := fmt.Sprintf("http://%s:%d", sourceNode.podIP, adminPort)
+		endpoint := adminEndpoint(sourceNode.podIP, adminPort)
 		nodeClient := garage.NewClient(endpoint, adminToken)
 
 		for _, targetNode := range nodes {
 			if targetNode.id == sourceNode.id {
 				continue // Skip self
 			}
-			addr := fmt.Sprintf("%s:%d", targetNode.podIP, rpcPort)
+			addr := rpcAddr(targetNode.podIP, rpcPort)
 			result, err := nodeClient.ConnectNode(ctx, targetNode.id, addr)
 			if err != nil {
 				log.V(1).Info("Failed to connect node (API error)", "source", sourceNode.podName, "target", targetNode.podName, "error", err)
@@ -3085,7 +3085,7 @@ func (r *GarageClusterReconciler) reconcileGatewayConnection(ctx context.Context
 	var gatewayClient *garage.Client
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
-			endpoint := fmt.Sprintf("http://%s:%d", pod.Status.PodIP, adminPort)
+			endpoint := adminEndpoint(pod.Status.PodIP, adminPort)
 			testClient := garage.NewClient(endpoint, gatewayAdminToken)
 			if _, err := testClient.GetClusterStatus(ctx); err == nil {
 				gatewayClient = testClient
@@ -3166,7 +3166,7 @@ func (r *GarageClusterReconciler) connectGatewayToClusterRef(ctx context.Context
 	var storageClient *garage.Client
 	for _, pod := range storagePods.Items {
 		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
-			endpoint := fmt.Sprintf("http://%s:%d", pod.Status.PodIP, storageAdminPort)
+			endpoint := adminEndpoint(pod.Status.PodIP, storageAdminPort)
 			testClient := garage.NewClient(endpoint, storageAdminToken)
 			if _, err := testClient.GetClusterStatus(ctx); err == nil {
 				storageClient = testClient
@@ -3300,7 +3300,7 @@ func (r *GarageClusterReconciler) reconcileFederation(ctx context.Context, clust
 	var localStatus *garage.ClusterStatus
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
-			endpoint := fmt.Sprintf("http://%s:%d", pod.Status.PodIP, adminPort)
+			endpoint := adminEndpoint(pod.Status.PodIP, adminPort)
 			testClient := garage.NewClient(endpoint, adminToken)
 			// Short timeout per pod: if the admin API is hanging due to RPC lock
 			// contention (broken mesh), skip this pod and try the next one.
@@ -3443,7 +3443,7 @@ func (r *GarageClusterReconciler) connectToRemoteCluster(
 			// 3. Tailscale handles the actual routing to the correct pod
 			var addr string
 			if remoteRPCHost != "" {
-				addr = fmt.Sprintf("%s:%d", remoteRPCHost, rpcPort)
+				addr = rpcAddr(remoteRPCHost, rpcPort)
 			} else if node.Address != nil && *node.Address != "" {
 				addr = *node.Address
 			} else {

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -786,7 +786,7 @@ func (r *GarageNodeReconciler) discoverNodeIDDirect(ctx context.Context, cluster
 	if cluster.Spec.Admin != nil && cluster.Spec.Admin.BindPort != 0 {
 		adminPort = cluster.Spec.Admin.BindPort
 	}
-	directEndpoint := fmt.Sprintf("http://%s:%d", podIP, adminPort)
+	directEndpoint := adminEndpoint(podIP, adminPort)
 	directClient := garage.NewClient(directEndpoint, adminToken)
 
 	// Get status from the pod directly
@@ -817,7 +817,7 @@ func (r *GarageNodeReconciler) connectNodeToCluster(ctx context.Context, garageC
 		rpcPort = cluster.Spec.Network.RPCBindPort
 	}
 
-	nodeAddr := fmt.Sprintf("%s:%d", podIP, rpcPort)
+	nodeAddr := rpcAddr(podIP, rpcPort)
 	result, err := garageClient.ConnectNode(ctx, nodeID, nodeAddr)
 	if err != nil {
 		return err

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -527,26 +527,28 @@ func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1
 		nodeID = discovered
 	}
 
-	// If node ID is still empty, try to discover from Admin API using pod IP
+	// If node ID is still empty, try to discover from Admin API using pod IPs.
+	// All pod IPs are used for address matching to handle dual-stack clusters where
+	// Garage may use a different IP family than the primary pod IP.
 	if nodeID == "" {
-		podIP, err := r.getPodIP(ctx, node, cluster)
+		podIPs, err := r.getPodIPs(ctx, node, cluster)
 		if err != nil {
-			return fmt.Errorf("failed to get pod IP for node discovery: %w", err)
+			return fmt.Errorf("failed to get pod IPs for node discovery: %w", err)
 		}
 
-		discovered, err := r.discoverNodeIDFromAdminAPI(ctx, garageClient, podIP)
+		discovered, err := r.discoverNodeIDFromAdminAPI(ctx, garageClient, podIPs)
 		if err != nil {
 			// Node might not be connected to the cluster yet.
 			// Try to discover its ID by connecting directly to the pod's Admin API.
-			log.Info("Node not found in cluster status, trying direct discovery", "podIP", podIP)
-			discovered, err = r.discoverNodeIDDirect(ctx, cluster, podIP)
+			log.Info("Node not found in cluster status, trying direct discovery", "podIPs", podIPs)
+			discovered, err = r.discoverNodeIDDirect(ctx, cluster, podIPs)
 			if err != nil {
 				return fmt.Errorf("failed to discover node ID: %w", err)
 			}
 
 			// Connect this node to the cluster so other nodes can see it
-			log.Info("Connecting node to cluster", "nodeID", discovered, "podIP", podIP)
-			if err := r.connectNodeToCluster(ctx, garageClient, discovered, podIP, cluster); err != nil {
+			log.Info("Connecting node to cluster", "nodeID", discovered, "podIPs", podIPs)
+			if err := r.connectNodeToCluster(ctx, garageClient, discovered, podIPs[0], cluster); err != nil {
 				return fmt.Errorf("failed to connect node to cluster: %w", err)
 			}
 		}
@@ -683,28 +685,37 @@ func (r *GarageNodeReconciler) discoverNodeID(ctx context.Context, node *garagev
 	return r.getNodeIDFromPod(ctx, cluster.Namespace, podName)
 }
 
-func (r *GarageNodeReconciler) getPodIP(ctx context.Context, node *garagev1alpha1.GarageNode, cluster *garagev1alpha1.GarageCluster) (string, error) {
-	// If external node, we can't get pod IP
+// getPodIPs returns all IP addresses assigned to the node's pod.
+// The first element is the primary IP (pod.Status.PodIP). On dual-stack clusters
+// additional IPs (IPv4 or IPv6) are appended from pod.Status.PodIPs.
+func (r *GarageNodeReconciler) getPodIPs(ctx context.Context, node *garagev1alpha1.GarageNode, cluster *garagev1alpha1.GarageCluster) ([]string, error) {
 	if node.Spec.External != nil {
-		return "", fmt.Errorf("external nodes must have nodeId specified")
+		return nil, fmt.Errorf("external nodes must have nodeId specified")
 	}
 
-	// Pod name is node name with -0 suffix (StatefulSet with replica 1)
 	podName := node.Name + "-0"
 
 	pod := &corev1.Pod{}
 	if err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: cluster.Namespace}, pod); err != nil {
-		return "", fmt.Errorf("failed to get pod %s: %w", podName, err)
+		return nil, fmt.Errorf("failed to get pod %s: %w", podName, err)
 	}
 
 	if pod.Status.PodIP == "" {
-		return "", fmt.Errorf("pod %s has no IP address yet", podName)
+		return nil, fmt.Errorf("pod %s has no IP address yet", podName)
 	}
 
-	return pod.Status.PodIP, nil
+	seen := map[string]bool{pod.Status.PodIP: true}
+	ips := []string{pod.Status.PodIP}
+	for _, pip := range pod.Status.PodIPs {
+		if pip.IP != "" && !seen[pip.IP] {
+			seen[pip.IP] = true
+			ips = append(ips, pip.IP)
+		}
+	}
+	return ips, nil
 }
 
-func (r *GarageNodeReconciler) discoverNodeIDFromAdminAPI(ctx context.Context, garageClient *garage.Client, podIP string) (string, error) {
+func (r *GarageNodeReconciler) discoverNodeIDFromAdminAPI(ctx context.Context, garageClient *garage.Client, podIPs []string) (string, error) {
 	log := logf.FromContext(ctx)
 
 	status, err := garageClient.GetClusterStatus(ctx)
@@ -712,18 +723,12 @@ func (r *GarageNodeReconciler) discoverNodeIDFromAdminAPI(ctx context.Context, g
 		return "", fmt.Errorf("failed to get cluster status: %w", err)
 	}
 
-	// Find node by matching IP address
-	for _, n := range status.Nodes {
-		if n.Address != nil {
-			nodeIP := extractIPFromAddress(*n.Address)
-			if nodeIP == podIP {
-				log.Info("Discovered node ID from Admin API", "nodeID", n.ID, "podIP", podIP)
-				return n.ID, nil
-			}
-		}
+	if id, ok := findNodeByIPs(status.Nodes, podIPs); ok {
+		log.Info("Discovered node ID from Admin API", "nodeID", id, "podIPs", podIPs)
+		return id, nil
 	}
 
-	return "", fmt.Errorf("no node found with IP address %s in cluster status (cluster has %d nodes)", podIP, len(status.Nodes))
+	return "", fmt.Errorf("no node found with IPs %v in cluster status (cluster has %d nodes)", podIPs, len(status.Nodes))
 }
 
 // extractIPFromAddress extracts the IP address from an address string.
@@ -772,38 +777,41 @@ func (r *GarageNodeReconciler) getNodeIDFromPod(ctx context.Context, namespace, 
 
 // discoverNodeIDDirect discovers a node's ID by connecting directly to the pod's Admin API.
 // This is used when the node hasn't yet connected to the cluster and isn't visible in cluster status.
-func (r *GarageNodeReconciler) discoverNodeIDDirect(ctx context.Context, cluster *garagev1alpha1.GarageCluster, podIP string) (string, error) {
+// discoverNodeIDDirect discovers a node's ID by connecting directly to the pod's Admin API.
+// This is used when the node hasn't yet connected to the cluster and isn't visible in cluster status.
+// podIPs[0] is the primary IP used to reach the pod; all IPs are tried for address matching.
+func (r *GarageNodeReconciler) discoverNodeIDDirect(ctx context.Context, cluster *garagev1alpha1.GarageCluster, podIPs []string) (string, error) {
 	log := logf.FromContext(ctx)
 
-	// Get admin token from cluster
 	adminToken, err := GetAdminToken(ctx, r.Client, cluster)
 	if err != nil {
 		return "", fmt.Errorf("failed to get admin token: %w", err)
 	}
 
-	// Create a client that connects directly to the pod
 	adminPort := int32(3903)
 	if cluster.Spec.Admin != nil && cluster.Spec.Admin.BindPort != 0 {
 		adminPort = cluster.Spec.Admin.BindPort
 	}
-	directEndpoint := adminEndpoint(podIP, adminPort)
+	directEndpoint := adminEndpoint(podIPs[0], adminPort)
 	directClient := garage.NewClient(directEndpoint, adminToken)
 
-	// Get status from the pod directly
 	status, err := directClient.GetClusterStatus(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get status from pod directly: %w", err)
 	}
 
-	// The pod should see itself in its own cluster status
-	for _, n := range status.Nodes {
-		if n.Address != nil {
-			nodeIP := extractIPFromAddress(*n.Address)
-			if nodeIP == podIP {
-				log.Info("Discovered node ID from direct pod connection", "nodeID", n.ID, "podIP", podIP)
-				return n.ID, nil
-			}
-		}
+	// First try matching by any pod IP address (works when rpc_public_addr is configured).
+	if id, ok := findNodeByIPs(status.Nodes, podIPs); ok {
+		log.Info("Discovered node ID from direct pod connection (by address)", "nodeID", id, "podIPs", podIPs)
+		return id, nil
+	}
+
+	// Fall back to identifying the self-node by its unique peer state: isUp && lastSeenSecsAgo==nil.
+	// Garage sets PeerConnState::Ourself for the local node, which has no lastSeenSecsAgo and no
+	// address when rpc_public_addr is not configured — the common case for in-cluster pods.
+	if id, ok := findSelfNode(status.Nodes); ok {
+		log.Info("Discovered node ID from direct pod connection (as self)", "nodeID", id, "podIPs", podIPs)
+		return id, nil
 	}
 
 	return "", fmt.Errorf("node not found in its own cluster status")

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +35,14 @@ import (
 	garagev1alpha1 "github.com/rajsinghtech/garage-operator/api/v1alpha1"
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
+
+func adminEndpoint(ip string, port int32) string {
+	return "http://" + net.JoinHostPort(ip, strconv.Itoa(int(port)))
+}
+
+func rpcAddr(ip string, port int32) string {
+	return net.JoinHostPort(ip, strconv.Itoa(int(port)))
+}
 
 // Common status phases
 const (

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -36,6 +36,34 @@ import (
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
+// findNodeByIPs returns the node ID whose RPC address matches any of the given pod IPs.
+// Handles both IPv4 and IPv6 address formats in the cluster status.
+func findNodeByIPs(nodes []garage.NodeInfo, podIPs []string) (string, bool) {
+	ipSet := make(map[string]bool, len(podIPs))
+	for _, ip := range podIPs {
+		ipSet[ip] = true
+	}
+	for _, n := range nodes {
+		if n.Address != nil && ipSet[extractIPFromAddress(*n.Address)] {
+			return n.ID, true
+		}
+	}
+	return "", false
+}
+
+// findSelfNode finds the local node in a cluster status response obtained directly from
+// the pod's own admin API. Garage sets PeerConnState::Ourself for the local node, which
+// serialises as isUp=true with lastSeenSecsAgo absent (nil) — a combination that is
+// unique to the self-entry and holds regardless of whether rpc_public_addr is configured.
+func findSelfNode(nodes []garage.NodeInfo) (string, bool) {
+	for _, n := range nodes {
+		if n.IsUp && n.LastSeenSecsAgo == nil {
+			return n.ID, true
+		}
+	}
+	return "", false
+}
+
 func adminEndpoint(ip string, port int32) string {
 	return "http://" + net.JoinHostPort(ip, strconv.Itoa(int(port)))
 }

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -763,6 +763,48 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 	})
 }
 
+func TestAdminEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		port int32
+		want string
+	}{
+		{"ipv4", "192.168.1.1", 3903, "http://192.168.1.1:3903"},
+		{"ipv6", "2a14:abcd::5d92", 3903, "http://[2a14:abcd::5d92]:3903"},
+		{"ipv6 loopback", "::1", 3903, "http://[::1]:3903"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adminEndpoint(tt.ip, tt.port)
+			if got != tt.want {
+				t.Errorf("adminEndpoint(%q, %d) = %q, want %q", tt.ip, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRPCAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		port int32
+		want string
+	}{
+		{"ipv4", "10.0.0.1", 3901, "10.0.0.1:3901"},
+		{"ipv6", "2a14:abcd::5d92", 3901, "[2a14:abcd::5d92]:3901"},
+		{"ipv6 loopback", "::1", 3901, "[::1]:3901"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rpcAddr(tt.ip, tt.port)
+			if got != tt.want {
+				t.Errorf("rpcAddr(%q, %d) = %q, want %q", tt.ip, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	garagev1alpha1 "github.com/rajsinghtech/garage-operator/api/v1alpha1"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 const (
@@ -761,6 +762,114 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 			t.Errorf("StorageClassName = %v, want %q (first path should win)", pvc.Spec.StorageClassName, encryptedSC)
 		}
 	})
+}
+
+func TestFindNodeByIPs(t *testing.T) {
+	addr := func(s string) *string { return &s }
+	var u64 uint64 = 5
+
+	tests := []struct {
+		name   string
+		nodes  []garage.NodeInfo
+		podIPs []string
+		wantID string
+		wantOK bool
+	}{
+		{
+			name: "ipv4 match on primary",
+			nodes: []garage.NodeInfo{
+				{ID: "aaa", Address: addr("10.0.0.1:3901"), IsUp: true, LastSeenSecsAgo: &u64},
+			},
+			podIPs: []string{"10.0.0.1"},
+			wantID: "aaa", wantOK: true,
+		},
+		{
+			name: "ipv6 match on secondary pod IP",
+			nodes: []garage.NodeInfo{
+				{ID: "bbb", Address: addr("[2a14::1]:3901"), IsUp: true, LastSeenSecsAgo: &u64},
+			},
+			podIPs: []string{"192.168.1.5", "2a14::1"},
+			wantID: "bbb", wantOK: true,
+		},
+		{
+			name: "no match when node has nil address",
+			nodes: []garage.NodeInfo{
+				{ID: "ccc", Address: nil, IsUp: true, LastSeenSecsAgo: nil},
+			},
+			podIPs: []string{"10.0.0.1"},
+			wantOK: false,
+		},
+		{
+			name:   "no match in empty list",
+			nodes:  []garage.NodeInfo{},
+			podIPs: []string{"10.0.0.1"},
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotOK := findNodeByIPs(tt.nodes, tt.podIPs)
+			if gotOK != tt.wantOK {
+				t.Errorf("findNodeByIPs() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotOK && gotID != tt.wantID {
+				t.Errorf("findNodeByIPs() id = %q, want %q", gotID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestFindSelfNode(t *testing.T) {
+	addr := func(s string) *string { return &s }
+	var u64 uint64 = 3
+
+	tests := []struct {
+		name   string
+		nodes  []garage.NodeInfo
+		wantID string
+		wantOK bool
+	}{
+		{
+			name: "self is isUp with nil lastSeenSecsAgo",
+			nodes: []garage.NodeInfo{
+				{ID: "peer1", Address: addr("10.0.0.2:3901"), IsUp: true, LastSeenSecsAgo: &u64},
+				{ID: "self1", Address: nil, IsUp: true, LastSeenSecsAgo: nil},
+			},
+			wantID: "self1", wantOK: true,
+		},
+		{
+			name: "self with rpc_public_addr set still has nil lastSeenSecsAgo",
+			nodes: []garage.NodeInfo{
+				{ID: "peer1", Address: addr("10.0.0.2:3901"), IsUp: true, LastSeenSecsAgo: &u64},
+				{ID: "self2", Address: addr("203.0.113.1:3901"), IsUp: true, LastSeenSecsAgo: nil},
+			},
+			wantID: "self2", wantOK: true,
+		},
+		{
+			name: "no self when all nodes have lastSeenSecsAgo",
+			nodes: []garage.NodeInfo{
+				{ID: "n1", Address: addr("10.0.0.1:3901"), IsUp: true, LastSeenSecsAgo: &u64},
+				{ID: "n2", Address: addr("10.0.0.2:3901"), IsUp: true, LastSeenSecsAgo: &u64},
+			},
+			wantOK: false,
+		},
+		{
+			name:   "empty list",
+			nodes:  []garage.NodeInfo{},
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotOK := findSelfNode(tt.nodes)
+			if gotOK != tt.wantOK {
+				t.Errorf("findSelfNode() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotOK && gotID != tt.wantID {
+				t.Errorf("findSelfNode() id = %q, want %q", gotID, tt.wantID)
+			}
+		})
+	}
 }
 
 func TestAdminEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes `GarageNode` autodiscovery on dual-stack clusters where the pod's primary IP is IPv6 (#119). There were three independent bugs, all fixed here:

**1. IPv6-unsafe URL construction (9 sites)**
All `fmt.Sprintf("http://%s:%d", ip, port)` and `fmt.Sprintf("%s:%d", ip, port)` calls replaced with `adminEndpoint()` / `rpcAddr()` helpers using `net.JoinHostPort`, which brackets IPv6 addresses automatically.

**2. Dual-stack address matching in `discoverNodeIDFromAdminAPI`**
Previously compared only the primary pod IP (IPv6) against Garage's reported RPC address. On dual-stack clusters, Garage's RPC connections may use IPv4, so the node appeared in cluster status with an IPv4 address that didn't match. Now collects all pod IPs from `pod.Status.PodIPs` and checks any of them via `findNodeByIPs`.

**3. Self-node not found in `discoverNodeIDDirect`**
When `rpc_public_addr` is not configured (the default for in-cluster pods), Garage sets `addr = nil` for the local node (`PeerConnState::Ourself`). The previous code skipped nil-address nodes, so the pod could never find itself in its own cluster status. Added `findSelfNode` as a fallback that identifies the self-node by its unique cluster status signature: `isUp=true` with `lastSeenSecsAgo=nil` — guaranteed by Garage's peer state machine for `Ourself`.

## Test plan

- [x] `TestAdminEndpoint` / `TestRPCAddr` — IPv4, IPv6, loopback address formatting
- [x] `TestFindNodeByIPs` — IPv4 match, IPv6 secondary IP match, nil-address skip
- [x] `TestFindSelfNode` — self-node with/without `rpc_public_addr`, no false positives
- [x] Full controller unit test suite passes
- [ ] Verify autodiscovery works on a dual-stack cluster with IPv6 primary pod IPs