### PR TITLE
fix(gateway): make external cluster connection bidirectional

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.1
           args: --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,11 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	"$(GOLANGCI_LINT)" config verify
 
+.PHONY: install-hooks
+install-hooks: ## Install git pre-commit hook to run lint locally before committing
+	cp hack/pre-commit .git/hooks/pre-commit
+	chmod +x .git/hooks/pre-commit
+
 ##@ Build
 
 .PHONY: build
@@ -361,7 +366,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -388,7 +393,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -25,6 +25,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	testFieldS3Api = "s3Api"
+	testClusterRef = "test"
+	testKeyRef     = "key1"
+)
+
 func TestValidateBindAddress(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -35,37 +41,37 @@ func TestValidateBindAddress(t *testing.T) {
 		{
 			name:    "valid TCP address with port only",
 			addr:    ":3900",
-			field:   "s3Api",
+			field:   testFieldS3Api,
 			wantErr: false,
 		},
 		{
 			name:    "valid TCP address with host and port",
 			addr:    "0.0.0.0:3900",
-			field:   "s3Api",
+			field:   testFieldS3Api,
 			wantErr: false,
 		},
 		{
 			name:    "valid TCP address with IPv6",
 			addr:    "[::]:3900",
-			field:   "s3Api",
+			field:   testFieldS3Api,
 			wantErr: false,
 		},
 		{
 			name:    "valid unix socket",
 			addr:    "unix:///run/garage/s3.sock",
-			field:   "s3Api",
+			field:   testFieldS3Api,
 			wantErr: false,
 		},
 		{
 			name:    "invalid address - no port",
 			addr:    "localhost",
-			field:   "s3Api",
+			field:   testFieldS3Api,
 			wantErr: true,
 		},
 		{
 			name:    "invalid address - empty",
 			addr:    "",
-			field:   "s3Api",
+			field:   testFieldS3Api,
 			wantErr: true,
 		},
 	}
@@ -245,7 +251,7 @@ func TestGarageBucket_ValidateGarageBucket(t *testing.T) {
 			name: "bucket with valid key permissions",
 			bucket: GarageBucket{
 				Spec: GarageBucketSpec{
-					ClusterRef: ClusterReference{Name: "test"},
+					ClusterRef: ClusterReference{Name: testClusterRef},
 					KeyPermissions: []KeyPermission{
 						{
 							KeyRef: "my-key",
@@ -456,7 +462,7 @@ func TestGarageKey_ValidateAllBuckets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			key := &GarageKey{
 				Spec: GarageKeySpec{
-					ClusterRef: ClusterReference{Name: "test"},
+					ClusterRef: ClusterReference{Name: testClusterRef},
 					AllBuckets: tt.allBuckets,
 				},
 			}
@@ -472,7 +478,7 @@ func TestGarageKey_ValidateWarningWithAllBuckets(t *testing.T) {
 	// When allBuckets is set, should NOT warn about no bucket permissions
 	key := &GarageKey{
 		Spec: GarageKeySpec{
-			ClusterRef: ClusterReference{Name: "test"},
+			ClusterRef: ClusterReference{Name: testClusterRef},
 			AllBuckets: &AllBucketsPermission{Read: true},
 		},
 	}
@@ -487,7 +493,7 @@ func TestGarageKey_ValidateWarningWithAllBuckets(t *testing.T) {
 	// When neither allBuckets nor bucketPermissions is set, should warn
 	key2 := &GarageKey{
 		Spec: GarageKeySpec{
-			ClusterRef: ClusterReference{Name: "test"},
+			ClusterRef: ClusterReference{Name: testClusterRef},
 		},
 	}
 	warnings2, err := key2.validateGarageKey()
@@ -518,21 +524,21 @@ func TestGarageBucket_ValidateKeyPermissions(t *testing.T) {
 		{
 			name: "valid permission with read",
 			permissions: []KeyPermission{
-				{KeyRef: "key1", Read: true},
+				{KeyRef: testKeyRef, Read: true},
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid permission with write",
 			permissions: []KeyPermission{
-				{KeyRef: "key1", Write: true},
+				{KeyRef: testKeyRef, Write: true},
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid permission with owner",
 			permissions: []KeyPermission{
-				{KeyRef: "key1", Owner: true},
+				{KeyRef: testKeyRef, Owner: true},
 			},
 			wantErr: false,
 		},
@@ -546,15 +552,15 @@ func TestGarageBucket_ValidateKeyPermissions(t *testing.T) {
 		{
 			name: "invalid - no permissions granted",
 			permissions: []KeyPermission{
-				{KeyRef: "key1"},
+				{KeyRef: testKeyRef},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid - duplicate keyRef",
 			permissions: []KeyPermission{
-				{KeyRef: "key1", Read: true},
-				{KeyRef: "key1", Write: true},
+				{KeyRef: testKeyRef, Read: true},
+				{KeyRef: testKeyRef, Write: true},
 			},
 			wantErr: true,
 		},
@@ -564,7 +570,7 @@ func TestGarageBucket_ValidateKeyPermissions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			bucket := &GarageBucket{
 				Spec: GarageBucketSpec{
-					ClusterRef:     ClusterReference{Name: "test"},
+					ClusterRef:     ClusterReference{Name: testClusterRef},
 					KeyPermissions: tt.permissions,
 				},
 			}

--- a/hack/pre-commit
+++ b/hack/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Run gofmt on staged Go files first (fast, no binary needed)
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+if [ -n "$STAGED" ]; then
+  BAD=$(gofmt -l $STAGED)
+  if [ -n "$BAD" ]; then
+    echo "gofmt violations (run 'gofmt -w' on these files):"
+    echo "$BAD"
+    exit 1
+  fi
+fi
+
+# Run golangci-lint via make (ensures pinned version is installed)
+make -C "$ROOT" lint

--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -41,6 +41,7 @@ const (
 	pathUpdateLayout     = "/v2/UpdateClusterLayout"
 	pathApplyLayout      = "/v2/ApplyClusterLayout"
 	localNodeID          = "1111111111111111aaaaaaaaaaaa0001"
+	testNodeTagLocal     = "local"
 )
 
 // newMockGarageServer creates a mock Garage Admin API server with configurable
@@ -167,7 +168,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 			}
 			remoteServer := newMockGarageServer(remoteHandler)
@@ -180,7 +181,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					return http.StatusOK, garage.ClusterStatus{}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 				connectResp: func() (int, any) {
 					connectCalls.Add(1)
@@ -198,7 +199,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   "abcdef0123456789abcdef01local001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{"local"}},
+						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
 					},
 					{
 						ID:   "abcdef0123456789abcdef01remote01",
@@ -244,7 +245,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					return http.StatusOK, garage.ClusterStatus{}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 				connectResp: func() (int, any) {
 					connectCalls.Add(1)
@@ -259,7 +260,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					return http.StatusOK, garage.ClusterStatus{}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 			}
 			remoteServer := newMockGarageServer(remoteHandler)
@@ -273,7 +274,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   localNodeID,
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{"local"}},
+						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
 					},
 					{
 						ID:   "fedcba9876543210fedcba98remote001",
@@ -320,7 +321,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 			}
 			remoteServer := newMockGarageServer(remoteHandler)
@@ -332,7 +333,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					return http.StatusOK, garage.ClusterStatus{}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 				connectResp: func() (int, any) {
 					connectCalls.Add(1)
@@ -350,7 +351,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   "1111111111111111aaaaaaaaonly0001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{"local"}},
+						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
 					},
 				},
 			}
@@ -396,7 +397,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					return http.StatusOK, garage.ClusterStatus{}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 			}
 			localServer := newMockGarageServer(localHandler)
@@ -448,7 +449,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					return http.StatusOK, garage.ClusterStatus{}
 				},
 				healthResp: func() (int, any) {
-					return http.StatusOK, garage.ClusterHealth{Status: "healthy"}
+					return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
 				},
 			}
 			localServer := newMockGarageServer(localHandler)
@@ -565,7 +566,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
 						Version: 1,
 						Roles: []garage.LayoutNodeRole{
-							{ID: localNodeID, Zone: "zone-local", Tags: []string{"local"}},
+							{ID: localNodeID, Zone: "zone-local", Tags: []string{testNodeTagLocal}},
 						},
 					})
 				case pathUpdateLayout:
@@ -593,7 +594,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					{
 						ID:   localNodeID,
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{"local"}},
+						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
 					},
 					{
 						ID:   "fedcba9876543210fedcba98newnode01",

--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -40,6 +40,7 @@ const (
 	pathConnectNodes     = "/v2/ConnectClusterNodes"
 	pathUpdateLayout     = "/v2/UpdateClusterLayout"
 	pathApplyLayout      = "/v2/ApplyClusterLayout"
+	localNodeID          = "1111111111111111aaaaaaaaaaaa0001"
 )
 
 // newMockGarageServer creates a mock Garage Admin API server with configurable
@@ -270,7 +271,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 			localStatus := &garage.ClusterStatus{
 				Nodes: []garage.NodeInfo{
 					{
-						ID:   "1111111111111111aaaaaaaaaaaa0001",
+						ID:   localNodeID,
 						IsUp: true,
 						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{"local"}},
 					},
@@ -564,7 +565,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
 						Version: 1,
 						Roles: []garage.LayoutNodeRole{
-							{ID: "1111111111111111aaaaaaaaaaaa0001", Zone: "zone-local", Tags: []string{"local"}},
+							{ID: localNodeID, Zone: "zone-local", Tags: []string{"local"}},
 						},
 					})
 				case pathUpdateLayout:
@@ -590,7 +591,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 			localStatus := &garage.ClusterStatus{
 				Nodes: []garage.NodeInfo{
 					{
-						ID:   "1111111111111111aaaaaaaaaaaa0001",
+						ID:   localNodeID,
 						IsUp: true,
 						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{"local"}},
 					},
@@ -628,7 +629,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
 						Version: 1,
 						Roles: []garage.LayoutNodeRole{
-							{ID: "1111111111111111aaaaaaaaaaaa0001", Zone: "zone-local"},
+							{ID: localNodeID, Zone: "zone-local"},
 							{ID: "fedcba9876543210fedcba98exist001", Zone: "zone-remote"}, // already in layout
 						},
 					})
@@ -647,7 +648,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 
 			localStatus := &garage.ClusterStatus{
 				Nodes: []garage.NodeInfo{
-					{ID: "1111111111111111aaaaaaaaaaaa0001", IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-local"}},
+					{ID: localNodeID, IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-local"}},
 					{ID: "fedcba9876543210fedcba98exist001", IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-remote", Capacity: &cap}},
 				},
 			}
@@ -677,7 +678,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
 						Version: 1,
 						Roles: []garage.LayoutNodeRole{
-							{ID: "1111111111111111aaaaaaaaaaaa0001", Zone: "zone-local"},
+							{ID: localNodeID, Zone: "zone-local"},
 						},
 					})
 				case pathUpdateLayout:
@@ -711,7 +712,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 
 			localStatus := &garage.ClusterStatus{
 				Nodes: []garage.NodeInfo{
-					{ID: "1111111111111111aaaaaaaaaaaa0001", IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-local"}},
+					{ID: localNodeID, IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-local"}},
 				},
 			}
 

--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -34,14 +34,19 @@ import (
 )
 
 const (
-	pathGetClusterStatus = "/v2/GetClusterStatus"
-	pathGetClusterHealth = "/v2/GetClusterHealth"
-	pathGetClusterLayout = "/v2/GetClusterLayout"
-	pathConnectNodes     = "/v2/ConnectClusterNodes"
-	pathUpdateLayout     = "/v2/UpdateClusterLayout"
-	pathApplyLayout      = "/v2/ApplyClusterLayout"
-	localNodeID          = "1111111111111111aaaaaaaaaaaa0001"
-	testNodeTagLocal     = "local"
+	pathGetClusterStatus  = "/v2/GetClusterStatus"
+	pathGetClusterHealth  = "/v2/GetClusterHealth"
+	pathGetClusterLayout  = "/v2/GetClusterLayout"
+	pathConnectNodes      = "/v2/ConnectClusterNodes"
+	pathUpdateLayout      = "/v2/UpdateClusterLayout"
+	pathApplyLayout       = "/v2/ApplyClusterLayout"
+	localNodeID           = "1111111111111111aaaaaaaaaaaa0001"
+	testNodeTagLocal      = "local"
+	testRemoteAdminSecret = "remote-admin-token"
+	testAdminTokenKey     = "token"
+	testZoneLocal         = "zone-local"
+	testZoneRemote        = "zone-remote"
+	testTagRemoteCluster  = "remote-cluster"
 )
 
 // newMockGarageServer creates a mock Garage Admin API server with configurable
@@ -128,10 +133,10 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "remote-admin-token",
+				Name:      testRemoteAdminSecret,
 				Namespace: testNamespace,
 			},
-			StringData: map[string]string{"token": adminToken},
+			StringData: map[string]string{testAdminTokenKey: adminToken},
 		}
 		_ = k8sClient.Delete(ctx, secret)
 		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
@@ -142,7 +147,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 				Namespace: testNamespace,
 			},
 			Spec: garagev1alpha1.GarageClusterSpec{
-				Zone:     "zone-local",
+				Zone:     testZoneLocal,
 				Replicas: 1,
 				Replication: garagev1alpha1.ReplicationConfig{
 					Factor: 1,
@@ -199,29 +204,29 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   "abcdef0123456789abcdef01local001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneLocal, Tags: []string{testNodeTagLocal}},
 					},
 					{
 						ID:   "abcdef0123456789abcdef01remote01",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-remote", Tags: []string{"remote-cluster"}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{testTagRemoteCluster}},
 					},
 					{
 						ID:   "abcdef0123456789abcdef01remote02",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-remote", Tags: []string{"remote-cluster"}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{testTagRemoteCluster}},
 					},
 				},
 			}
 
 			remote := garagev1alpha1.RemoteClusterConfig{
-				Name: "remote-cluster",
-				Zone: "zone-remote",
+				Name: testTagRemoteCluster,
+				Zone: testZoneRemote,
 				Connection: garagev1alpha1.RemoteClusterConnection{
 					AdminAPIEndpoint: remoteServer.URL,
 					AdminTokenSecretRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "remote-admin-token"},
-						Key:                  "token",
+						LocalObjectReference: corev1.LocalObjectReference{Name: testRemoteAdminSecret},
+						Key:                  testAdminTokenKey,
 					},
 				},
 			}
@@ -274,24 +279,24 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   localNodeID,
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneLocal, Tags: []string{testNodeTagLocal}},
 					},
 					{
 						ID:   "fedcba9876543210fedcba98remote001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-remote", Tags: []string{"remote"}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{"remote"}},
 					},
 				},
 			}
 
 			remote := garagev1alpha1.RemoteClusterConfig{
-				Name: "remote-cluster",
-				Zone: "zone-remote",
+				Name: testTagRemoteCluster,
+				Zone: testZoneRemote,
 				Connection: garagev1alpha1.RemoteClusterConnection{
 					AdminAPIEndpoint: remoteServer.URL,
 					AdminTokenSecretRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "remote-admin-token"},
-						Key:                  "token",
+						LocalObjectReference: corev1.LocalObjectReference{Name: testRemoteAdminSecret},
+						Key:                  testAdminTokenKey,
 					},
 				},
 			}
@@ -351,19 +356,19 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   "1111111111111111aaaaaaaaonly0001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneLocal, Tags: []string{testNodeTagLocal}},
 					},
 				},
 			}
 
 			remote := garagev1alpha1.RemoteClusterConfig{
-				Name: "remote-cluster",
-				Zone: "zone-remote",
+				Name: testTagRemoteCluster,
+				Zone: testZoneRemote,
 				Connection: garagev1alpha1.RemoteClusterConnection{
 					AdminAPIEndpoint: remoteServer.URL,
 					AdminTokenSecretRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "remote-admin-token"},
-						Key:                  "token",
+						LocalObjectReference: corev1.LocalObjectReference{Name: testRemoteAdminSecret},
+						Key:                  testAdminTokenKey,
 					},
 				},
 			}
@@ -410,19 +415,19 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   "1111111111111111bbbbbbbbonly0001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local"},
+						Role: &garage.NodeAssignedRole{Zone: testZoneLocal},
 					},
 				},
 			}
 
 			remote := garagev1alpha1.RemoteClusterConfig{
 				Name: "unreachable-remote",
-				Zone: "zone-remote",
+				Zone: testZoneRemote,
 				Connection: garagev1alpha1.RemoteClusterConnection{
 					AdminAPIEndpoint: remoteServer.URL,
 					AdminTokenSecretRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "remote-admin-token"},
-						Key:                  "token",
+						LocalObjectReference: corev1.LocalObjectReference{Name: testRemoteAdminSecret},
+						Key:                  testAdminTokenKey,
 					},
 				},
 			}
@@ -462,19 +467,19 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   "1111111111111111bbbbbbbbonly0001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local"},
+						Role: &garage.NodeAssignedRole{Zone: testZoneLocal},
 					},
 				},
 			}
 
 			remote := garagev1alpha1.RemoteClusterConfig{
 				Name: "hanging-remote",
-				Zone: "zone-remote",
+				Zone: testZoneRemote,
 				Connection: garagev1alpha1.RemoteClusterConnection{
 					AdminAPIEndpoint: hangServer.URL,
 					AdminTokenSecretRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "remote-admin-token"},
-						Key:                  "token",
+						LocalObjectReference: corev1.LocalObjectReference{Name: testRemoteAdminSecret},
+						Key:                  testAdminTokenKey,
 					},
 				},
 			}
@@ -503,7 +508,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 
 			remote := garagev1alpha1.RemoteClusterConfig{
 				Name: "self",
-				Zone: "zone-local", // same as cluster.Spec.Zone
+				Zone: testZoneLocal, // same as cluster.Spec.Zone
 				Connection: garagev1alpha1.RemoteClusterConnection{
 					AdminAPIEndpoint: "http://unused:3903",
 				},
@@ -539,7 +544,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 				Namespace: testNamespace,
 			},
 			Spec: garagev1alpha1.GarageClusterSpec{
-				Zone:     "zone-local",
+				Zone:     testZoneLocal,
 				Replicas: 1,
 				Replication: garagev1alpha1.ReplicationConfig{
 					Factor: 1,
@@ -566,7 +571,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
 						Version: 1,
 						Roles: []garage.LayoutNodeRole{
-							{ID: localNodeID, Zone: "zone-local", Tags: []string{testNodeTagLocal}},
+							{ID: localNodeID, Zone: testZoneLocal, Tags: []string{testNodeTagLocal}},
 						},
 					})
 				case pathUpdateLayout:
@@ -594,19 +599,19 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					{
 						ID:   localNodeID,
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-local", Tags: []string{testNodeTagLocal}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneLocal, Tags: []string{testNodeTagLocal}},
 					},
 					{
 						ID:   "fedcba9876543210fedcba98newnode01",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-remote", Tags: []string{"remote"}, Capacity: &cap},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{"remote"}, Capacity: &cap},
 					},
 				},
 			}
 
 			remote := garagev1alpha1.RemoteClusterConfig{
-				Name: "remote-cluster",
-				Zone: "zone-remote",
+				Name: testTagRemoteCluster,
+				Zone: testZoneRemote,
 			}
 
 			// nil remoteStatus -> should use localStatus filtered by zone
@@ -630,8 +635,8 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
 						Version: 1,
 						Roles: []garage.LayoutNodeRole{
-							{ID: localNodeID, Zone: "zone-local"},
-							{ID: "fedcba9876543210fedcba98exist001", Zone: "zone-remote"}, // already in layout
+							{ID: localNodeID, Zone: testZoneLocal},
+							{ID: "fedcba9876543210fedcba98exist001", Zone: testZoneRemote}, // already in layout
 						},
 					})
 				case pathUpdateLayout:
@@ -649,14 +654,14 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 
 			localStatus := &garage.ClusterStatus{
 				Nodes: []garage.NodeInfo{
-					{ID: localNodeID, IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-local"}},
-					{ID: "fedcba9876543210fedcba98exist001", IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-remote", Capacity: &cap}},
+					{ID: localNodeID, IsUp: true, Role: &garage.NodeAssignedRole{Zone: testZoneLocal}},
+					{ID: "fedcba9876543210fedcba98exist001", IsUp: true, Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap}},
 				},
 			}
 
 			remote := garagev1alpha1.RemoteClusterConfig{
-				Name: "remote-cluster",
-				Zone: "zone-remote",
+				Name: testTagRemoteCluster,
+				Zone: testZoneRemote,
 			}
 
 			err := reconciler.addRemoteNodesToLayout(ctx, cluster, localClient, nil, nil, localStatus, remote)
@@ -679,7 +684,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
 						Version: 1,
 						Roles: []garage.LayoutNodeRole{
-							{ID: localNodeID, Zone: "zone-local"},
+							{ID: localNodeID, Zone: testZoneLocal},
 						},
 					})
 				case pathUpdateLayout:
@@ -701,19 +706,19 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					{
 						ID:   "fedcba9876543210fedcba98fromapi1",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-remote", Capacity: &cap},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap},
 					},
 					{
 						ID:   "fedcba9876543210fedcba98fromapi2",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: "zone-remote", Capacity: &cap},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap},
 					},
 				},
 			}
 
 			localStatus := &garage.ClusterStatus{
 				Nodes: []garage.NodeInfo{
-					{ID: localNodeID, IsUp: true, Role: &garage.NodeAssignedRole{Zone: "zone-local"}},
+					{ID: localNodeID, IsUp: true, Role: &garage.NodeAssignedRole{Zone: testZoneLocal}},
 				},
 			}
 
@@ -721,8 +726,8 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 			remoteClient := garage.NewClient(server.URL, adminToken)
 
 			remote := garagev1alpha1.RemoteClusterConfig{
-				Name: "remote-cluster",
-				Zone: "zone-remote",
+				Name: testTagRemoteCluster,
+				Zone: testZoneRemote,
 			}
 
 			err := reconciler.addRemoteNodesToLayout(ctx, cluster, localClient, remoteClient, remoteStatus, localStatus, remote)

--- a/internal/controller/garageadmintoken_controller.go
+++ b/internal/controller/garageadmintoken_controller.go
@@ -77,7 +77,7 @@ func (r *GarageAdminTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if errors.IsNotFound(err) {
 			return r.updateStatusWaiting(ctx, token)
 		}
-		return r.updateStatus(ctx, token, "Error", fmt.Errorf("cluster not found: %w", err))
+		return r.updateStatus(ctx, token, PhaseError, fmt.Errorf("cluster not found: %w", err))
 	}
 
 	// Handle deletion
@@ -111,7 +111,7 @@ func (r *GarageAdminTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if isTransientConnectivityError(err) {
 			return r.updateStatusWaiting(ctx, token)
 		}
-		return r.updateStatus(ctx, token, "Error", err)
+		return r.updateStatus(ctx, token, PhaseError, err)
 	}
 
 	// Check expiration
@@ -123,7 +123,7 @@ func (r *GarageAdminTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	return r.updateStatus(ctx, token, "Ready", nil)
+	return r.updateStatus(ctx, token, PhaseReady, nil)
 }
 
 func (r *GarageAdminTokenReconciler) reconcileSecret(ctx context.Context, token *garagev1alpha1.GarageAdminToken, cluster *garagev1alpha1.GarageCluster) error {
@@ -294,7 +294,7 @@ func (r *GarageAdminTokenReconciler) finalize(ctx context.Context, token *garage
 func (r *GarageAdminTokenReconciler) updateStatusWaiting(ctx context.Context, token *garagev1alpha1.GarageAdminToken) (ctrl.Result, error) {
 	token.Status.Phase = PhasePending
 	meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1alpha1.ReasonClusterNotReady,
 		Message:            "waiting for cluster to be reachable",
@@ -320,7 +320,7 @@ func (r *GarageAdminTokenReconciler) updateStatus(ctx context.Context, token *ga
 
 	if err != nil {
 		conditionStatus = metav1.ConditionFalse
-		reason = "Error"
+		reason = PhaseError
 		message = err.Error()
 	} else if token.Status.Expired {
 		conditionStatus = metav1.ConditionFalse
@@ -329,7 +329,7 @@ func (r *GarageAdminTokenReconciler) updateStatus(ctx context.Context, token *ga
 	}
 
 	meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             conditionStatus,
 		Reason:             reason,
 		Message:            message,

--- a/internal/controller/garageadmintoken_controller.go
+++ b/internal/controller/garageadmintoken_controller.go
@@ -198,7 +198,7 @@ func (r *GarageAdminTokenReconciler) reconcileSecret(ctx context.Context, token 
 
 	// Build labels
 	labels := map[string]string{
-		labelAppManagedBy:               "garage-operator",
+		labelAppManagedBy:                 operatorName,
 		"garage.rajsingh.info/admintoken": token.Name,
 	}
 	if token.Spec.SecretTemplate != nil && token.Spec.SecretTemplate.Labels != nil {
@@ -297,7 +297,7 @@ func (r *GarageAdminTokenReconciler) updateStatusWaiting(ctx context.Context, to
 		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1alpha1.ReasonClusterNotReady,
-		Message:            "waiting for cluster to be reachable",
+		Message:            msgWaitingForCluster,
 		ObservedGeneration: token.Generation,
 	})
 	if statusErr := r.Status().Update(ctx, token); statusErr != nil {

--- a/internal/controller/garageadmintoken_controller.go
+++ b/internal/controller/garageadmintoken_controller.go
@@ -198,7 +198,7 @@ func (r *GarageAdminTokenReconciler) reconcileSecret(ctx context.Context, token 
 
 	// Build labels
 	labels := map[string]string{
-		"app.kubernetes.io/managed-by":    "garage-operator",
+		labelAppManagedBy:               "garage-operator",
 		"garage.rajsingh.info/admintoken": token.Name,
 	}
 	if token.Spec.SecretTemplate != nil && token.Spec.SecretTemplate.Labels != nil {

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -96,7 +96,7 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if errors.IsNotFound(clusterErr) {
 			return r.updateStatusWaiting(ctx, bucket)
 		}
-		return r.updateStatus(ctx, bucket, "Error", fmt.Errorf("cluster not found: %w", clusterErr))
+		return r.updateStatus(ctx, bucket, PhaseError, fmt.Errorf("cluster not found: %w", clusterErr))
 	}
 
 	// Guard against calling the Garage API before the cluster layout has converged.
@@ -112,7 +112,7 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			msg = "garage cluster is being deleted"
 		}
 		meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
+			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
 			Reason:             garagev1alpha1.ReasonClusterNotReady,
 			Message:            msg,
@@ -128,7 +128,7 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Get garage client
 	garageClient, err := GetGarageClient(ctx, r.Client, cluster, r.ClusterDomain)
 	if err != nil {
-		return r.updateStatus(ctx, bucket, "Error", fmt.Errorf("failed to create garage client: %w", err))
+		return r.updateStatus(ctx, bucket, PhaseError, fmt.Errorf("failed to create garage client: %w", err))
 	}
 
 	// Handle deletion (cluster exists at this point)
@@ -189,7 +189,7 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Reconcile the bucket
 	if err := r.reconcileBucket(ctx, bucket, cluster, garageClient); err != nil {
-		return r.updateStatus(ctx, bucket, "Error", err)
+		return r.updateStatus(ctx, bucket, PhaseError, err)
 	}
 
 	return r.updateStatusFromGarage(ctx, bucket, garageClient, cluster)
@@ -558,7 +558,7 @@ func (r *GarageBucketReconciler) finalize(ctx context.Context, bucket *garagev1a
 func (r *GarageBucketReconciler) updateStatusWaiting(ctx context.Context, bucket *garagev1alpha1.GarageBucket) (ctrl.Result, error) {
 	bucket.Status.Phase = PhasePending
 	meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1alpha1.ReasonClusterNotReady,
 		Message:            "waiting for cluster to be reachable",
@@ -579,9 +579,9 @@ func (r *GarageBucketReconciler) updateStatus(ctx context.Context, bucket *garag
 
 	if err != nil {
 		meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
+			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "Error",
+			Reason:             PhaseError,
 			Message:            err.Error(),
 			ObservedGeneration: bucket.Generation,
 		})
@@ -605,7 +605,7 @@ func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, buc
 	// Get bucket info from Garage
 	garageBucket, err := garageClient.GetBucket(ctx, garage.GetBucketRequest{ID: bucket.Status.BucketID})
 	if err != nil {
-		return r.updateStatus(ctx, bucket, "Error", fmt.Errorf("failed to get bucket info: %w", err))
+		return r.updateStatus(ctx, bucket, PhaseError, fmt.Errorf("failed to get bucket info: %w", err))
 	}
 
 	// Capture old status before modifications to detect no-op updates
@@ -706,7 +706,7 @@ func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, buc
 	})
 
 	meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             metav1.ConditionTrue,
 		Reason:             "BucketReady",
 		Message:            "Bucket is ready",

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -561,7 +561,7 @@ func (r *GarageBucketReconciler) updateStatusWaiting(ctx context.Context, bucket
 		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1alpha1.ReasonClusterNotReady,
-		Message:            "waiting for cluster to be reachable",
+		Message:            msgWaitingForCluster,
 		ObservedGeneration: bucket.Generation,
 	})
 	if statusErr := UpdateStatusWithRetry(ctx, r.Client, bucket); statusErr != nil {

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -32,6 +32,8 @@ import (
 	garagev1alpha1 "github.com/rajsinghtech/garage-operator/api/v1alpha1"
 )
 
+const testNamespace = "default"
+
 var _ = Describe("GarageBucket Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-bucket"
@@ -40,7 +42,7 @@ var _ = Describe("GarageBucket Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 		})
 
@@ -60,7 +62,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			bucket := &garagev1alpha1.GarageBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
@@ -95,7 +97,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			bucket := &garagev1alpha1.GarageBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
@@ -122,7 +124,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			bucket := &garagev1alpha1.GarageBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
@@ -151,7 +153,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			bucket := &garagev1alpha1.GarageBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
@@ -190,7 +192,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			cluster := &garagev1alpha1.GarageCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "deleting-cluster",
-					Namespace:  "default",
+					Namespace:  testNamespace,
 					Finalizers: []string{"test.garage.rajsingh.info/keep"},
 				},
 				Spec: garagev1alpha1.GarageClusterSpec{
@@ -213,7 +215,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			bucket := &garagev1alpha1.GarageBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{Name: cluster.Name},
@@ -242,7 +244,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			bucket := &garagev1alpha1.GarageBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
@@ -277,7 +279,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "non-existent",
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -291,7 +293,7 @@ var _ = Describe("GarageBucket Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 		})
 
@@ -311,7 +313,7 @@ var _ = Describe("GarageBucket Controller", func() {
 			bucket := &garagev1alpha1.GarageBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GarageBucket Controller", func() {
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "non-existent-cluster",
+						Name: testNonExistentCluster,
 					},
 				},
 			}
@@ -101,7 +101,7 @@ var _ = Describe("GarageBucket Controller", func() {
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					Quotas: &garagev1alpha1.BucketQuotas{
 						MaxSize:    &maxSize,
@@ -128,7 +128,7 @@ var _ = Describe("GarageBucket Controller", func() {
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					Website: &garagev1alpha1.WebsiteConfig{
 						Enabled:       true,
@@ -157,7 +157,7 @@ var _ = Describe("GarageBucket Controller", func() {
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					Lifecycle: &garagev1alpha1.BucketLifecycle{
 						Rules: []garagev1alpha1.LifecycleRule{
@@ -248,7 +248,7 @@ var _ = Describe("GarageBucket Controller", func() {
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					KeyPermissions: []garagev1alpha1.KeyPermission{
 						{
@@ -278,7 +278,7 @@ var _ = Describe("GarageBucket Controller", func() {
 
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name:      "non-existent",
+					Name:      testNonExistent,
 					Namespace: testNamespace,
 				},
 			})
@@ -317,7 +317,7 @@ var _ = Describe("GarageBucket Controller", func() {
 				},
 				Spec: garagev1alpha1.GarageBucketSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 				},
 			}

--- a/internal/controller/garagebucket_lifecycle.go
+++ b/internal/controller/garagebucket_lifecycle.go
@@ -31,6 +31,11 @@ import (
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
+const (
+	garageClusterKind      = "GarageCluster"
+	lifecycleStatusEnabled = "Enabled"
+)
+
 // hardcoded GVK because controller-runtime's typed Get leaves TypeMeta empty.
 func garageClusterRef(cluster *garagev1alpha1.GarageCluster) garage.ClusterRef {
 	return garage.ClusterRef{
@@ -38,7 +43,7 @@ func garageClusterRef(cluster *garagev1alpha1.GarageCluster) garage.ClusterRef {
 		Namespace:  cluster.Namespace,
 		UID:        cluster.UID,
 		APIVersion: garagev1alpha1.GroupVersion.String(),
-		Kind:       "GarageCluster",
+		Kind:       garageClusterKind,
 	}
 }
 
@@ -170,7 +175,7 @@ func buildLifecycleXMLRule(in garagev1alpha1.LifecycleRule) garage.LifecycleXMLR
 		Status: in.Status,
 	}
 	if out.Status == "" {
-		out.Status = "Enabled"
+		out.Status = lifecycleStatusEnabled
 	}
 	if in.Filter != nil {
 		out.Filter = buildLifecycleXMLFilter(in.Filter)
@@ -319,7 +324,7 @@ func lifecycleRulesStatusFromSpec(spec *garagev1alpha1.BucketLifecycle) []garage
 	for _, rule := range spec.Rules {
 		status := rule.Status
 		if status == "" {
-			status = "Enabled"
+			status = lifecycleStatusEnabled
 		}
 		out = append(out, garagev1alpha1.LifecycleRuleStatus{
 			ID:     rule.ID,

--- a/internal/controller/garagebucket_lifecycle_test.go
+++ b/internal/controller/garagebucket_lifecycle_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
+const (
+	testLifecycleClusterName = "demo"
+	testLifecycleNamespace   = "test-ns"
+)
+
 func days(n int32) *int32   { return &n }
 func bytesP(n int64) *int64 { return &n }
 
@@ -276,8 +281,8 @@ func TestShouldSkipLifecycle(t *testing.T) {
 func TestGarageClusterRef_PopulatesTypeMeta(t *testing.T) {
 	// real runtime shape: client.Get leaves TypeMeta zeroed.
 	cluster := &garagev1alpha1.GarageCluster{}
-	cluster.Name = "demo"
-	cluster.Namespace = "test-ns"
+	cluster.Name = testLifecycleClusterName
+	cluster.Namespace = testLifecycleNamespace
 	cluster.UID = testClusterUID
 
 	ref := garageClusterRef(cluster)
@@ -288,13 +293,13 @@ func TestGarageClusterRef_PopulatesTypeMeta(t *testing.T) {
 	if ref.Kind != garageClusterKind {
 		t.Fatalf("Kind: got %q, want %q", ref.Kind, garageClusterKind)
 	}
-	if ref.Name != "demo" || ref.Namespace != "test-ns" || ref.UID != testClusterUID {
+	if ref.Name != testLifecycleClusterName || ref.Namespace != testLifecycleNamespace || ref.UID != testClusterUID {
 		t.Fatalf("identity fields lost: %+v", ref)
 	}
 
 	want := garage.ClusterRef{
-		Name:       "demo",
-		Namespace:  "test-ns",
+		Name:       testLifecycleClusterName,
+		Namespace:  testLifecycleNamespace,
 		UID:        testClusterUID,
 		APIVersion: "garage.rajsingh.info/v1alpha1",
 		Kind:       garageClusterKind,

--- a/internal/controller/garagebucket_lifecycle_test.go
+++ b/internal/controller/garagebucket_lifecycle_test.go
@@ -30,8 +30,10 @@ func days(n int32) *int32   { return &n }
 func bytesP(n int64) *int64 { return &n }
 
 const (
-	testLifecycleEnabled = "Enabled"
-	testPrefix           = "logs/"
+	testLifecycleEnabled  = "Enabled"
+	testLifecycleDisabled = "Disabled"
+	testPrefix            = "logs/"
+	testClusterUID        = "00000000-0000-0000-0000-000000000001"
 )
 
 func TestBuildLifecycleConfiguration_NilOrEmpty(t *testing.T) {
@@ -119,7 +121,7 @@ func TestLifecycleEqual(t *testing.T) {
 	}
 
 	c := &garage.LifecycleConfiguration{Rules: []garage.LifecycleXMLRule{
-		{ID: "x", Status: "Disabled", Filter: &garage.LifecycleXMLFilter{Prefix: &p}},
+		{ID: "x", Status: testLifecycleDisabled, Filter: &garage.LifecycleXMLFilter{Prefix: &p}},
 	}}
 	if lifecycleEqual(a, c) {
 		t.Fatal("status diff should not compare equal")
@@ -222,13 +224,13 @@ func TestLifecycleRulesStatusFromSpec(t *testing.T) {
 	spec := &garagev1alpha1.BucketLifecycle{
 		Rules: []garagev1alpha1.LifecycleRule{
 			{ID: "r1", ExpirationDays: days(7)}, // status defaulted
-			{ID: "r2", Status: "Disabled", ExpirationDays: days(7)},
+			{ID: "r2", Status: testLifecycleDisabled, ExpirationDays: days(7)},
 		},
 	}
 	got := lifecycleRulesStatusFromSpec(spec)
 	want := []garagev1alpha1.LifecycleRuleStatus{
 		{ID: "r1", Status: testLifecycleEnabled},
-		{ID: "r2", Status: "Disabled"},
+		{ID: "r2", Status: testLifecycleDisabled},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %+v, want %+v", got, want)
@@ -276,26 +278,26 @@ func TestGarageClusterRef_PopulatesTypeMeta(t *testing.T) {
 	cluster := &garagev1alpha1.GarageCluster{}
 	cluster.Name = "demo"
 	cluster.Namespace = "test-ns"
-	cluster.UID = "00000000-0000-0000-0000-000000000001"
+	cluster.UID = testClusterUID
 
 	ref := garageClusterRef(cluster)
 
 	if ref.APIVersion != "garage.rajsingh.info/v1alpha1" {
 		t.Fatalf("APIVersion: got %q, want %q", ref.APIVersion, "garage.rajsingh.info/v1alpha1")
 	}
-	if ref.Kind != "GarageCluster" {
-		t.Fatalf("Kind: got %q, want %q", ref.Kind, "GarageCluster")
+	if ref.Kind != garageClusterKind {
+		t.Fatalf("Kind: got %q, want %q", ref.Kind, garageClusterKind)
 	}
-	if ref.Name != "demo" || ref.Namespace != "test-ns" || ref.UID != "00000000-0000-0000-0000-000000000001" {
+	if ref.Name != "demo" || ref.Namespace != "test-ns" || ref.UID != testClusterUID {
 		t.Fatalf("identity fields lost: %+v", ref)
 	}
 
 	want := garage.ClusterRef{
 		Name:       "demo",
 		Namespace:  "test-ns",
-		UID:        "00000000-0000-0000-0000-000000000001",
+		UID:        testClusterUID,
 		APIVersion: "garage.rajsingh.info/v1alpha1",
-		Kind:       "GarageCluster",
+		Kind:       garageClusterKind,
 	}
 	if !reflect.DeepEqual(ref, want) {
 		t.Fatalf("ref mismatch:\ngot:  %+v\nwant: %+v", ref, want)

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -1134,7 +1134,7 @@ func (r *GarageClusterReconciler) reconcileHeadlessService(ctx context.Context, 
 			Selector:  selector,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "rpc",
+					Name:       rpcPortName,
 					Port:       rpcPort,
 					TargetPort: intstr.FromInt32(rpcPort),
 					Protocol:   corev1.ProtocolTCP,
@@ -1367,8 +1367,8 @@ func buildVolumesAndMounts(cluster *garagev1alpha1.GarageCluster) ([]corev1.Volu
 	volumeMounts := []corev1.VolumeMount{
 		{Name: configVolumeName, MountPath: "/etc/garage", ReadOnly: true},
 		{Name: RPCSecretKey, MountPath: "/secrets/rpc", ReadOnly: true},
-		{Name: "metadata", MountPath: "/data/metadata"},
-		{Name: "data", MountPath: dataPath},
+		{Name: metadataVolName, MountPath: "/data/metadata"},
+		{Name: dataVolName, MountPath: dataPath},
 	}
 
 	rpcSecretName := cluster.Name + "-rpc-secret"
@@ -1420,7 +1420,7 @@ func buildVolumesAndMounts(cluster *garagev1alpha1.GarageCluster) ([]corev1.Volu
 			emptyDir.SizeLimit = cluster.Spec.Storage.Metadata.Size
 		}
 		volumes = append(volumes, corev1.Volume{
-			Name:         "metadata",
+			Name:         metadataVolName,
 			VolumeSource: corev1.VolumeSource{EmptyDir: emptyDir},
 		})
 	}
@@ -1435,7 +1435,7 @@ func buildVolumesAndMounts(cluster *garagev1alpha1.GarageCluster) ([]corev1.Volu
 			emptyDir.SizeLimit = cluster.Spec.Storage.Data.Size
 		}
 		volumes = append(volumes, corev1.Volume{
-			Name:         "data",
+			Name:         dataVolName,
 			VolumeSource: corev1.VolumeSource{EmptyDir: emptyDir},
 		})
 	}
@@ -1466,22 +1466,22 @@ func buildVolumesAndMounts(cluster *garagev1alpha1.GarageCluster) ([]corev1.Volu
 
 	// Add metrics token secret volume and mount if configured separately from admin token
 	if cluster.Spec.Admin != nil && cluster.Spec.Admin.MetricsTokenSecretRef != nil {
-		metricsTokenKey := "metrics-token"
+		localMetricsTokenKey := metricsTokenKey
 		if cluster.Spec.Admin.MetricsTokenSecretRef.Key != "" {
-			metricsTokenKey = cluster.Spec.Admin.MetricsTokenSecretRef.Key
+			localMetricsTokenKey = cluster.Spec.Admin.MetricsTokenSecretRef.Key
 		}
 		volumes = append(volumes, corev1.Volume{
-			Name: "metrics-token",
+			Name: metricsTokenKey,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  cluster.Spec.Admin.MetricsTokenSecretRef.Name,
 					DefaultMode: ptr.To[int32](0600),
-					Items:       []corev1.KeyToPath{{Key: metricsTokenKey, Path: "metrics-token"}},
+					Items:       []corev1.KeyToPath{{Key: localMetricsTokenKey, Path: metricsTokenKey}},
 				},
 			},
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "metrics-token",
+			Name:      metricsTokenKey,
 			MountPath: "/secrets/metrics",
 			ReadOnly:  true,
 		})
@@ -1608,7 +1608,7 @@ func buildMetadataPVC(cluster *garagev1alpha1.GarageCluster) corev1.PersistentVo
 	}
 
 	metadataPVC := corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "metadata"},
+		ObjectMeta: metav1.ObjectMeta{Name: metadataVolName},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources: corev1.VolumeResourceRequirements{
@@ -1669,7 +1669,7 @@ func buildDataPVC(cluster *garagev1alpha1.GarageCluster) corev1.PersistentVolume
 	}
 
 	dataPVC := corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		ObjectMeta: metav1.ObjectMeta{Name: dataVolName},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources: corev1.VolumeResourceRequirements{
@@ -1802,7 +1802,7 @@ func (r *GarageClusterReconciler) reconcileStatefulSet(ctx context.Context, clus
 			Image:   "busybox:1.37",
 			Command: []string{"touch", dataPath + "/garage-marker"},
 			VolumeMounts: []corev1.VolumeMount{
-				{Name: "data", MountPath: dataPath},
+				{Name: dataVolName, MountPath: dataPath},
 			},
 			SecurityContext: buildInitContainerSecurityContext(cluster),
 		}
@@ -2382,11 +2382,11 @@ func (r *GarageClusterReconciler) labelsForCluster(cluster *garagev1alpha1.Garag
 		component = "gateway"
 	}
 	return map[string]string{
-		labelAppName:                   defaultAppName,
-		labelAppInstance:               cluster.Name,
-		labelAppManagedBy:              "garage-operator",
-		"app.kubernetes.io/component":  component,
-		labelCluster: cluster.Name,
+		labelAppName:                  defaultAppName,
+		labelAppInstance:              cluster.Name,
+		labelAppManagedBy:             operatorName,
+		"app.kubernetes.io/component": component,
+		labelCluster:                  cluster.Name,
 	}
 }
 
@@ -2679,7 +2679,7 @@ func assignNewNodesToLayout(ctx context.Context, garageClient *garage.Client, no
 
 	zone := cfg.zone
 	if zone == "" {
-		zone = "default"
+		zone = defaultZoneName
 	}
 
 	// Find new nodes to add and detect config drift on existing nodes

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -130,23 +130,23 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Ensure RPC secret exists
 	if _, err := r.ensureRPCSecret(ctx, cluster); err != nil {
-		return r.updateStatus(ctx, cluster, "Error", err)
+		return r.updateStatus(ctx, cluster, PhaseError, err)
 	}
 
 	// Create or update ConfigMap and get config hash for pod restart triggering
 	configHash, err := r.reconcileConfigMap(ctx, cluster)
 	if err != nil {
-		return r.updateStatus(ctx, cluster, "Error", err)
+		return r.updateStatus(ctx, cluster, PhaseError, err)
 	}
 
 	// Create or update headless Service for RPC
 	if err := r.reconcileHeadlessService(ctx, cluster); err != nil {
-		return r.updateStatus(ctx, cluster, "Error", err)
+		return r.updateStatus(ctx, cluster, PhaseError, err)
 	}
 
 	// Create or update API Service
 	if err := r.reconcileAPIService(ctx, cluster); err != nil {
-		return r.updateStatus(ctx, cluster, "Error", err)
+		return r.updateStatus(ctx, cluster, PhaseError, err)
 	}
 
 	// Create or update StatefulSet for Auto layout policy clusters.
@@ -154,7 +154,7 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Note: Garage does NOT support hot-reload - all config changes require pod restart.
 	if cluster.Spec.LayoutPolicy != LayoutPolicyManual {
 		if err := r.reconcileStatefulSet(ctx, cluster, configHash); err != nil {
-			return r.updateStatus(ctx, cluster, "Error", err)
+			return r.updateStatus(ctx, cluster, PhaseError, err)
 		}
 
 		// Clean up old Deployment if it exists (migration from previous gateway implementation)
@@ -167,13 +167,13 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		// Create or update PodDisruptionBudget if enabled (only for Auto mode)
 		if err := r.reconcilePDB(ctx, cluster); err != nil {
-			return r.updateStatus(ctx, cluster, "Error", err)
+			return r.updateStatus(ctx, cluster, PhaseError, err)
 		}
 
 		// Expand PVCs if spec requests a larger size than what was originally provisioned.
 		// StatefulSet VolumeClaimTemplates are immutable, so we patch PVCs directly.
 		if err := r.reconcilePVCExpansion(ctx, cluster); err != nil {
-			return r.updateStatus(ctx, cluster, "Error", err)
+			return r.updateStatus(ctx, cluster, PhaseError, err)
 		}
 	}
 
@@ -1188,7 +1188,7 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 			adminPort = cluster.Spec.Admin.BindPort
 		}
 		ports = append(ports, corev1.ServicePort{
-			Name:       "admin",
+			Name:       adminPortName,
 			Port:       adminPort,
 			TargetPort: intstr.FromInt32(adminPort),
 			Protocol:   corev1.ProtocolTCP,
@@ -1336,7 +1336,7 @@ func buildContainerPorts(cluster *garagev1alpha1.GarageCluster) []corev1.Contain
 		if cluster.Spec.Admin != nil && cluster.Spec.Admin.BindPort != 0 {
 			adminPort = cluster.Spec.Admin.BindPort
 		}
-		ports = append(ports, corev1.ContainerPort{Name: "admin", ContainerPort: adminPort})
+		ports = append(ports, corev1.ContainerPort{Name: adminPortName, ContainerPort: adminPort})
 	}
 
 	// K2V API port
@@ -1365,10 +1365,10 @@ func buildContainerPorts(cluster *garagev1alpha1.GarageCluster) []corev1.Contain
 // Metadata volume comes from PVC (via VolumeClaimTemplates) for both gateway and storage.
 func buildVolumesAndMounts(cluster *garagev1alpha1.GarageCluster) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "config", MountPath: "/etc/garage", ReadOnly: true},
+		{Name: configVolumeName, MountPath: "/etc/garage", ReadOnly: true},
 		{Name: RPCSecretKey, MountPath: "/secrets/rpc", ReadOnly: true},
 		{Name: "metadata", MountPath: "/data/metadata"},
-		{Name: "data", MountPath: "/data/data"},
+		{Name: "data", MountPath: dataPath},
 	}
 
 	rpcSecretName := cluster.Name + "-rpc-secret"
@@ -1394,7 +1394,7 @@ func buildVolumesAndMounts(cluster *garagev1alpha1.GarageCluster) ([]corev1.Volu
 
 	volumes := []corev1.Volume{
 		{
-			Name: "config",
+			Name: configVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: cluster.Name + "-config"},
@@ -1448,17 +1448,17 @@ func buildVolumesAndMounts(cluster *garagev1alpha1.GarageCluster) ([]corev1.Volu
 			adminTokenKey = cluster.Spec.Admin.AdminTokenSecretRef.Key
 		}
 		volumes = append(volumes, corev1.Volume{
-			Name: "admin-token",
+			Name: adminTokenVolume,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  cluster.Spec.Admin.AdminTokenSecretRef.Name,
 					DefaultMode: ptr.To[int32](0600),
-					Items:       []corev1.KeyToPath{{Key: adminTokenKey, Path: "admin-token"}},
+					Items:       []corev1.KeyToPath{{Key: adminTokenKey, Path: adminTokenVolume}},
 				},
 			},
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "admin-token",
+			Name:      adminTokenVolume,
 			MountPath: "/secrets/admin",
 			ReadOnly:  true,
 		})
@@ -1800,9 +1800,9 @@ func (r *GarageClusterReconciler) reconcileStatefulSet(ctx context.Context, clus
 		initContainer := corev1.Container{
 			Name:    "init-marker",
 			Image:   "busybox:1.37",
-			Command: []string{"touch", "/data/data/garage-marker"},
+			Command: []string{"touch", dataPath + "/garage-marker"},
 			VolumeMounts: []corev1.VolumeMount{
-				{Name: "data", MountPath: "/data/data"},
+				{Name: "data", MountPath: dataPath},
 			},
 			SecurityContext: buildInitContainerSecurityContext(cluster),
 		}
@@ -2081,9 +2081,9 @@ func (r *GarageClusterReconciler) updateStatus(ctx context.Context, cluster *gar
 
 	if err != nil {
 		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
+			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "Error",
+			Reason:             PhaseError,
 			Message:            err.Error(),
 			ObservedGeneration: cluster.Generation,
 		})
@@ -2341,7 +2341,7 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 	}
 
 	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             readyStatus,
 		Reason:             readyReason,
 		Message:            readyMessage,
@@ -2382,9 +2382,9 @@ func (r *GarageClusterReconciler) labelsForCluster(cluster *garagev1alpha1.Garag
 		component = "gateway"
 	}
 	return map[string]string{
-		"app.kubernetes.io/name":       defaultAppName,
-		"app.kubernetes.io/instance":   cluster.Name,
-		"app.kubernetes.io/managed-by": "garage-operator",
+		labelAppName:                   defaultAppName,
+		labelAppInstance:               cluster.Name,
+		labelAppManagedBy:              "garage-operator",
 		"app.kubernetes.io/component":  component,
 		"garage.rajsingh.info/cluster": cluster.Name,
 	}
@@ -2392,8 +2392,8 @@ func (r *GarageClusterReconciler) labelsForCluster(cluster *garagev1alpha1.Garag
 
 func (r *GarageClusterReconciler) selectorLabelsForCluster(cluster *garagev1alpha1.GarageCluster) map[string]string {
 	return map[string]string{
-		"app.kubernetes.io/name":     defaultAppName,
-		"app.kubernetes.io/instance": cluster.Name,
+		labelAppName:     defaultAppName,
+		labelAppInstance: cluster.Name,
 	}
 }
 
@@ -3019,7 +3019,7 @@ func (r *GarageClusterReconciler) getExternalStorageClient(ctx context.Context, 
 	}
 	key := secretRef.Key
 	if key == "" {
-		key = "admin-token"
+		key = DefaultAdminTokenKey
 	}
 	adminToken := string(secret.Data[key])
 	if adminToken == "" {
@@ -3837,7 +3837,7 @@ func (r *GarageClusterReconciler) getRemoteAdminToken(
 			return "", err
 		}
 
-		key := "admin-token"
+		key := DefaultAdminTokenKey
 		if remote.Connection.AdminTokenSecretRef.Key != "" {
 			key = remote.Connection.AdminTokenSecretRef.Key
 		}

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3259,6 +3259,9 @@ func (r *GarageClusterReconciler) connectGatewayToClusterRef(ctx context.Context
 }
 
 // connectGatewayToExternalCluster connects a gateway to an external storage cluster via Admin API endpoint.
+// It establishes bidirectional connectivity: gateway → storage AND storage → gateway.
+// The reverse direction ensures the external cluster has the gateway's current routable address
+// (set via publicEndpoint / rpc_public_addr), so it can reconnect after gateway pod restarts.
 func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Context, cluster *garagev1alpha1.GarageCluster, gatewayClient *garage.Client) {
 	log := logf.FromContext(ctx)
 
@@ -3269,26 +3272,52 @@ func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Co
 	}
 
 	// Get external cluster status for node discovery
-	status, err := externalClient.GetClusterStatus(ctx)
+	externalStatus, err := externalClient.GetClusterStatus(ctx)
 	if err != nil {
 		log.V(1).Info("Failed to get external cluster status", "endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint, "error", err)
 		return
 	}
 
-	// Connect gateway to each external node
-	connectedCount := 0
-	for _, node := range status.Nodes {
+	// Connect gateway to each external node (gateway → storage)
+	connectedToStorage := 0
+	for _, node := range externalStatus.Nodes {
 		if node.Address != nil && *node.Address != "" {
 			if _, err := gatewayClient.ConnectNode(ctx, node.ID, *node.Address); err != nil {
-				log.V(1).Info("Failed to connect to external node", "nodeID", node.ID[:16]+"...", "address", *node.Address, "error", err)
+				log.V(1).Info("Failed to connect gateway to external node", "nodeID", node.ID[:16]+"...", "address", *node.Address, "error", err)
 			} else {
-				connectedCount++
+				connectedToStorage++
 			}
 		}
 	}
 
-	if connectedCount > 0 {
-		log.Info("Gateway connected to external storage cluster", "endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint, "nodesConnected", connectedCount)
+	// Get gateway status to discover gateway node addresses
+	gatewayStatus, err := gatewayClient.GetClusterStatus(ctx)
+	if err != nil {
+		log.V(1).Info("Failed to get gateway cluster status", "error", err)
+		if connectedToStorage > 0 {
+			log.Info("Gateway connected to external storage cluster (one-way)", "endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint, "nodesConnected", connectedToStorage)
+		}
+		return
+	}
+
+	// Connect external storage to each gateway node (storage → gateway)
+	// Requires publicEndpoint so gateway nodes advertise a routable address.
+	connectedToGateway := 0
+	for _, node := range gatewayStatus.Nodes {
+		if node.Address != nil && *node.Address != "" {
+			if _, err := externalClient.ConnectNode(ctx, node.ID, *node.Address); err != nil {
+				log.V(1).Info("Failed to connect external storage to gateway node", "nodeID", node.ID[:16]+"...", "address", *node.Address, "error", err)
+			} else {
+				connectedToGateway++
+			}
+		}
+	}
+
+	if connectedToStorage > 0 || connectedToGateway > 0 {
+		log.Info("Gateway-external storage bidirectional connection established",
+			"endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint,
+			"gatewayToStorage", connectedToStorage,
+			"storageToGateway", connectedToGateway)
 	}
 }
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -1119,7 +1119,7 @@ func (r *GarageClusterReconciler) reconcileHeadlessService(ctx context.Context, 
 	selector := r.selectorLabelsForCluster(cluster)
 	if cluster.Spec.LayoutPolicy == LayoutPolicyManual {
 		selector = map[string]string{
-			"garage.rajsingh.info/cluster": cluster.Name,
+			labelCluster: cluster.Name,
 		}
 	}
 
@@ -1238,7 +1238,7 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 	selector := r.selectorLabelsForCluster(cluster)
 	if cluster.Spec.LayoutPolicy == LayoutPolicyManual {
 		selector = map[string]string{
-			"garage.rajsingh.info/cluster": cluster.Name,
+			labelCluster: cluster.Name,
 		}
 	}
 
@@ -2386,7 +2386,7 @@ func (r *GarageClusterReconciler) labelsForCluster(cluster *garagev1alpha1.Garag
 		labelAppInstance:               cluster.Name,
 		labelAppManagedBy:              "garage-operator",
 		"app.kubernetes.io/component":  component,
-		"garage.rajsingh.info/cluster": cluster.Name,
+		labelCluster: cluster.Name,
 	}
 }
 

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -45,7 +45,7 @@ var _ = Describe("GarageCluster Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 		})
 
@@ -62,19 +62,19 @@ var _ = Describe("GarageCluster Controller", func() {
 
 			// Cleanup created resources
 			_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: testNamespace},
 			})
 			_ = k8sClient.Delete(ctx, &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: testNamespace},
 			})
 			_ = k8sClient.Delete(ctx, &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-headless", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-headless", Namespace: testNamespace},
 			})
 			_ = k8sClient.Delete(ctx, &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-config", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-config", Namespace: testNamespace},
 			})
 			_ = k8sClient.Delete(ctx, &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-rpc-secret", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-rpc-secret", Namespace: testNamespace},
 			})
 		})
 
@@ -83,7 +83,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			cluster := &garagev1alpha1.GarageCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageClusterSpec{
 					Replicas: 3,
@@ -123,7 +123,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      resourceName + "-headless",
-					Namespace: "default",
+					Namespace: testNamespace,
 				}, headlessSvc)
 			}, timeout, interval).Should(Succeed())
 			Expect(headlessSvc.Spec.ClusterIP).To(Equal("None"))
@@ -140,7 +140,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      resourceName + "-config",
-					Namespace: "default",
+					Namespace: testNamespace,
 				}, cm)
 			}, timeout, interval).Should(Succeed())
 			Expect(cm.Data).To(HaveKey("garage.toml"))
@@ -150,7 +150,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      resourceName + "-rpc-secret",
-					Namespace: "default",
+					Namespace: testNamespace,
 				}, secret)
 			}, timeout, interval).Should(Succeed())
 			Expect(secret.Data).To(HaveKey("rpc-secret"))
@@ -161,7 +161,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			cluster := &garagev1alpha1.GarageCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageClusterSpec{
 					Replicas: 1,
@@ -194,7 +194,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			cluster := &garagev1alpha1.GarageCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageClusterSpec{
 					Replicas: 1,
@@ -238,7 +238,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      resourceName + "-config",
-					Namespace: "default",
+					Namespace: testNamespace,
 				}, cm)
 			}, timeout, interval).Should(Succeed())
 			Expect(cm.Data["garage.toml"]).To(ContainSubstring("4901"))
@@ -256,8 +256,8 @@ var _ = Describe("GarageCluster Controller", func() {
 
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name:      "non-existent",
-					Namespace: "default",
+					Name:      testNonExistent,
+					Namespace: testNamespace,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -271,14 +271,14 @@ var _ = Describe("GarageCluster Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 
 			// Create the external secret
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "external-rpc-secret",
-					Namespace: "default",
+					Name:      testExternalRPCSecret,
+					Namespace: testNamespace,
 				},
 				StringData: map[string]string{
 					"my-key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -300,7 +300,7 @@ var _ = Describe("GarageCluster Controller", func() {
 				_ = k8sClient.Delete(ctx, cluster)
 			}
 			_ = k8sClient.Delete(ctx, &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "external-rpc-secret", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: testExternalRPCSecret, Namespace: testNamespace},
 			})
 		})
 
@@ -309,7 +309,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			cluster := &garagev1alpha1.GarageCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageClusterSpec{
 					Replicas: 1,
@@ -319,7 +319,7 @@ var _ = Describe("GarageCluster Controller", func() {
 					Network: garagev1alpha1.NetworkConfig{
 						RPCSecretRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "external-rpc-secret",
+								Name: testExternalRPCSecret,
 							},
 							Key: "my-key",
 						},
@@ -350,7 +350,7 @@ var _ = Describe("GarageCluster Controller", func() {
 			autoSecret := &corev1.Secret{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      resourceName + "-rpc-secret",
-				Namespace: "default",
+				Namespace: testNamespace,
 			}, autoSecret)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -325,8 +325,8 @@ func (r *GarageKeyReconciler) importKey(ctx context.Context, key *garagev1alpha1
 		if importSecret.Data == nil {
 			return nil, "", fmt.Errorf("import secret %s has no data", key.Spec.ImportKey.SecretRef.Name)
 		}
-		akKey := "access-key-id"
-		skKey := "secret-access-key"
+		akKey := defaultAccessKeyIDKey
+		skKey := defaultSecretAccessKeyKey
 		if key.Spec.ImportKey.AccessKeyIDKey != "" {
 			akKey = key.Spec.ImportKey.AccessKeyIDKey
 		}
@@ -670,17 +670,17 @@ func resolveSecretConfig(key *garagev1alpha1.GarageKey) secretConfig {
 	cfg := secretConfig{
 		name:               key.Name,
 		namespace:          key.Namespace,
-		accessKeyIDKey:     "access-key-id",
-		secretAccessKeyKey: "secret-access-key",
+		accessKeyIDKey:     defaultAccessKeyIDKey,
+		secretAccessKeyKey: defaultSecretAccessKeyKey,
 		endpointKey:        "endpoint",
 		hostKey:            "host",
-		schemeKey:          "scheme",
-		regionKey:          "region",
+		schemeKey:          defaultSchemeKey,
+		regionKey:          defaultRegionKey,
 		includeEndpoint:    true,
 		includeRegion:      true,
 		labels: map[string]string{
-			"app.kubernetes.io/managed-by": "garage-operator",
-			"garage.rajsingh.info/key":     key.Name,
+			labelAppManagedBy:          operatorName,
+			"garage.rajsingh.info/key": key.Name,
 		},
 		annotations: map[string]string{},
 		secretType:  corev1.SecretTypeOpaque,
@@ -893,7 +893,7 @@ func (r *GarageKeyReconciler) updateStatusWaiting(ctx context.Context, key *gara
 		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1alpha1.ReasonClusterNotReady,
-		Message:            "waiting for cluster to be reachable",
+		Message:            msgWaitingForCluster,
 		ObservedGeneration: key.Generation,
 	})
 	if statusErr := UpdateStatusWithRetry(ctx, r.Client, key); statusErr != nil {

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -98,7 +98,7 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if errors.IsNotFound(clusterErr) {
 			return r.updateStatusWaiting(ctx, key)
 		}
-		return r.updateStatus(ctx, key, "Error", fmt.Errorf("cluster not found: %w", clusterErr))
+		return r.updateStatus(ctx, key, PhaseError, fmt.Errorf("cluster not found: %w", clusterErr))
 	}
 
 	// Guard against calling the Garage API before the cluster layout has converged.
@@ -107,7 +107,7 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	} else if cluster.Status.Phase != PhaseRunning {
 		msg := "waiting for cluster to reach Running phase"
 		meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
+			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
 			Reason:             "ClusterNotReady",
 			Message:            msg,
@@ -123,7 +123,7 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Get garage client
 	garageClient, err := GetGarageClient(ctx, r.Client, cluster, r.ClusterDomain)
 	if err != nil {
-		return r.updateStatus(ctx, key, "Error", fmt.Errorf("failed to create garage client: %w", err))
+		return r.updateStatus(ctx, key, PhaseError, fmt.Errorf("failed to create garage client: %w", err))
 	}
 
 	// Handle deletion (cluster exists at this point)
@@ -890,7 +890,7 @@ func (r *GarageKeyReconciler) finalize(ctx context.Context, key *garagev1alpha1.
 func (r *GarageKeyReconciler) updateStatusWaiting(ctx context.Context, key *garagev1alpha1.GarageKey) (ctrl.Result, error) {
 	key.Status.Phase = PhasePending
 	meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1alpha1.ReasonClusterNotReady,
 		Message:            "waiting for cluster to be reachable",
@@ -911,9 +911,9 @@ func (r *GarageKeyReconciler) updateStatus(ctx context.Context, key *garagev1alp
 
 	if err != nil {
 		meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
+			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "Error",
+			Reason:             PhaseError,
 			Message:            err.Error(),
 			ObservedGeneration: key.Generation,
 		})
@@ -951,13 +951,13 @@ func (r *GarageKeyReconciler) updateStatusFromGarage(ctx context.Context, key *g
 			}
 			return ctrl.Result{Requeue: true}, nil
 		}
-		return r.updateStatus(ctx, key, "Error", fmt.Errorf("failed to get key info: %w", err))
+		return r.updateStatus(ctx, key, PhaseError, fmt.Errorf("failed to get key info: %w", err))
 	}
 
 	// Capture old status before modifications to detect no-op updates
 	oldStatus := key.Status.DeepCopy()
 
-	key.Status.Phase = "Ready"
+	key.Status.Phase = PhaseReady
 	key.Status.ObservedGeneration = key.Generation
 	key.Status.Permissions = &garagev1alpha1.KeyPermissions{
 		CreateBucket: garageKey.Permissions.CreateBucket,
@@ -1001,7 +1001,7 @@ func (r *GarageKeyReconciler) updateStatusFromGarage(ctx context.Context, key *g
 	})
 
 	meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             metav1.ConditionTrue,
 		Reason:             "KeyReady",
 		Message:            "Key is ready",

--- a/internal/controller/garagekey_controller_test.go
+++ b/internal/controller/garagekey_controller_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GarageKey Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 		})
 
@@ -58,11 +58,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "non-existent-cluster",
+						Name: testNonExistentCluster,
 					},
 				},
 			}
@@ -92,11 +92,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					BucketPermissions: []garagev1alpha1.BucketPermission{
 						{
@@ -122,11 +122,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					Permissions: &garagev1alpha1.KeyPermissions{
 						CreateBucket: true,
@@ -147,11 +147,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					SecretTemplate: &garagev1alpha1.SecretTemplate{
 						Name: "custom-secret-name",
@@ -175,11 +175,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					AllBuckets: &garagev1alpha1.AllBucketsPermission{
 						Read:  true,
@@ -204,11 +204,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					AllBuckets: &garagev1alpha1.AllBucketsPermission{
 						Read: true,
@@ -243,11 +243,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					AllBuckets: &garagev1alpha1.AllBucketsPermission{
 						Read: true,
@@ -275,11 +275,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 					Expiration: "2030-12-31T23:59:59Z",
 				},
@@ -303,7 +303,7 @@ var _ = Describe("GarageKey Controller", func() {
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "non-existent",
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -317,7 +317,7 @@ var _ = Describe("GarageKey Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 		})
 
@@ -337,11 +337,11 @@ var _ = Describe("GarageKey Controller", func() {
 			key := &garagev1alpha1.GarageKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageKeySpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
 				},
 			}

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -209,7 +209,7 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 	}
 
 	container := corev1.Container{
-		Name:            "garage",
+		Name:            defaultAppName,
 		Image:           image,
 		ImagePullPolicy: cluster.Spec.ImagePullPolicy,
 		Command:         []string{"/garage", "-c", "/etc/garage/garage.toml", "server"},
@@ -240,7 +240,7 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 			Image:   "busybox:1.37",
 			Command: []string{"touch", dataPath + "/garage-marker"},
 			VolumeMounts: []corev1.VolumeMount{
-				{Name: "data", MountPath: dataPath},
+				{Name: dataVolName, MountPath: dataPath},
 			},
 			SecurityContext: buildInitContainerSecurityContext(cluster),
 		}
@@ -335,8 +335,8 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1alpha1.Ga
 	volumeMounts := []corev1.VolumeMount{
 		{Name: configVolumeName, MountPath: "/etc/garage", ReadOnly: true},
 		{Name: RPCSecretKey, MountPath: "/secrets/rpc", ReadOnly: true},
-		{Name: "metadata", MountPath: "/data/metadata"},
-		{Name: "data", MountPath: dataPath},
+		{Name: metadataVolName, MountPath: "/data/metadata"},
+		{Name: dataVolName, MountPath: dataPath},
 	}
 
 	// RPC secret from cluster
@@ -373,7 +373,7 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1alpha1.Ga
 	// Handle data volume: gateway nodes use EmptyDir, storage nodes use PVC
 	if node.Spec.Gateway {
 		volumes = append(volumes, corev1.Volume{
-			Name: "data",
+			Name: dataVolName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -381,7 +381,7 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1alpha1.Ga
 	} else if node.Spec.Storage != nil && node.Spec.Storage.Data != nil && node.Spec.Storage.Data.ExistingClaim != "" {
 		// Use existing PVC for data
 		volumes = append(volumes, corev1.Volume{
-			Name: "data",
+			Name: dataVolName,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: node.Spec.Storage.Data.ExistingClaim,
@@ -394,7 +394,7 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1alpha1.Ga
 	// Handle metadata volume: if existingClaim, add as volume
 	if node.Spec.Storage != nil && node.Spec.Storage.Metadata != nil && node.Spec.Storage.Metadata.ExistingClaim != "" {
 		volumes = append(volumes, corev1.Volume{
-			Name: "metadata",
+			Name: metadataVolName,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: node.Spec.Storage.Metadata.ExistingClaim,
@@ -411,17 +411,17 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1alpha1.Ga
 			adminTokenKey = cluster.Spec.Admin.AdminTokenSecretRef.Key
 		}
 		volumes = append(volumes, corev1.Volume{
-			Name: "admin-token",
+			Name: DefaultAdminTokenKey,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  cluster.Spec.Admin.AdminTokenSecretRef.Name,
 					DefaultMode: ptr.To[int32](0600),
-					Items:       []corev1.KeyToPath{{Key: adminTokenKey, Path: "admin-token"}},
+					Items:       []corev1.KeyToPath{{Key: adminTokenKey, Path: DefaultAdminTokenKey}},
 				},
 			},
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "admin-token",
+			Name:      DefaultAdminTokenKey,
 			MountPath: "/secrets/admin",
 			ReadOnly:  true,
 		})
@@ -441,7 +441,7 @@ func (r *GarageNodeReconciler) buildNodeVolumeClaimTemplates(node *garagev1alpha
 	// Metadata PVC (if not using existingClaim)
 	if node.Spec.Storage.Metadata != nil && node.Spec.Storage.Metadata.ExistingClaim == "" && node.Spec.Storage.Metadata.Size != nil {
 		metadataPVC := corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: "metadata"},
+			ObjectMeta: metav1.ObjectMeta{Name: metadataVolName},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.VolumeResourceRequirements{
@@ -458,7 +458,7 @@ func (r *GarageNodeReconciler) buildNodeVolumeClaimTemplates(node *garagev1alpha
 	} else if node.Spec.Storage.Metadata == nil {
 		// Default metadata PVC if not specified
 		metadataPVC := corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: "metadata"},
+			ObjectMeta: metav1.ObjectMeta{Name: metadataVolName},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.VolumeResourceRequirements{
@@ -474,7 +474,7 @@ func (r *GarageNodeReconciler) buildNodeVolumeClaimTemplates(node *garagev1alpha
 	// Data PVC (if not gateway and not using existingClaim)
 	if !node.Spec.Gateway && node.Spec.Storage.Data != nil && node.Spec.Storage.Data.ExistingClaim == "" && node.Spec.Storage.Data.Size != nil {
 		dataPVC := corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			ObjectMeta: metav1.ObjectMeta{Name: dataVolName},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.VolumeResourceRequirements{

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -83,7 +83,7 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		Name:      node.Spec.ClusterRef.Name,
 		Namespace: clusterNamespace,
 	}, cluster); err != nil {
-		return r.updateStatus(ctx, node, "Error", fmt.Errorf("cluster not found: %w", err))
+		return r.updateStatus(ctx, node, PhaseError, fmt.Errorf("cluster not found: %w", err))
 	}
 
 	// Handle deletion
@@ -131,19 +131,19 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// For managed nodes (not external), create/update the StatefulSet
 	if node.Spec.External == nil {
 		if err := r.reconcileStatefulSet(ctx, node, cluster); err != nil {
-			return r.updateStatus(ctx, node, "Error", err)
+			return r.updateStatus(ctx, node, PhaseError, err)
 		}
 	}
 
 	// Get garage client for layout management
 	garageClient, err := GetGarageClient(ctx, r.Client, cluster, r.ClusterDomain)
 	if err != nil {
-		return r.updateStatus(ctx, node, "Error", fmt.Errorf("failed to create garage client: %w", err))
+		return r.updateStatus(ctx, node, PhaseError, fmt.Errorf("failed to create garage client: %w", err))
 	}
 
 	// Reconcile the node layout
 	if err := r.reconcileNode(ctx, node, cluster, garageClient); err != nil {
-		return r.updateStatus(ctx, node, "Error", err)
+		return r.updateStatus(ctx, node, PhaseError, err)
 	}
 
 	return r.updateStatusFromGarage(ctx, node, garageClient)
@@ -238,9 +238,9 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 		initContainer := corev1.Container{
 			Name:    "init-marker",
 			Image:   "busybox:1.37",
-			Command: []string{"touch", "/data/data/garage-marker"},
+			Command: []string{"touch", dataPath + "/garage-marker"},
 			VolumeMounts: []corev1.VolumeMount{
-				{Name: "data", MountPath: "/data/data"},
+				{Name: "data", MountPath: dataPath},
 			},
 			SecurityContext: buildInitContainerSecurityContext(cluster),
 		}
@@ -333,10 +333,10 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 // buildNodeVolumesAndMounts returns volumes and volume mounts for a GarageNode's StatefulSet.
 func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1alpha1.GarageNode, cluster *garagev1alpha1.GarageCluster) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "config", MountPath: "/etc/garage", ReadOnly: true},
+		{Name: configVolumeName, MountPath: "/etc/garage", ReadOnly: true},
 		{Name: RPCSecretKey, MountPath: "/secrets/rpc", ReadOnly: true},
 		{Name: "metadata", MountPath: "/data/metadata"},
-		{Name: "data", MountPath: "/data/data"},
+		{Name: "data", MountPath: dataPath},
 	}
 
 	// RPC secret from cluster
@@ -351,7 +351,7 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1alpha1.Ga
 
 	volumes := []corev1.Volume{
 		{
-			Name: "config",
+			Name: configVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: cluster.Name + "-config"},
@@ -938,9 +938,9 @@ func (r *GarageNodeReconciler) updateStatus(ctx context.Context, node *garagev1a
 
 	if err != nil {
 		meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
+			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "Error",
+			Reason:             PhaseError,
 			Message:            err.Error(),
 			ObservedGeneration: node.Generation,
 		})
@@ -963,7 +963,7 @@ func (r *GarageNodeReconciler) updateStatusFromGarage(ctx context.Context, node 
 
 	status, err := garageClient.GetClusterStatus(ctx)
 	if err != nil {
-		return r.updateStatus(ctx, node, "Error", fmt.Errorf("failed to get cluster status: %w", err))
+		return r.updateStatus(ctx, node, PhaseError, fmt.Errorf("failed to get cluster status: %w", err))
 	}
 
 	var nodeInfo *garage.NodeInfo
@@ -976,7 +976,7 @@ func (r *GarageNodeReconciler) updateStatusFromGarage(ctx context.Context, node 
 
 	layout, err := garageClient.GetClusterLayout(ctx)
 	if err != nil {
-		return r.updateStatus(ctx, node, "Error", fmt.Errorf("failed to get cluster layout: %w", err))
+		return r.updateStatus(ctx, node, PhaseError, fmt.Errorf("failed to get cluster layout: %w", err))
 	}
 
 	var layoutRole *garage.LayoutRole
@@ -987,7 +987,7 @@ func (r *GarageNodeReconciler) updateStatusFromGarage(ctx context.Context, node 
 		}
 	}
 
-	node.Status.Phase = "Ready"
+	node.Status.Phase = PhaseReady
 	node.Status.ObservedGeneration = node.Generation
 	node.Status.InLayout = layoutRole != nil
 
@@ -1021,7 +1021,7 @@ func (r *GarageNodeReconciler) updateStatusFromGarage(ctx context.Context, node 
 	}
 
 	meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
-		Type:               "Ready",
+		Type:               PhaseReady,
 		Status:             conditionStatus,
 		Reason:             reason,
 		Message:            message,

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -30,6 +30,8 @@ import (
 	garagev1alpha1 "github.com/rajsinghtech/garage-operator/api/v1alpha1"
 )
 
+const testZoneDC1 = "dc1"
+
 var _ = Describe("GarageNode Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-node"
@@ -38,7 +40,7 @@ var _ = Describe("GarageNode Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 		})
 
@@ -60,13 +62,13 @@ var _ = Describe("GarageNode Controller", func() {
 			node := &garagev1alpha1.GarageNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageNodeSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "non-existent-cluster",
+						Name: testNonExistentCluster,
 					},
-					Zone:     "dc1",
+					Zone:     testZoneDC1,
 					Capacity: &capacity,
 					Storage: &garagev1alpha1.NodeStorageSpec{
 						Data: &garagev1alpha1.NodeVolumeSource{
@@ -103,13 +105,13 @@ var _ = Describe("GarageNode Controller", func() {
 			node := &garagev1alpha1.GarageNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageNodeSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
-					Zone:     "dc1",
+					Zone:     testZoneDC1,
 					Capacity: &capacity,
 					Tags:     []string{"ssd", "rack-a"},
 					Storage: &garagev1alpha1.NodeStorageSpec{
@@ -132,13 +134,13 @@ var _ = Describe("GarageNode Controller", func() {
 			node := &garagev1alpha1.GarageNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageNodeSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
-					Zone:    "dc1",
+					Zone:    testZoneDC1,
 					Gateway: true,
 					Storage: &garagev1alpha1.NodeStorageSpec{
 						// Gateway only needs metadata storage
@@ -166,13 +168,13 @@ var _ = Describe("GarageNode Controller", func() {
 			node := &garagev1alpha1.GarageNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageNodeSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
-					Zone:     "dc1",
+					Zone:     testZoneDC1,
 					Capacity: &capacity,
 					Storage: &garagev1alpha1.NodeStorageSpec{
 						Metadata: &garagev1alpha1.NodeVolumeSource{
@@ -202,13 +204,13 @@ var _ = Describe("GarageNode Controller", func() {
 			node := &garagev1alpha1.GarageNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageNodeSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
-					Zone:     "dc1",
+					Zone:     testZoneDC1,
 					Capacity: &capacity,
 					NodeID:   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 					External: &garagev1alpha1.ExternalNodeConfig{
@@ -236,8 +238,8 @@ var _ = Describe("GarageNode Controller", func() {
 
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name:      "non-existent",
-					Namespace: "default",
+					Name:      testNonExistent,
+					Namespace: testNamespace,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -251,7 +253,7 @@ var _ = Describe("GarageNode Controller", func() {
 		BeforeEach(func() {
 			typeNamespacedName = types.NamespacedName{
 				Name:      resourceName,
-				Namespace: "default",
+				Namespace: testNamespace,
 			}
 		})
 
@@ -273,13 +275,13 @@ var _ = Describe("GarageNode Controller", func() {
 			node := &garagev1alpha1.GarageNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: garagev1alpha1.GarageNodeSpec{
 					ClusterRef: garagev1alpha1.ClusterReference{
-						Name: "test-cluster",
+						Name: testClusterName,
 					},
-					Zone:     "dc1",
+					Zone:     testZoneDC1,
 					Capacity: &capacity,
 					Storage: &garagev1alpha1.NodeStorageSpec{
 						Data: &garagev1alpha1.NodeVolumeSource{

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -105,9 +105,23 @@ const (
 
 // Volume and mount name constants
 const (
-	configVolumeName = "config"
-	dataPath         = "/data/data"
-	adminTokenVolume = "admin-token"
+	configVolumeName     = "config"
+	dataPath             = "/data/data"
+	adminTokenVolume     = "admin-token"
+	metadataVolName      = "metadata"
+	dataVolName          = "data"
+	rpcPortName          = "rpc"
+	defaultZoneName      = "default"
+	operatorName         = "garage-operator"
+	msgWaitingForCluster = "waiting for cluster to be reachable"
+)
+
+// Secret key name constants for S3 credentials
+const (
+	defaultAccessKeyIDKey     = "access-key-id"
+	defaultSecretAccessKeyKey = "secret-access-key"
+	defaultSchemeKey          = "scheme"
+	defaultRegionKey          = "region"
 )
 
 var validRepairTypes = map[string]bool{

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -96,6 +96,20 @@ const (
 // annotationTrue is the canonical value for boolean-style annotations.
 const annotationTrue = "true"
 
+// Kubernetes well-known label keys
+const (
+	labelAppName      = "app.kubernetes.io/name"
+	labelAppInstance  = "app.kubernetes.io/instance"
+	labelAppManagedBy = "app.kubernetes.io/managed-by"
+)
+
+// Volume and mount name constants
+const (
+	configVolumeName = "config"
+	dataPath         = "/data/data"
+	adminTokenVolume = "admin-token"
+)
+
 var validRepairTypes = map[string]bool{
 	garagev1alpha1.RepairTypeTables:           true,
 	garagev1alpha1.RepairTypeBlocks:           true,

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -28,19 +28,29 @@ import (
 )
 
 const (
-	metadataVolumeName  = "metadata"
-	dataVolumeName      = "data"
-	testClusterName     = "test-cluster"
-	testStorageClass    = "fast-ssd"
-	testIPv4Addr        = "10.0.0.1"
-	testEndpointKey     = "endpoint"
-	testHostKey         = "host"
-	testAccessKeyID     = "AKIAIOSFODNN7EXAMPLE"
-	testCustomKey       = "custom-key"
-	testImageFull       = "custom/garage:v1.0.0"
-	testImageRepo       = "my-mirror/garage"
-	testImageFull2      = "custom/garage:v3.0.0"
-	testNodeImageRepo   = "node-mirror/garage"
+	metadataVolumeName     = "metadata"
+	dataVolumeName         = "data"
+	testClusterName        = "test-cluster"
+	testNonExistentCluster = "non-existent-cluster"
+	testNonExistent        = "non-existent"
+	testExternalRPCSecret  = "external-rpc-secret"
+	testStorageClass       = "fast-ssd"
+	testIPv4Addr           = "10.0.0.1"
+	testEndpointKey        = "endpoint"
+	testHostKey            = "host"
+	testAccessKeyID        = "AKIAIOSFODNN7EXAMPLE"
+	testCustomKey          = "custom-key"
+	testImageFull          = "custom/garage:v1.0.0"
+	testImageRepo          = "my-mirror/garage"
+	testImageFull2         = "custom/garage:v3.0.0"
+	testNodeImageRepo      = "node-mirror/garage"
+	testAccessKeyIDKey     = "access-key-id"
+	testSecretAccessKey    = "secret-access-key"
+	testSchemeKey          = "scheme"
+	testRegionKey          = "region"
+	testSecretValue        = "secret123"
+	testOperatorImage      = "registry.example.com/garage:v2.0.0"
+	testPortNameRPC        = "rpc"
 )
 
 func TestResolveSecretConfig(t *testing.T) {
@@ -55,12 +65,12 @@ func TestResolveSecretConfig(t *testing.T) {
 				Spec: garagev1alpha1.GarageKeySpec{},
 			},
 			expected: secretConfig{
-				accessKeyIDKey:     "access-key-id",
-				secretAccessKeyKey: "secret-access-key",
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
 				endpointKey:        testEndpointKey,
 				hostKey:            testHostKey,
-				schemeKey:          "scheme",
-				regionKey:          "region",
+				schemeKey:          testSchemeKey,
+				regionKey:          testRegionKey,
 				includeEndpoint:    true,
 				includeRegion:      true,
 				secretType:         corev1.SecretTypeOpaque,
@@ -103,12 +113,12 @@ func TestResolveSecretConfig(t *testing.T) {
 				},
 			},
 			expected: secretConfig{
-				accessKeyIDKey:     "access-key-id",
-				secretAccessKeyKey: "secret-access-key",
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
 				endpointKey:        testEndpointKey,
 				hostKey:            testHostKey,
-				schemeKey:          "scheme",
-				regionKey:          "region",
+				schemeKey:          testSchemeKey,
+				regionKey:          testRegionKey,
 				includeEndpoint:    false,
 				includeRegion:      false,
 				secretType:         corev1.SecretTypeOpaque,
@@ -124,12 +134,12 @@ func TestResolveSecretConfig(t *testing.T) {
 				},
 			},
 			expected: secretConfig{
-				accessKeyIDKey:     "access-key-id",
-				secretAccessKeyKey: "secret-access-key",
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
 				endpointKey:        testEndpointKey,
 				hostKey:            testHostKey,
-				schemeKey:          "scheme",
-				regionKey:          "region",
+				schemeKey:          testSchemeKey,
+				regionKey:          testRegionKey,
 				includeEndpoint:    true,
 				includeRegion:      true,
 				secretType:         corev1.SecretTypeDockerConfigJson,
@@ -185,12 +195,12 @@ func TestBuildSecretData(t *testing.T) {
 		{
 			name: "basic secret with all fields",
 			cfg: secretConfig{
-				accessKeyIDKey:     "access-key-id",
-				secretAccessKeyKey: "secret-access-key",
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
 				endpointKey:        testEndpointKey,
 				hostKey:            testHostKey,
-				schemeKey:          "scheme",
-				regionKey:          "region",
+				schemeKey:          testSchemeKey,
+				regionKey:          testRegionKey,
 				includeEndpoint:    true,
 				includeRegion:      true,
 			},
@@ -207,23 +217,23 @@ func TestBuildSecretData(t *testing.T) {
 				},
 			},
 			secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-			wantKeys:        []string{"access-key-id", "secret-access-key", "endpoint", "host", "scheme", "region"},
+			wantKeys:        []string{testAccessKeyIDKey, testSecretAccessKey, "endpoint", "host", testSchemeKey, testRegionKey},
 			wantValues: map[string]string{
-				"access-key-id":     "AKIAIOSFODNN7EXAMPLE",
-				"secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-				"region":            "us-west-2",
-				"scheme":            "http",
+				testAccessKeyIDKey:  "AKIAIOSFODNN7EXAMPLE",
+				testSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				testRegionKey:       "us-west-2",
+				testSchemeKey:       "http",
 			},
 		},
 		{
 			name: "without endpoint and region",
 			cfg: secretConfig{
-				accessKeyIDKey:     "access-key-id",
-				secretAccessKeyKey: "secret-access-key",
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
 				endpointKey:        testEndpointKey,
 				hostKey:            testHostKey,
-				schemeKey:          "scheme",
-				regionKey:          "region",
+				schemeKey:          testSchemeKey,
+				regionKey:          testRegionKey,
 				includeEndpoint:    false,
 				includeRegion:      false,
 			},
@@ -233,15 +243,15 @@ func TestBuildSecretData(t *testing.T) {
 				},
 			},
 			cluster:         &garagev1alpha1.GarageCluster{},
-			secretAccessKey: "secret123",
-			wantKeys:        []string{"access-key-id", "secret-access-key"},
+			secretAccessKey: testSecretValue,
+			wantKeys:        []string{testAccessKeyIDKey, testSecretAccessKey},
 		},
 		{
 			name: "default region when not specified",
 			cfg: secretConfig{
-				accessKeyIDKey:     "access-key-id",
-				secretAccessKeyKey: "secret-access-key",
-				regionKey:          "region",
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				regionKey:          testRegionKey,
 				includeEndpoint:    false,
 				includeRegion:      true,
 			},
@@ -251,7 +261,7 @@ func TestBuildSecretData(t *testing.T) {
 				},
 			},
 			cluster:         &garagev1alpha1.GarageCluster{},
-			secretAccessKey: "secret123",
+			secretAccessKey: testSecretValue,
 			wantValues: map[string]string{
 				"region": defaultS3Region,
 			},
@@ -259,8 +269,8 @@ func TestBuildSecretData(t *testing.T) {
 		{
 			name: "with additional data",
 			cfg: secretConfig{
-				accessKeyIDKey:     "access-key-id",
-				secretAccessKeyKey: "secret-access-key",
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
 				includeEndpoint:    false,
 				includeRegion:      false,
 				additionalData: map[string]string{
@@ -273,8 +283,8 @@ func TestBuildSecretData(t *testing.T) {
 				},
 			},
 			cluster:         &garagev1alpha1.GarageCluster{},
-			secretAccessKey: "secret123",
-			wantKeys:        []string{"access-key-id", "secret-access-key", "custom-key"},
+			secretAccessKey: testSecretValue,
+			wantKeys:        []string{testAccessKeyIDKey, testSecretAccessKey, testCustomKey},
 			wantValues: map[string]string{
 				testCustomKey: "custom-value",
 			},
@@ -315,7 +325,7 @@ func TestResolveGarageImage(t *testing.T) {
 		{
 			name:     "image takes precedence",
 			image:    testImageFull,
-			expected: "custom/garage:v1.0.0",
+			expected: testImageFull,
 		},
 		{
 			name:            "imageRepository uses default tag",
@@ -330,19 +340,19 @@ func TestResolveGarageImage(t *testing.T) {
 		},
 		{
 			name:            "operator default used when CR fields empty",
-			operatorDefault: "registry.example.com/garage:v2.0.0",
-			expected:        "registry.example.com/garage:v2.0.0",
+			operatorDefault: testOperatorImage,
+			expected:        testOperatorImage,
 		},
 		{
 			name:            "CR image overrides operator default",
 			image:           "custom/garage:v1.0.0",
-			operatorDefault: "registry.example.com/garage:v2.0.0",
+			operatorDefault: testOperatorImage,
 			expected:        "custom/garage:v1.0.0",
 		},
 		{
 			name:            "CR imageRepository overrides operator default",
 			imageRepository: testImageRepo,
-			operatorDefault: "registry.example.com/garage:v2.0.0",
+			operatorDefault: testOperatorImage,
 			expected:        "my-mirror/garage:" + defaultGarageTag,
 		},
 	}
@@ -373,7 +383,7 @@ func TestMergeNodeImage(t *testing.T) {
 		{
 			name:         "cluster image only",
 			clusterImage: testImageFull2,
-			expected:     "custom/garage:v3.0.0",
+			expected:     testImageFull2,
 		},
 		{
 			name:        "cluster imageRepository only",
@@ -408,14 +418,14 @@ func TestMergeNodeImage(t *testing.T) {
 		},
 		{
 			name:            "operator default used when all empty",
-			operatorDefault: "registry.example.com/garage:v2.0.0",
-			expected:        "registry.example.com/garage:v2.0.0",
+			operatorDefault: testOperatorImage,
+			expected:        testOperatorImage,
 		},
 		{
 			name:            "cluster image overrides operator default",
 			clusterImage:    "custom/garage:v3.0.0",
-			operatorDefault: "registry.example.com/garage:v2.0.0",
-			expected:        "custom/garage:v3.0.0",
+			operatorDefault: testOperatorImage,
+			expected:        testImageFull2,
 		},
 	}
 	for _, tt := range tests {
@@ -442,7 +452,7 @@ func TestBuildContainerPorts(t *testing.T) {
 				Spec: garagev1alpha1.GarageClusterSpec{},
 			},
 			wantMinPort: 3, // RPC, Admin, S3
-			wantPorts:   []string{"rpc", "s3", "admin"},
+			wantPorts:   []string{testPortNameRPC, "s3", "admin"},
 		},
 		// S3 API is always enabled - Garage requires the [s3_api] section
 		{
@@ -455,7 +465,7 @@ func TestBuildContainerPorts(t *testing.T) {
 				},
 			},
 			wantMinPort: 2, // RPC, S3 only
-			wantPorts:   []string{"rpc", "s3"},
+			wantPorts:   []string{testPortNameRPC, "s3"},
 		},
 		{
 			name: "custom RPC port",
@@ -467,7 +477,7 @@ func TestBuildContainerPorts(t *testing.T) {
 				},
 			},
 			wantMinPort: 3,
-			wantPorts:   []string{"rpc", "s3", "admin"},
+			wantPorts:   []string{testPortNameRPC, "s3", "admin"},
 		},
 	}
 
@@ -642,7 +652,7 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 						StorageClassName: &fastSC,
 						Paths: []garagev1alpha1.DataPath{
 							{
-								Path: "/data/data",
+								Path: dataPath,
 								Volume: &garagev1alpha1.VolumeConfig{
 									StorageClassName: &encryptedSC,
 								},
@@ -665,7 +675,7 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 					Data: &garagev1alpha1.DataStorageConfig{
 						Paths: []garagev1alpha1.DataPath{
 							{
-								Path: "/data/data",
+								Path: dataPath,
 								Volume: &garagev1alpha1.VolumeConfig{
 									AccessModes: []corev1.PersistentVolumeAccessMode{
 										corev1.ReadWriteMany,
@@ -690,7 +700,7 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 					Data: &garagev1alpha1.DataStorageConfig{
 						Paths: []garagev1alpha1.DataPath{
 							{
-								Path: "/data/data",
+								Path: dataPath,
 								Volume: &garagev1alpha1.VolumeConfig{
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{"tier": "fast"},
@@ -737,7 +747,7 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 				Storage: garagev1alpha1.StorageConfig{
 					Data: &garagev1alpha1.DataStorageConfig{
 						Paths: []garagev1alpha1.DataPath{
-							{Path: "/data/data", Capacity: ptrQuantity(resource.MustParse("50Gi"))},
+							{Path: dataPath, Capacity: ptrQuantity(resource.MustParse("50Gi"))},
 						},
 					},
 				},
@@ -938,7 +948,7 @@ func TestEffectiveWebAPI(t *testing.T) {
 		{
 			name: "default rootDomain when WebAPI spec is nil",
 			cluster: &garagev1alpha1.GarageCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "garage", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: defaultAppName, Namespace: testNamespace},
 				Spec:       garagev1alpha1.GarageClusterSpec{},
 			},
 			expectNonNil:       true,
@@ -948,7 +958,7 @@ func TestEffectiveWebAPI(t *testing.T) {
 		{
 			name: "returns nil when web API disabled",
 			cluster: &garagev1alpha1.GarageCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "garage", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: defaultAppName, Namespace: testNamespace},
 				Spec: garagev1alpha1.GarageClusterSpec{
 					WebAPI: &garagev1alpha1.WebAPIConfig{Disabled: true},
 				},
@@ -958,7 +968,7 @@ func TestEffectiveWebAPI(t *testing.T) {
 		{
 			name: "uses custom rootDomain when set",
 			cluster: &garagev1alpha1.GarageCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "garage", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: defaultAppName, Namespace: testNamespace},
 				Spec: garagev1alpha1.GarageClusterSpec{
 					WebAPI: &garagev1alpha1.WebAPIConfig{RootDomain: ".web.example.com"},
 				},

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -28,11 +28,19 @@ import (
 )
 
 const (
-	metadataVolumeName = "metadata"
-	dataVolumeName     = "data"
-	testClusterName    = "test-cluster"
-	testStorageClass   = "fast-ssd"
-	testIPv4Addr       = "10.0.0.1"
+	metadataVolumeName  = "metadata"
+	dataVolumeName      = "data"
+	testClusterName     = "test-cluster"
+	testStorageClass    = "fast-ssd"
+	testIPv4Addr        = "10.0.0.1"
+	testEndpointKey     = "endpoint"
+	testHostKey         = "host"
+	testAccessKeyID     = "AKIAIOSFODNN7EXAMPLE"
+	testCustomKey       = "custom-key"
+	testImageFull       = "custom/garage:v1.0.0"
+	testImageRepo       = "my-mirror/garage"
+	testImageFull2      = "custom/garage:v3.0.0"
+	testNodeImageRepo   = "node-mirror/garage"
 )
 
 func TestResolveSecretConfig(t *testing.T) {
@@ -49,8 +57,8 @@ func TestResolveSecretConfig(t *testing.T) {
 			expected: secretConfig{
 				accessKeyIDKey:     "access-key-id",
 				secretAccessKeyKey: "secret-access-key",
-				endpointKey:        "endpoint",
-				hostKey:            "host",
+				endpointKey:        testEndpointKey,
+				hostKey:            testHostKey,
 				schemeKey:          "scheme",
 				regionKey:          "region",
 				includeEndpoint:    true,
@@ -97,8 +105,8 @@ func TestResolveSecretConfig(t *testing.T) {
 			expected: secretConfig{
 				accessKeyIDKey:     "access-key-id",
 				secretAccessKeyKey: "secret-access-key",
-				endpointKey:        "endpoint",
-				hostKey:            "host",
+				endpointKey:        testEndpointKey,
+				hostKey:            testHostKey,
 				schemeKey:          "scheme",
 				regionKey:          "region",
 				includeEndpoint:    false,
@@ -118,8 +126,8 @@ func TestResolveSecretConfig(t *testing.T) {
 			expected: secretConfig{
 				accessKeyIDKey:     "access-key-id",
 				secretAccessKeyKey: "secret-access-key",
-				endpointKey:        "endpoint",
-				hostKey:            "host",
+				endpointKey:        testEndpointKey,
+				hostKey:            testHostKey,
 				schemeKey:          "scheme",
 				regionKey:          "region",
 				includeEndpoint:    true,
@@ -179,8 +187,8 @@ func TestBuildSecretData(t *testing.T) {
 			cfg: secretConfig{
 				accessKeyIDKey:     "access-key-id",
 				secretAccessKeyKey: "secret-access-key",
-				endpointKey:        "endpoint",
-				hostKey:            "host",
+				endpointKey:        testEndpointKey,
+				hostKey:            testHostKey,
 				schemeKey:          "scheme",
 				regionKey:          "region",
 				includeEndpoint:    true,
@@ -188,7 +196,7 @@ func TestBuildSecretData(t *testing.T) {
 			},
 			key: &garagev1alpha1.GarageKey{
 				Status: garagev1alpha1.GarageKeyStatus{
-					AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+					AccessKeyID: testAccessKeyID,
 				},
 			},
 			cluster: &garagev1alpha1.GarageCluster{
@@ -212,8 +220,8 @@ func TestBuildSecretData(t *testing.T) {
 			cfg: secretConfig{
 				accessKeyIDKey:     "access-key-id",
 				secretAccessKeyKey: "secret-access-key",
-				endpointKey:        "endpoint",
-				hostKey:            "host",
+				endpointKey:        testEndpointKey,
+				hostKey:            testHostKey,
 				schemeKey:          "scheme",
 				regionKey:          "region",
 				includeEndpoint:    false,
@@ -221,7 +229,7 @@ func TestBuildSecretData(t *testing.T) {
 			},
 			key: &garagev1alpha1.GarageKey{
 				Status: garagev1alpha1.GarageKeyStatus{
-					AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+					AccessKeyID: testAccessKeyID,
 				},
 			},
 			cluster:         &garagev1alpha1.GarageCluster{},
@@ -239,13 +247,13 @@ func TestBuildSecretData(t *testing.T) {
 			},
 			key: &garagev1alpha1.GarageKey{
 				Status: garagev1alpha1.GarageKeyStatus{
-					AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+					AccessKeyID: testAccessKeyID,
 				},
 			},
 			cluster:         &garagev1alpha1.GarageCluster{},
 			secretAccessKey: "secret123",
 			wantValues: map[string]string{
-				"region": "garage",
+				"region": defaultS3Region,
 			},
 		},
 		{
@@ -256,19 +264,19 @@ func TestBuildSecretData(t *testing.T) {
 				includeEndpoint:    false,
 				includeRegion:      false,
 				additionalData: map[string]string{
-					"custom-key": "custom-value",
+					testCustomKey: "custom-value",
 				},
 			},
 			key: &garagev1alpha1.GarageKey{
 				Status: garagev1alpha1.GarageKeyStatus{
-					AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+					AccessKeyID: testAccessKeyID,
 				},
 			},
 			cluster:         &garagev1alpha1.GarageCluster{},
 			secretAccessKey: "secret123",
 			wantKeys:        []string{"access-key-id", "secret-access-key", "custom-key"},
 			wantValues: map[string]string{
-				"custom-key": "custom-value",
+				testCustomKey: "custom-value",
 			},
 		},
 	}
@@ -306,18 +314,18 @@ func TestResolveGarageImage(t *testing.T) {
 		},
 		{
 			name:     "image takes precedence",
-			image:    "custom/garage:v1.0.0",
+			image:    testImageFull,
 			expected: "custom/garage:v1.0.0",
 		},
 		{
 			name:            "imageRepository uses default tag",
-			imageRepository: "my-mirror/garage",
+			imageRepository: testImageRepo,
 			expected:        "my-mirror/garage:" + defaultGarageTag,
 		},
 		{
 			name:            "image overrides imageRepository",
 			image:           "full/override:latest",
-			imageRepository: "my-mirror/garage",
+			imageRepository: testImageRepo,
 			expected:        "full/override:latest",
 		},
 		{
@@ -333,7 +341,7 @@ func TestResolveGarageImage(t *testing.T) {
 		},
 		{
 			name:            "CR imageRepository overrides operator default",
-			imageRepository: "my-mirror/garage",
+			imageRepository: testImageRepo,
 			operatorDefault: "registry.example.com/garage:v2.0.0",
 			expected:        "my-mirror/garage:" + defaultGarageTag,
 		},
@@ -364,7 +372,7 @@ func TestMergeNodeImage(t *testing.T) {
 		},
 		{
 			name:         "cluster image only",
-			clusterImage: "custom/garage:v3.0.0",
+			clusterImage: testImageFull2,
 			expected:     "custom/garage:v3.0.0",
 		},
 		{
@@ -381,7 +389,7 @@ func TestMergeNodeImage(t *testing.T) {
 		{
 			name:         "node imageRepository overrides cluster image",
 			clusterImage: "cluster/garage:v3.0.0",
-			nodeRepo:     "node-mirror/garage",
+			nodeRepo:     testNodeImageRepo,
 			expected:     "node-mirror/garage:" + defaultGarageTag,
 		},
 		{
@@ -395,7 +403,7 @@ func TestMergeNodeImage(t *testing.T) {
 			clusterImage: "cluster/garage:v1.0.0",
 			clusterRepo:  "cluster-mirror/garage",
 			nodeImage:    "node/garage:latest",
-			nodeRepo:     "node-mirror/garage",
+			nodeRepo:     testNodeImageRepo,
 			expected:     "node/garage:latest",
 		},
 		{
@@ -608,7 +616,7 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 					Data: &garagev1alpha1.DataStorageConfig{
 						Paths: []garagev1alpha1.DataPath{
 							{
-								Path:     "/data/data",
+								Path:     dataPath,
 								Capacity: ptrQuantity(resource.MustParse("100Gi")),
 								Volume: &garagev1alpha1.VolumeConfig{
 									Size:             ptrQuantity(resource.MustParse("100Gi")),

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -32,6 +32,7 @@ const (
 	dataVolumeName     = "data"
 	testClusterName    = "test-cluster"
 	testStorageClass   = "fast-ssd"
+	testIPv4Addr       = "10.0.0.1"
 )
 
 func TestResolveSecretConfig(t *testing.T) {
@@ -780,7 +781,7 @@ func TestFindNodeByIPs(t *testing.T) {
 			nodes: []garage.NodeInfo{
 				{ID: "aaa", Address: addr("10.0.0.1:3901"), IsUp: true, LastSeenSecsAgo: &u64},
 			},
-			podIPs: []string{"10.0.0.1"},
+			podIPs: []string{testIPv4Addr},
 			wantID: "aaa", wantOK: true,
 		},
 		{
@@ -796,13 +797,13 @@ func TestFindNodeByIPs(t *testing.T) {
 			nodes: []garage.NodeInfo{
 				{ID: "ccc", Address: nil, IsUp: true, LastSeenSecsAgo: nil},
 			},
-			podIPs: []string{"10.0.0.1"},
+			podIPs: []string{testIPv4Addr},
 			wantOK: false,
 		},
 		{
 			name:   "no match in empty list",
 			nodes:  []garage.NodeInfo{},
-			podIPs: []string{"10.0.0.1"},
+			podIPs: []string{testIPv4Addr},
 			wantOK: false,
 		},
 	}
@@ -900,7 +901,7 @@ func TestRPCAddr(t *testing.T) {
 		port int32
 		want string
 	}{
-		{"ipv4", "10.0.0.1", 3901, "10.0.0.1:3901"},
+		{"ipv4", testIPv4Addr, 3901, "10.0.0.1:3901"},
 		{"ipv6", "2a14:abcd::5d92", 3901, "[2a14:abcd::5d92]:3901"},
 		{"ipv6 loopback", "::1", 3901, "[::1]:3901"},
 	}

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -112,7 +112,7 @@ func (r *GarageClusterReconciler) buildServiceMonitor(cluster *garagev1alpha1.Ga
 			// jobLabel tells Prometheus to use the value of app.kubernetes.io/name
 			// from the scraped Service as the job label — produces job="garage",
 			// which matches the official Garage Grafana dashboard queries.
-			JobLabel: "app.kubernetes.io/name",
+			JobLabel: labelAppName,
 			Selector: metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	adminPortName     = "admin"
-	metricsPath       = "/metrics"
-	metricsTokenKey   = "metrics-token"
-	labelCluster      = "garage.rajsingh.info/cluster"
+	adminPortName   = "admin"
+	metricsPath     = "/metrics"
+	metricsTokenKey = "metrics-token"
+	labelCluster    = "garage.rajsingh.info/cluster"
 )
 
 // reconcileMonitoring creates or deletes the ServiceMonitor for the cluster's admin port.

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	adminPortName = "admin"
-	metricsPath   = "/metrics"
+	adminPortName     = "admin"
+	metricsPath       = "/metrics"
+	metricsTokenKey   = "metrics-token"
+	labelCluster      = "garage.rajsingh.info/cluster"
 )
 
 // reconcileMonitoring creates or deletes the ServiceMonitor for the cluster's admin port.
@@ -88,7 +90,7 @@ func (r *GarageClusterReconciler) buildServiceMonitor(cluster *garagev1alpha1.Ga
 		ref := cluster.Spec.Admin.MetricsTokenSecretRef
 		key := ref.Key
 		if key == "" {
-			key = "metrics-token"
+			key = metricsTokenKey
 		}
 		endpoint.Authorization = &monitoringv1.SafeAuthorization{
 			Type: "Bearer",
@@ -116,7 +118,7 @@ func (r *GarageClusterReconciler) buildServiceMonitor(cluster *garagev1alpha1.Ga
 			Selector: metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{
-						Key:      "garage.rajsingh.info/cluster",
+						Key:      labelCluster,
 						Operator: metav1.LabelSelectorOpIn,
 						Values:   []string{cluster.Name},
 					},

--- a/internal/cosi/errors_test.go
+++ b/internal/cosi/errors_test.go
@@ -33,13 +33,13 @@ func TestMapGarageErrorToCOSI(t *testing.T) {
 		wantCode codes.Code
 	}{
 		{
-			name:     "not found",
-			err:      &garage.APIError{StatusCode: 404, Message: "not found"},
+			name:     testNotFound,
+			err:      &garage.APIError{StatusCode: 404, Message: testNotFound},
 			wantCode: codes.NotFound,
 		},
 		{
-			name:     "conflict",
-			err:      &garage.APIError{StatusCode: 409, Message: "conflict"},
+			name:     testConflictMsg,
+			err:      &garage.APIError{StatusCode: 409, Message: testConflictMsg},
 			wantCode: codes.AlreadyExists,
 		},
 		{

--- a/internal/cosi/parameters.go
+++ b/internal/cosi/parameters.go
@@ -23,6 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// Parameter key constants
+const (
+	paramClusterRef       = "clusterRef"
+	paramClusterNamespace = "clusterNamespace"
+	paramMaxSize          = "maxSize"
+	paramMaxObjects       = "maxObjects"
+	paramWebsiteEnabled   = "websiteEnabled"
+	paramTrue             = "true"
+)
+
 // BucketClassParameters holds parsed BucketClass parameters
 type BucketClassParameters struct {
 	ClusterRef       string
@@ -41,21 +51,21 @@ type BucketAccessClassParameters struct {
 }
 
 var knownBucketClassParams = map[string]struct{}{
-	"clusterRef": {}, "clusterNamespace": {}, "maxSize": {}, "maxObjects": {}, "websiteEnabled": {},
+	paramClusterRef: {}, paramClusterNamespace: {}, paramMaxSize: {}, paramMaxObjects: {}, paramWebsiteEnabled: {},
 }
 
 var knownBucketAccessClassParams = map[string]struct{}{
-	"clusterRef": {}, "clusterNamespace": {},
+	paramClusterRef: {}, paramClusterNamespace: {},
 }
 
 // ParseBucketClassParameters parses BucketClass parameters
 func ParseBucketClassParameters(params map[string]string, defaultNamespace string) (*BucketClassParameters, error) {
-	clusterRef, ok := params["clusterRef"]
+	clusterRef, ok := params[paramClusterRef]
 	if !ok || clusterRef == "" {
 		return nil, fmt.Errorf("required parameter 'clusterRef' not specified")
 	}
 
-	clusterNS := params["clusterNamespace"]
+	clusterNS := params[paramClusterNamespace]
 	if clusterNS == "" {
 		clusterNS = defaultNamespace
 	}
@@ -65,7 +75,7 @@ func ParseBucketClassParameters(params map[string]string, defaultNamespace strin
 		ClusterNamespace: clusterNS,
 	}
 
-	if maxSize, ok := params["maxSize"]; ok {
+	if maxSize, ok := params[paramMaxSize]; ok {
 		q, err := resource.ParseQuantity(maxSize)
 		if err != nil {
 			return nil, fmt.Errorf("invalid maxSize: %w", err)
@@ -73,7 +83,7 @@ func ParseBucketClassParameters(params map[string]string, defaultNamespace strin
 		p.MaxSize = &q
 	}
 
-	if maxObjects, ok := params["maxObjects"]; ok {
+	if maxObjects, ok := params[paramMaxObjects]; ok {
 		n, err := strconv.ParseInt(maxObjects, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid maxObjects: %w", err)
@@ -81,8 +91,8 @@ func ParseBucketClassParameters(params map[string]string, defaultNamespace strin
 		p.MaxObjects = &n
 	}
 
-	if websiteEnabled, ok := params["websiteEnabled"]; ok {
-		p.WebsiteEnabled = websiteEnabled == "true"
+	if websiteEnabled, ok := params[paramWebsiteEnabled]; ok {
+		p.WebsiteEnabled = websiteEnabled == paramTrue
 	}
 
 	for k := range params {
@@ -96,12 +106,12 @@ func ParseBucketClassParameters(params map[string]string, defaultNamespace strin
 
 // ParseBucketAccessClassParameters parses BucketAccessClass parameters
 func ParseBucketAccessClassParameters(params map[string]string, defaultNamespace string) (*BucketAccessClassParameters, error) {
-	clusterRef, ok := params["clusterRef"]
+	clusterRef, ok := params[paramClusterRef]
 	if !ok || clusterRef == "" {
 		return nil, fmt.Errorf("required parameter 'clusterRef' not specified")
 	}
 
-	clusterNS := params["clusterNamespace"]
+	clusterNS := params[paramClusterNamespace]
 	if clusterNS == "" {
 		clusterNS = defaultNamespace
 	}

--- a/internal/cosi/parameters_test.go
+++ b/internal/cosi/parameters_test.go
@@ -34,18 +34,18 @@ func TestParseBucketClassParameters(t *testing.T) {
 		{
 			name: "valid with namespace",
 			params: map[string]string{
-				"clusterRef":       "my-cluster",
-				"clusterNamespace": "garage-system",
+				testClusterRef:       testMyCluster,
+				testClusterNamespace: testGarageSystem,
 			},
-			wantCluster: "my-cluster",
-			wantNS:      "garage-system",
+			wantCluster: testMyCluster,
+			wantNS:      testGarageSystem,
 		},
 		{
 			name: "valid without namespace uses default",
 			params: map[string]string{
-				"clusterRef": "my-cluster",
+				testClusterRef: testMyCluster,
 			},
-			wantCluster: "my-cluster",
+			wantCluster: testMyCluster,
 			wantNS:      "default",
 		},
 		{
@@ -80,18 +80,18 @@ func TestParseBucketAccessClassParameters(t *testing.T) {
 		{
 			name: "valid with namespace",
 			params: map[string]string{
-				"clusterRef":       "my-cluster",
-				"clusterNamespace": "garage-system",
+				testClusterRef:       testMyCluster,
+				testClusterNamespace: testGarageSystem,
 			},
-			wantCluster: "my-cluster",
-			wantNS:      "garage-system",
+			wantCluster: testMyCluster,
+			wantNS:      testGarageSystem,
 		},
 		{
 			name: "valid without namespace uses default",
 			params: map[string]string{
-				"clusterRef": "my-cluster",
+				testClusterRef: testMyCluster,
 			},
-			wantCluster: "my-cluster",
+			wantCluster: testMyCluster,
 			wantNS:      "default",
 		},
 		{
@@ -117,9 +117,9 @@ func TestParseBucketAccessClassParameters(t *testing.T) {
 
 func TestParseBucketClassParameters_UnknownParams(t *testing.T) {
 	params, err := ParseBucketClassParameters(map[string]string{
-		"clusterRef": "my-cluster",
-		"unknownKey": "somevalue",
-		"anotherKey": "anothervalue",
+		testClusterRef: testMyCluster,
+		"unknownKey":   "somevalue",
+		"anotherKey":   "anothervalue",
 	}, "default")
 	require.NoError(t, err)
 	require.Len(t, params.UnknownParams, 2)
@@ -129,8 +129,8 @@ func TestParseBucketClassParameters_UnknownParams(t *testing.T) {
 
 func TestParseBucketAccessClassParameters_UnknownParams(t *testing.T) {
 	params, err := ParseBucketAccessClassParameters(map[string]string{
-		"clusterRef": "my-cluster",
-		"extra":      "ignored",
+		testClusterRef: testMyCluster,
+		"extra":        "ignored",
 	}, "default")
 	require.NoError(t, err)
 	require.Len(t, params.UnknownParams, 1)

--- a/internal/cosi/provisioner_test.go
+++ b/internal/cosi/provisioner_test.go
@@ -37,6 +37,26 @@ import (
 	cosiproto "sigs.k8s.io/container-object-storage-interface/proto"
 )
 
+const (
+	testGarageAccessKeyID = "GKtest-access"
+	testGarageSystem      = "garage-system"
+	testClusterRef        = paramClusterRef
+	testClusterNamespace  = paramClusterNamespace
+	testBucketNotFound    = "bucket not found"
+	testNotFound          = "not found"
+	testConflictMsg       = "conflict"
+	testGKTestKey         = "GKtest-key"
+	testExistingSecret    = "existing-secret"
+	testBucket1           = "bucket-1"
+	testExistingBucketID  = "existing-bucket-id"
+	testMyCluster         = "my-cluster"
+	testBucketName        = "test-bucket"
+	testAccountName       = "test-access"
+	testBucketID          = "test-bucket-id"
+	testMyBucket          = "my-bucket"
+	testParamMaxSize      = paramMaxSize
+)
+
 // mockGarageClient implements GarageClient for testing
 type mockGarageClient struct {
 	buckets map[string]*garage.Bucket
@@ -92,13 +112,13 @@ func (m *mockGarageClient) GetBucket(ctx context.Context, req garage.GetBucketRe
 			}
 		}
 	}
-	return nil, &garage.APIError{StatusCode: 404, Message: "bucket not found"}
+	return nil, &garage.APIError{StatusCode: 404, Message: testBucketNotFound}
 }
 
 func (m *mockGarageClient) UpdateBucket(ctx context.Context, req garage.UpdateBucketRequest) (*garage.Bucket, error) {
 	bucket, ok := m.buckets[req.ID]
 	if !ok {
-		return nil, &garage.APIError{StatusCode: 404, Message: "bucket not found"}
+		return nil, &garage.APIError{StatusCode: 404, Message: testBucketNotFound}
 	}
 	if req.Body.Quotas != nil {
 		bucket.Quotas = req.Body.Quotas
@@ -161,7 +181,7 @@ func (m *mockGarageClient) AllowBucketKey(ctx context.Context, req garage.AllowB
 	}
 	bucket, ok := m.buckets[req.BucketID]
 	if !ok {
-		return nil, &garage.APIError{StatusCode: 404, Message: "bucket not found"}
+		return nil, &garage.APIError{StatusCode: 404, Message: testBucketNotFound}
 	}
 	// Add key to bucket's key list
 	if key, ok := m.keys[req.AccessKeyID]; ok {
@@ -180,7 +200,7 @@ func (m *mockGarageClient) DenyBucketKey(ctx context.Context, req garage.DenyBuc
 	}
 	bucket, ok := m.buckets[req.BucketID]
 	if !ok {
-		return nil, &garage.APIError{StatusCode: 404, Message: "bucket not found"}
+		return nil, &garage.APIError{StatusCode: 404, Message: testBucketNotFound}
 	}
 	return bucket, nil
 }
@@ -191,9 +211,9 @@ func createShadowBucket(bucketID, globalAlias string) *garagev1alpha1.GarageBuck
 	return &garagev1alpha1.GarageBucket{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shadow-" + bucketID,
-			Namespace: "garage-system",
+			Namespace: testGarageSystem,
 			Labels: map[string]string{
-				LabelCOSIManaged:  "true",
+				LabelCOSIManaged:  paramTrue,
 				LabelCOSIBucketID: truncateLabelValue(bucketID),
 			},
 			Annotations: map[string]string{
@@ -210,8 +230,8 @@ func createShadowBucket(bucketID, globalAlias string) *garagev1alpha1.GarageBuck
 func createReadyCluster() *garagev1alpha1.GarageCluster {
 	return &garagev1alpha1.GarageCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-cluster",
-			Namespace: "garage-system",
+			Name:      testMyCluster,
+			Namespace: testGarageSystem,
 		},
 		Spec: garagev1alpha1.GarageClusterSpec{},
 		Status: garagev1alpha1.GarageClusterStatus{
@@ -234,10 +254,10 @@ func newTestScheme() *runtime.Scheme {
 
 func TestProvisionerServer_DriverCreateBucket_MissingClusterRef(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverCreateBucketRequest{
-		Name:       "test-bucket",
+		Name:       testBucketName,
 		Parameters: map[string]string{}, // Missing clusterRef
 	}
 
@@ -251,13 +271,13 @@ func TestProvisionerServer_DriverCreateBucket_MissingClusterRef(t *testing.T) {
 
 func TestProvisionerServer_DriverCreateBucket_ClusterNotFound(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverCreateBucketRequest{
-		Name: "test-bucket",
+		Name: testBucketName,
 		Parameters: map[string]string{
-			"clusterRef":       "nonexistent",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       "nonexistent",
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -272,8 +292,8 @@ func TestProvisionerServer_DriverCreateBucket_ClusterNotFound(t *testing.T) {
 func TestProvisionerServer_DriverCreateBucket_ClusterNotReady(t *testing.T) {
 	cluster := &garagev1alpha1.GarageCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-cluster",
-			Namespace: "garage-system",
+			Name:      testMyCluster,
+			Namespace: testGarageSystem,
 		},
 		Spec: garagev1alpha1.GarageClusterSpec{},
 		Status: garagev1alpha1.GarageClusterStatus{
@@ -282,13 +302,13 @@ func TestProvisionerServer_DriverCreateBucket_ClusterNotReady(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverCreateBucketRequest{
-		Name: "test-bucket",
+		Name: testBucketName,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -302,18 +322,18 @@ func TestProvisionerServer_DriverCreateBucket_ClusterNotReady(t *testing.T) {
 
 func TestProvisionerServer_DriverGrantBucketAccess_ServiceAccountRejected(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_SERVICE_ACCOUNT,
 		},
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -327,12 +347,12 @@ func TestProvisionerServer_DriverGrantBucketAccess_ServiceAccountRejected(t *tes
 
 func TestProvisionerServer_DriverGrantBucketAccess_MissingClusterRef(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
@@ -350,16 +370,16 @@ func TestProvisionerServer_DriverGrantBucketAccess_MissingClusterRef(t *testing.
 
 func TestProvisionerServer_DriverGrantBucketAccess_NoBuckets(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets:     []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{}, // Empty
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -382,13 +402,13 @@ func TestProvisionerServer_DriverCreateBucket_Success(t *testing.T) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverCreateBucketRequest{
-		Name: "test-bucket",
+		Name: testBucketName,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -402,7 +422,7 @@ func TestProvisionerServer_DriverCreateBucket_Success(t *testing.T) {
 
 	// Verify Garage client was called
 	require.Len(t, mockClient.createBucketCalls, 1)
-	assert.Equal(t, "test-bucket", mockClient.createBucketCalls[0].GlobalAlias)
+	assert.Equal(t, testBucketName, mockClient.createBucketCalls[0].GlobalAlias)
 }
 
 func TestProvisionerServer_DriverDeleteBucket_Success(t *testing.T) {
@@ -410,19 +430,19 @@ func TestProvisionerServer_DriverDeleteBucket_Success(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverDeleteBucketRequest{
-		BucketId: "test-bucket-id",
+		BucketId: testBucketID,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -432,34 +452,34 @@ func TestProvisionerServer_DriverDeleteBucket_Success(t *testing.T) {
 
 	// Verify Garage client was called
 	require.Len(t, mockClient.deleteBucketCalls, 1)
-	assert.Equal(t, "test-bucket-id", mockClient.deleteBucketCalls[0])
+	assert.Equal(t, testBucketID, mockClient.deleteBucketCalls[0])
 }
 
 func TestProvisionerServer_DriverGrantBucketAccess_Success(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("test-bucket-id", "test-bucket")
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -477,15 +497,15 @@ func TestProvisionerServer_DriverGrantBucketAccess_Success(t *testing.T) {
 
 	// Verify bucket info
 	require.Len(t, resp.Buckets, 1)
-	assert.Equal(t, "test-bucket-id", resp.Buckets[0].BucketId)
+	assert.Equal(t, testBucketID, resp.Buckets[0].BucketId)
 	assert.NotNil(t, resp.Buckets[0].BucketInfo)
 	assert.NotNil(t, resp.Buckets[0].BucketInfo.S3)
-	assert.Equal(t, "test-bucket", resp.Buckets[0].BucketInfo.S3.BucketId)
+	assert.Equal(t, testBucketName, resp.Buckets[0].BucketInfo.S3.BucketId)
 
 	// Verify Garage client was called
 	require.Len(t, mockClient.createKeyCalls, 1)
 	require.Len(t, mockClient.allowBucketKeyCalls, 1)
-	assert.Equal(t, "test-bucket-id", mockClient.allowBucketKeyCalls[0].BucketID)
+	assert.Equal(t, testBucketID, mockClient.allowBucketKeyCalls[0].BucketID)
 }
 
 func TestProvisionerServer_DriverRevokeBucketAccess_Success(t *testing.T) {
@@ -493,23 +513,23 @@ func TestProvisionerServer_DriverRevokeBucketAccess_Success(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
-	mockClient.keys["GKtest-key"] = &garage.Key{AccessKeyID: "GKtest-key"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
+	mockClient.keys[testGKTestKey] = &garage.Key{AccessKeyID: testGKTestKey}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverRevokeBucketAccessRequest{
-		AccountId: "GKtest-key",
+		AccountId: testGKTestKey,
 		Buckets: []*cosiproto.DriverRevokeBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -519,29 +539,29 @@ func TestProvisionerServer_DriverRevokeBucketAccess_Success(t *testing.T) {
 
 	// Verify Garage client was called
 	require.Len(t, mockClient.denyBucketKeyCalls, 1)
-	assert.Equal(t, "test-bucket-id", mockClient.denyBucketKeyCalls[0].BucketID)
-	assert.Equal(t, "GKtest-key", mockClient.denyBucketKeyCalls[0].AccessKeyID)
+	assert.Equal(t, testBucketID, mockClient.denyBucketKeyCalls[0].BucketID)
+	assert.Equal(t, testGKTestKey, mockClient.denyBucketKeyCalls[0].AccessKeyID)
 
 	require.Len(t, mockClient.deleteKeyCalls, 1)
-	assert.Equal(t, "GKtest-key", mockClient.deleteKeyCalls[0])
+	assert.Equal(t, testGKTestKey, mockClient.deleteKeyCalls[0])
 }
 
 // === Idempotency Tests ===
 
 func TestProvisionerServer_DriverGrantBucketAccess_Idempotent(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("test-bucket-id", "test-bucket")
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 	// Pre-existing key with the same name
-	mockClient.keys["GKtest-access"] = &garage.Key{
-		AccessKeyID:     "GKtest-access",
-		SecretAccessKey: "existing-secret",
-		Name:            "test-access",
+	mockClient.keys[testGarageAccessKeyID] = &garage.Key{
+		AccessKeyID:     testGarageAccessKeyID,
+		SecretAccessKey: testExistingSecret,
+		Name:            testAccountName,
 		Buckets: []garage.KeyBucket{
-			{ID: "test-bucket-id", Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+			{ID: testBucketID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
 		},
 	}
 
@@ -549,27 +569,27 @@ func TestProvisionerServer_DriverGrantBucketAccess_Idempotent(t *testing.T) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
 	resp, err := server.DriverGrantBucketAccess(context.Background(), req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "GKtest-access", resp.AccountId)
-	assert.Equal(t, "existing-secret", resp.Credentials.S3.AccessSecretKey)
+	assert.Equal(t, testGarageAccessKeyID, resp.AccountId)
+	assert.Equal(t, testExistingSecret, resp.Credentials.S3.AccessSecretKey)
 
 	// Should NOT create a new key (idempotent)
 	assert.Len(t, mockClient.createKeyCalls, 0)
@@ -580,19 +600,19 @@ func TestProvisionerServer_DriverDeleteBucket_NotFound(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.deleteBucketErr = &garage.APIError{StatusCode: 404, Message: "not found"}
+	mockClient.deleteBucketErr = &garage.APIError{StatusCode: 404, Message: testNotFound}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverDeleteBucketRequest{
 		BucketId: "nonexistent-bucket",
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -605,13 +625,13 @@ func TestProvisionerServer_DriverDeleteBucket_NotFound(t *testing.T) {
 
 func TestProvisionerServer_DriverGrantBucketAccess_MultiBucket(t *testing.T) {
 	cluster := createReadyCluster()
-	shadow1 := createShadowBucket("bucket-1", "alias-bucket-1")
+	shadow1 := createShadowBucket(testBucket1, "alias-bucket-1")
 	shadow2 := createShadowBucket("bucket-2", "alias-bucket-2")
 	shadow3 := createShadowBucket("bucket-3", "alias-bucket-3")
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadow1, shadow2, shadow3).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["bucket-1"] = &garage.Bucket{ID: "bucket-1"}
+	mockClient.buckets[testBucket1] = &garage.Bucket{ID: testBucket1}
 	mockClient.buckets["bucket-2"] = &garage.Bucket{ID: "bucket-2"}
 	mockClient.buckets["bucket-3"] = &garage.Bucket{ID: "bucket-3"}
 
@@ -619,12 +639,12 @@ func TestProvisionerServer_DriverGrantBucketAccess_MultiBucket(t *testing.T) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
 		AccountName: "multi-bucket-access",
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "bucket-1"},
+			{BucketId: testBucket1},
 			{BucketId: "bucket-2"},
 			{BucketId: "bucket-3"},
 		},
@@ -632,8 +652,8 @@ func TestProvisionerServer_DriverGrantBucketAccess_MultiBucket(t *testing.T) {
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -649,7 +669,7 @@ func TestProvisionerServer_DriverGrantBucketAccess_MultiBucket(t *testing.T) {
 		require.NotNil(t, b.BucketInfo)
 		require.NotNil(t, b.BucketInfo.S3)
 	}
-	assert.True(t, bucketIDs["bucket-1"])
+	assert.True(t, bucketIDs[testBucket1])
 	assert.True(t, bucketIDs["bucket-2"])
 	assert.True(t, bucketIDs["bucket-3"])
 
@@ -673,7 +693,7 @@ func TestProvisionerServer_DriverGrantBucketAccess_AccessModes(t *testing.T) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
 		AccountName: "access-modes-test",
@@ -686,8 +706,8 @@ func TestProvisionerServer_DriverGrantBucketAccess_AccessModes(t *testing.T) {
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -718,12 +738,12 @@ func TestProvisionerServer_DriverGrantBucketAccess_AccessModes(t *testing.T) {
 
 func TestProvisionerServer_DriverGrantBucketAccess_UnsupportedProtocol(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
@@ -732,7 +752,7 @@ func TestProvisionerServer_DriverGrantBucketAccess_UnsupportedProtocol(t *testin
 			Type: cosiproto.ObjectProtocol_AZURE,
 		},
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -746,22 +766,22 @@ func TestProvisionerServer_DriverGrantBucketAccess_UnsupportedProtocol(t *testin
 
 func TestProvisionerServer_DriverGrantBucketAccess_S3ProtocolAllowed(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("test-bucket-id", "test-bucket")
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
@@ -770,8 +790,8 @@ func TestProvisionerServer_DriverGrantBucketAccess_S3ProtocolAllowed(t *testing.
 			Type: cosiproto.ObjectProtocol_S3,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -782,36 +802,36 @@ func TestProvisionerServer_DriverGrantBucketAccess_S3ProtocolAllowed(t *testing.
 
 func TestProvisionerServer_DriverGetExistingBucket_Success(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("existing-bucket-id", "my-bucket")
+	shadowBucket := createShadowBucket(testExistingBucketID, testMyBucket)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["existing-bucket-id"] = &garage.Bucket{
-		ID:            "existing-bucket-id",
-		GlobalAliases: []string{"my-bucket"},
+	mockClient.buckets[testExistingBucketID] = &garage.Bucket{
+		ID:            testExistingBucketID,
+		GlobalAliases: []string{testMyBucket},
 	}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGetExistingBucketRequest{
-		ExistingBucketId: "existing-bucket-id",
+		ExistingBucketId: testExistingBucketID,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
 	resp, err := server.DriverGetExistingBucket(context.Background(), req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "existing-bucket-id", resp.BucketId)
+	assert.Equal(t, testExistingBucketID, resp.BucketId)
 	require.NotNil(t, resp.Protocols)
 	require.NotNil(t, resp.Protocols.S3)
-	assert.Equal(t, "my-bucket", resp.Protocols.S3.BucketId)
+	assert.Equal(t, testMyBucket, resp.Protocols.S3.BucketId)
 	assert.Equal(t, "http://garage.test:3900", resp.Protocols.S3.Endpoint)
 }
 
@@ -825,13 +845,13 @@ func TestProvisionerServer_DriverGetExistingBucket_NotFound(t *testing.T) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGetExistingBucketRequest{
 		ExistingBucketId: "nonexistent-id",
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
@@ -845,12 +865,12 @@ func TestProvisionerServer_DriverGetExistingBucket_NotFound(t *testing.T) {
 
 func TestProvisionerServer_DriverGetExistingBucket_MissingID(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverGetExistingBucketRequest{
 		ExistingBucketId: "",
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -871,27 +891,27 @@ func TestProvisionerServer_DriverCreateBucket_IdempotentMismatch(t *testing.T) {
 	// Pre-populate a bucket with specific quotas
 	mockClient.buckets["bucket-test-bucket"] = &garage.Bucket{
 		ID:            "bucket-test-bucket",
-		GlobalAliases: []string{"test-bucket"},
+		GlobalAliases: []string{testBucketName},
 		Quotas: &garage.BucketQuotas{
 			MaxSize: &existingSize,
 		},
 	}
 	// CreateBucket will return conflict since the bucket exists
-	mockClient.createBucketErr = &garage.APIError{StatusCode: 409, Message: "conflict"}
+	mockClient.createBucketErr = &garage.APIError{StatusCode: 409, Message: testConflictMsg}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	differentSize := resource.MustParse("2000")
 	req := &cosiproto.DriverCreateBucketRequest{
-		Name: "test-bucket",
+		Name: testBucketName,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
-			"maxSize":          "5000",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
+			testParamMaxSize:     "5000",
 		},
 	}
 	_ = differentSize // just to validate it parses
@@ -906,32 +926,32 @@ func TestProvisionerServer_DriverCreateBucket_IdempotentMismatch(t *testing.T) {
 
 func TestProvisionerServer_DriverCreateBucket_IdempotentMatch(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("bucket-test-bucket", "test-bucket")
+	shadowBucket := createShadowBucket("bucket-test-bucket", testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	existingSize := uint64(5000)
 	mockClient := newMockGarageClient()
 	mockClient.buckets["bucket-test-bucket"] = &garage.Bucket{
 		ID:            "bucket-test-bucket",
-		GlobalAliases: []string{"test-bucket"},
+		GlobalAliases: []string{testBucketName},
 		Quotas: &garage.BucketQuotas{
 			MaxSize: &existingSize,
 		},
 	}
-	mockClient.createBucketErr = &garage.APIError{StatusCode: 409, Message: "conflict"}
+	mockClient.createBucketErr = &garage.APIError{StatusCode: 409, Message: testConflictMsg}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverCreateBucketRequest{
-		Name: "test-bucket",
+		Name: testBucketName,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
-			"maxSize":          "5000",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
+			testParamMaxSize:     "5000",
 		},
 	}
 
@@ -942,8 +962,8 @@ func TestProvisionerServer_DriverCreateBucket_IdempotentMatch(t *testing.T) {
 }
 
 func TestSanitizeBucketName_Short(t *testing.T) {
-	name := "my-bucket"
-	assert.Equal(t, "my-bucket", sanitizeBucketName(name))
+	name := testMyBucket
+	assert.Equal(t, testMyBucket, sanitizeBucketName(name))
 }
 
 func TestSanitizeBucketName_ExactlyMax(t *testing.T) {
@@ -981,12 +1001,12 @@ func TestSanitizeBucketName_DifferentLongNamesProduceDifferentResults(t *testing
 
 func TestProvisionerServer_DriverCreateBucket_EmptyName(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverCreateBucketRequest{
 		Name: "",
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -1000,18 +1020,18 @@ func TestProvisionerServer_DriverCreateBucket_EmptyName(t *testing.T) {
 
 func TestProvisionerServer_DriverGrantBucketAccess_EmptyAccountName(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
 		AccountName: "",
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -1026,8 +1046,8 @@ func TestProvisionerServer_DriverGrantBucketAccess_EmptyAccountName(t *testing.T
 func TestProvisionerServer_GetS3Endpoint_NilEndpoints(t *testing.T) {
 	cluster := &garagev1alpha1.GarageCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-cluster",
-			Namespace: "garage-system",
+			Name:      testMyCluster,
+			Namespace: testGarageSystem,
 		},
 		Spec: garagev1alpha1.GarageClusterSpec{},
 		Status: garagev1alpha1.GarageClusterStatus{
@@ -1036,30 +1056,30 @@ func TestProvisionerServer_GetS3Endpoint_NilEndpoints(t *testing.T) {
 		},
 	}
 
-	shadowBucket := createShadowBucket("test-bucket-id", "test-bucket")
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 
 	factory := func(ctx context.Context, c client.Client, cluster *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	// This should NOT panic even with nil Endpoints
 	req := &cosiproto.DriverGetExistingBucketRequest{
-		ExistingBucketId: "test-bucket-id",
+		ExistingBucketId: testBucketID,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
 	resp, err := server.DriverGetExistingBucket(context.Background(), req)
 	require.NoError(t, err)
-	assert.Equal(t, "test-bucket-id", resp.BucketId)
+	assert.Equal(t, testBucketID, resp.BucketId)
 	// Should fall back to constructing endpoint from service
 	assert.Contains(t, resp.Protocols.S3.Endpoint, "my-cluster.garage-system.svc.cluster.local")
 }
@@ -1091,18 +1111,18 @@ func TestSanitizeKeyName_DifferentLongNamesProduceDifferentResults(t *testing.T)
 
 func TestProvisionerServer_DriverGrantBucketAccess_IdempotentUpdatesPermissions(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("test-bucket-id", "test-bucket")
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 	// Pre-existing key with READ_WRITE permissions
-	mockClient.keys["GKtest-access"] = &garage.Key{
-		AccessKeyID:     "GKtest-access",
-		SecretAccessKey: "existing-secret",
-		Name:            "test-access",
+	mockClient.keys[testGarageAccessKeyID] = &garage.Key{
+		AccessKeyID:     testGarageAccessKeyID,
+		SecretAccessKey: testExistingSecret,
+		Name:            testAccountName,
 		Buckets: []garage.KeyBucket{
-			{ID: "test-bucket-id", Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+			{ID: testBucketID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
 		},
 	}
 
@@ -1110,52 +1130,52 @@ func TestProvisionerServer_DriverGrantBucketAccess_IdempotentUpdatesPermissions(
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	// Request READ_ONLY -- should update even though key already has access
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id", AccessMode: &cosiproto.AccessMode{Mode: cosiproto.AccessMode_READ_ONLY}},
+			{BucketId: testBucketID, AccessMode: &cosiproto.AccessMode{Mode: cosiproto.AccessMode_READ_ONLY}},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
 	resp, err := server.DriverGrantBucketAccess(context.Background(), req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "GKtest-access", resp.AccountId)
+	assert.Equal(t, testGarageAccessKeyID, resp.AccountId)
 
 	// Should NOT create a new key (idempotent)
 	assert.Len(t, mockClient.createKeyCalls, 0)
 
 	// Should have called AllowBucketKey to update permissions
 	require.Len(t, mockClient.allowBucketKeyCalls, 1)
-	assert.Equal(t, "test-bucket-id", mockClient.allowBucketKeyCalls[0].BucketID)
+	assert.Equal(t, testBucketID, mockClient.allowBucketKeyCalls[0].BucketID)
 	assert.True(t, mockClient.allowBucketKeyCalls[0].Permissions.Read)
 	assert.False(t, mockClient.allowBucketKeyCalls[0].Permissions.Write, "should have updated to READ_ONLY")
 }
 
 func TestProvisionerServer_DriverGrantBucketAccess_IdempotentSkipsMatchingPermissions(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("test-bucket-id", "test-bucket")
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 	// Pre-existing key with READ_ONLY permissions - matches what we'll request
-	mockClient.keys["GKtest-access"] = &garage.Key{
-		AccessKeyID:     "GKtest-access",
-		SecretAccessKey: "existing-secret",
-		Name:            "test-access",
+	mockClient.keys[testGarageAccessKeyID] = &garage.Key{
+		AccessKeyID:     testGarageAccessKeyID,
+		SecretAccessKey: testExistingSecret,
+		Name:            testAccountName,
 		Buckets: []garage.KeyBucket{
-			{ID: "test-bucket-id", Permissions: garage.BucketKeyPerms{Read: true, Write: false}},
+			{ID: testBucketID, Permissions: garage.BucketKeyPerms{Read: true, Write: false}},
 		},
 	}
 
@@ -1163,26 +1183,26 @@ func TestProvisionerServer_DriverGrantBucketAccess_IdempotentSkipsMatchingPermis
 		return mockClient, nil
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", factory)
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, factory)
 
 	req := &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName: "test-access",
+		AccountName: testAccountName,
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id", AccessMode: &cosiproto.AccessMode{Mode: cosiproto.AccessMode_READ_ONLY}},
+			{BucketId: testBucketID, AccessMode: &cosiproto.AccessMode{Mode: cosiproto.AccessMode_READ_ONLY}},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	}
 
 	resp, err := server.DriverGrantBucketAccess(context.Background(), req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "GKtest-access", resp.AccountId)
+	assert.Equal(t, testGarageAccessKeyID, resp.AccountId)
 
 	// Should NOT call AllowBucketKey since permissions already match
 	assert.Len(t, mockClient.allowBucketKeyCalls, 0)
@@ -1190,12 +1210,12 @@ func TestProvisionerServer_DriverGrantBucketAccess_IdempotentSkipsMatchingPermis
 
 func TestProvisionerServer_DriverDeleteBucket_EmptyBucketId(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverDeleteBucketRequest{
 		BucketId: "",
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -1209,15 +1229,15 @@ func TestProvisionerServer_DriverDeleteBucket_EmptyBucketId(t *testing.T) {
 
 func TestProvisionerServer_DriverRevokeBucketAccess_EmptyAccountId(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-	server := NewProvisionerServer(fakeClient, "garage-system", "cluster.local")
+	server := NewProvisionerServer(fakeClient, testGarageSystem, "cluster.local")
 
 	req := &cosiproto.DriverRevokeBucketAccessRequest{
 		AccountId: "",
 		Buckets: []*cosiproto.DriverRevokeBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		Parameters: map[string]string{
-			"clusterRef": "my-cluster",
+			testClusterRef: testMyCluster,
 		},
 	}
 
@@ -1283,53 +1303,53 @@ func TestProvisionerServer_DriverGetExistingBucket_NoShadow_FallsBackToGarageAli
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["existing-bucket-id"] = &garage.Bucket{
-		ID:            "existing-bucket-id",
+	mockClient.buckets[testExistingBucketID] = &garage.Bucket{
+		ID:            testExistingBucketID,
 		GlobalAliases: []string{"my-existing-bucket"},
 	}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", func(_ context.Context, _ client.Client, _ *garagev1alpha1.GarageCluster) (GarageClient, error) {
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, func(_ context.Context, _ client.Client, _ *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	})
 
 	resp, err := server.DriverGetExistingBucket(context.Background(), &cosiproto.DriverGetExistingBucketRequest{
-		ExistingBucketId: "existing-bucket-id",
+		ExistingBucketId: testExistingBucketID,
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, "existing-bucket-id", resp.BucketId)
+	assert.Equal(t, testExistingBucketID, resp.BucketId)
 	// Should use GlobalAlias from Garage directly
 	assert.Equal(t, "my-existing-bucket", resp.Protocols.S3.BucketId)
 }
 
 func TestProvisionerServer_DriverGrantBucketAccess_StoresServiceAccountName(t *testing.T) {
 	cluster := createReadyCluster()
-	shadowBucket := createShadowBucket("test-bucket-id", "test-bucket")
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", func(_ context.Context, _ client.Client, _ *garagev1alpha1.GarageCluster) (GarageClient, error) {
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, func(_ context.Context, _ client.Client, _ *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	})
 
 	_, err := server.DriverGrantBucketAccess(context.Background(), &cosiproto.DriverGrantBucketAccessRequest{
-		AccountName:        "test-access",
+		AccountName:        testAccountName,
 		ServiceAccountName: "my-sa",
 		Buckets: []*cosiproto.DriverGrantBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 		AuthenticationType: &cosiproto.AuthenticationType{
 			Type: cosiproto.AuthenticationType_KEY,
 		},
 		Parameters: map[string]string{
-			"clusterRef":       "my-cluster",
-			"clusterNamespace": "garage-system",
+			testClusterRef:       testMyCluster,
+			testClusterNamespace: testGarageSystem,
 		},
 	})
 	require.NoError(t, err)
@@ -1346,32 +1366,32 @@ func TestProvisionerServer_DriverRevokeBucketAccess_NoParameters_UsesClusterRefF
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster).Build()
 
 	mockClient := newMockGarageClient()
-	mockClient.buckets["test-bucket-id"] = &garage.Bucket{ID: "test-bucket-id"}
-	mockClient.keys["GKtest-key"] = &garage.Key{AccessKeyID: "GKtest-key"}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
+	mockClient.keys[testGKTestKey] = &garage.Key{AccessKeyID: testGKTestKey}
 
-	server := NewProvisionerServerWithFactory(fakeClient, "garage-system", func(_ context.Context, _ client.Client, _ *garagev1alpha1.GarageCluster) (GarageClient, error) {
+	server := NewProvisionerServerWithFactory(fakeClient, testGarageSystem, func(_ context.Context, _ client.Client, _ *garagev1alpha1.GarageCluster) (GarageClient, error) {
 		return mockClient, nil
 	})
 
 	// Simulate what the sidecar does: create the shadow key first (as grant would)
 	_, err := server.shadowManager.CreateShadowKeyWithID(
-		context.Background(), "test-access", "GKtest-key",
-		"my-cluster", "garage-system",
-		[]BucketPermission{{BucketID: "test-bucket-id", Read: true, Write: true}},
+		context.Background(), testAccountName, testGKTestKey,
+		testMyCluster, "garage-system",
+		[]BucketPermission{{BucketID: testBucketID, Read: true, Write: true}},
 		"",
 	)
 	require.NoError(t, err)
 
 	// Revoke with NO Parameters (as the sidecar actually sends)
 	_, err = server.DriverRevokeBucketAccess(context.Background(), &cosiproto.DriverRevokeBucketAccessRequest{
-		AccountId:  "GKtest-key",
+		AccountId:  testGKTestKey,
 		Parameters: map[string]string{}, // empty — no clusterRef
 		Buckets: []*cosiproto.DriverRevokeBucketAccessRequest_AccessedBucket{
-			{BucketId: "test-bucket-id"},
+			{BucketId: testBucketID},
 		},
 	})
 
 	require.NoError(t, err)
 	require.Len(t, mockClient.deleteKeyCalls, 1)
-	assert.Equal(t, "GKtest-key", mockClient.deleteKeyCalls[0])
+	assert.Equal(t, testGKTestKey, mockClient.deleteKeyCalls[0])
 }

--- a/internal/cosi/shadow.go
+++ b/internal/cosi/shadow.go
@@ -80,7 +80,7 @@ func truncateLabelValue(value string) string {
 // ShadowBucketLabels returns labels for a shadow GarageBucket
 func ShadowBucketLabels(cosiName string) map[string]string {
 	return map[string]string{
-		LabelCOSIManaged:     "true",
+		LabelCOSIManaged:     paramTrue,
 		LabelCOSIBucketClaim: truncateLabelValue(cosiName),
 	}
 }
@@ -88,7 +88,7 @@ func ShadowBucketLabels(cosiName string) map[string]string {
 // ShadowKeyLabels returns labels for a shadow GarageKey
 func ShadowKeyLabels(cosiName string) map[string]string {
 	return map[string]string{
-		LabelCOSIManaged:      "true",
+		LabelCOSIManaged:      paramTrue,
 		LabelCOSIBucketAccess: truncateLabelValue(cosiName),
 	}
 }
@@ -162,7 +162,7 @@ func (m *ShadowManager) CreateShadowBucketWithID(ctx context.Context, cosiName, 
 func (m *ShadowManager) GetShadowBucketNameByID(ctx context.Context, bucketID string) (string, error) {
 	bucketList := &garagev1alpha1.GarageBucketList{}
 	labelSelector := client.MatchingLabels{
-		LabelCOSIManaged:  "true",
+		LabelCOSIManaged:  paramTrue,
 		LabelCOSIBucketID: truncateLabelValue(bucketID),
 	}
 	if err := m.client.List(ctx, bucketList,
@@ -183,7 +183,7 @@ func (m *ShadowManager) GetShadowBucketNameByID(ctx context.Context, bucketID st
 func (m *ShadowManager) GetShadowBucketGlobalAliasByID(ctx context.Context, bucketID string) (string, error) {
 	bucketList := &garagev1alpha1.GarageBucketList{}
 	labelSelector := client.MatchingLabels{
-		LabelCOSIManaged:  "true",
+		LabelCOSIManaged:  paramTrue,
 		LabelCOSIBucketID: truncateLabelValue(bucketID),
 	}
 	if err := m.client.List(ctx, bucketList,
@@ -208,7 +208,7 @@ func (m *ShadowManager) DeleteShadowBucketByID(ctx context.Context, bucketID str
 	// Use label selector for efficient lookup
 	bucketList := &garagev1alpha1.GarageBucketList{}
 	labelSelector := client.MatchingLabels{
-		LabelCOSIManaged:  "true",
+		LabelCOSIManaged:  paramTrue,
 		LabelCOSIBucketID: truncateLabelValue(bucketID),
 	}
 	if err := m.client.List(ctx, bucketList,
@@ -285,7 +285,7 @@ func (m *ShadowManager) DeleteShadowKeyByID(ctx context.Context, accountID strin
 	// Use label selector for efficient lookup
 	keyList := &garagev1alpha1.GarageKeyList{}
 	labelSelector := client.MatchingLabels{
-		LabelCOSIManaged:   "true",
+		LabelCOSIManaged:   paramTrue,
 		LabelCOSIAccountID: truncateLabelValue(accountID),
 	}
 	if err := m.client.List(ctx, keyList,
@@ -313,7 +313,7 @@ func (m *ShadowManager) GetShadowKeyClusterRef(ctx context.Context, accountID st
 	if err = m.client.List(ctx, keyList,
 		client.InNamespace(m.namespace),
 		client.MatchingLabels{
-			LabelCOSIManaged:   "true",
+			LabelCOSIManaged:   paramTrue,
 			LabelCOSIAccountID: truncateLabelValue(accountID),
 		},
 	); err != nil {

--- a/internal/cosi/shadow_test.go
+++ b/internal/cosi/shadow_test.go
@@ -30,7 +30,7 @@ func TestShadowResourceName(t *testing.T) {
 	tests := []struct {
 		cosiName string
 	}{
-		{"my-bucket"},
+		{testMyBucket},
 		{"default-my-bucket"},
 		{"my-very-long-bucket-name-that-exceeds-normal-limits"},
 	}
@@ -75,7 +75,7 @@ func TestCreateShadowKeyWithID_StoresServiceAccountName(t *testing.T) {
 	mgr := NewShadowManager(fakeClient, "garage-system")
 
 	key, err := mgr.CreateShadowKeyWithID(context.Background(), "my-access", "GKabc", "my-cluster", "garage-system",
-		[]BucketPermission{{BucketID: "bucket-1", Read: true, Write: true}},
+		[]BucketPermission{{BucketID: testBucket1, Read: true, Write: true}},
 		"my-serviceaccount",
 	)
 	require.NoError(t, err)

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -33,6 +33,11 @@ import (
 // Worker state constants
 const (
 	WorkerStateThrottled = "throttled"
+	workerStateBusy      = "busy"
+	workerStateIdle      = "idle"
+	workerStateDone      = "done"
+	workerStateNull      = "null"
+	workerNodeKey        = "node"
 )
 
 // APIError represents an error returned by the Garage Admin API
@@ -388,7 +393,7 @@ func (z ZoneRedundancy) MarshalJSON() ([]byte, error) {
 // Garage uses lowercase "maximum" in JSON serialization (via serde rename_all = "camelCase")
 func (z *ZoneRedundancy) UnmarshalJSON(data []byte) error {
 	// Handle null value
-	if string(data) == "null" {
+	if string(data) == workerStateNull {
 		return nil
 	}
 
@@ -1146,13 +1151,13 @@ func (w WorkerState) MarshalJSON() ([]byte, error) {
 }
 
 // IsBusy returns true if the worker is in busy state
-func (w WorkerState) IsBusy() bool { return w.State == "busy" }
+func (w WorkerState) IsBusy() bool { return w.State == workerStateBusy }
 
 // IsIdle returns true if the worker is in idle state
-func (w WorkerState) IsIdle() bool { return w.State == "idle" }
+func (w WorkerState) IsIdle() bool { return w.State == workerStateIdle }
 
 // IsDone returns true if the worker is in done state
-func (w WorkerState) IsDone() bool { return w.State == "done" }
+func (w WorkerState) IsDone() bool { return w.State == workerStateDone }
 
 // IsThrottled returns true if the worker is in throttled state
 func (w WorkerState) IsThrottled() bool { return w.State == WorkerStateThrottled }
@@ -1187,7 +1192,7 @@ type ListWorkersRequest struct {
 
 // ListWorkers returns information about background workers on a node
 func (c *Client) ListWorkers(ctx context.Context, nodeID string, busyOnly, errorOnly bool) ([]WorkerInfo, error) {
-	query := map[string]string{"node": nodeID}
+	query := map[string]string{workerNodeKey: nodeID}
 	req := ListWorkersRequest{BusyOnly: busyOnly, ErrorOnly: errorOnly}
 	resp, err := c.doRequestWithQuery(ctx, http.MethodPost, "/v2/ListWorkers", query, req)
 	if err != nil {
@@ -1212,7 +1217,7 @@ type GetWorkerVariableRequest struct {
 // Returns a map of variable names to values. If variable is empty, returns all variables.
 // Matches Garage's LocalGetWorkerVariableResponse which is HashMap<String, String>
 func (c *Client) GetWorkerVariable(ctx context.Context, nodeID, variable string) (map[string]string, error) {
-	query := map[string]string{"node": nodeID}
+	query := map[string]string{workerNodeKey: nodeID}
 	var req GetWorkerVariableRequest
 	if variable != "" {
 		req.Variable = &variable
@@ -1243,7 +1248,7 @@ type SetWorkerVariableRequest struct {
 
 // SetWorkerVariable sets a worker configuration variable on a node
 func (c *Client) SetWorkerVariable(ctx context.Context, nodeID, variable, value string) error {
-	query := map[string]string{"node": nodeID}
+	query := map[string]string{workerNodeKey: nodeID}
 	req := SetWorkerVariableRequest{Variable: variable, Value: value}
 	_, err := c.doRequestWithQuery(ctx, http.MethodPost, "/v2/SetWorkerVariable", query, req)
 	return err
@@ -1256,7 +1261,7 @@ type LaunchRepairRequest struct {
 
 // LaunchRepair starts a repair operation on a node
 func (c *Client) LaunchRepair(ctx context.Context, nodeID, repairType string) error {
-	query := map[string]string{"node": nodeID}
+	query := map[string]string{workerNodeKey: nodeID}
 	req := LaunchRepairRequest{RepairType: repairType}
 	_, err := c.doRequestWithQuery(ctx, http.MethodPost, "/v2/LaunchRepairOperation", query, req)
 	return err
@@ -1273,7 +1278,7 @@ func (c *Client) LaunchScrubCommand(ctx context.Context, nodeID, command string)
 	type scrubRequest struct {
 		RepairType scrubType `json:"repairType"`
 	}
-	query := map[string]string{"node": nodeID}
+	query := map[string]string{workerNodeKey: nodeID}
 	req := scrubRequest{RepairType: scrubType{Scrub: command}}
 	_, err := c.doRequestWithQuery(ctx, http.MethodPost, "/v2/LaunchRepairOperation", query, req)
 	return err
@@ -1281,7 +1286,7 @@ func (c *Client) LaunchScrubCommand(ctx context.Context, nodeID, command string)
 
 // CreateMetadataSnapshot triggers a metadata snapshot on a node
 func (c *Client) CreateMetadataSnapshot(ctx context.Context, nodeID string) error {
-	query := map[string]string{"node": nodeID}
+	query := map[string]string{workerNodeKey: nodeID}
 	_, err := c.doRequestWithQuery(ctx, http.MethodPost, "/v2/CreateMetadataSnapshot", query, nil)
 	return err
 }

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -349,28 +349,28 @@ func TestWorkerState_UnmarshalJSON(t *testing.T) {
 		{
 			name:          "busy state",
 			input:         `"busy"`,
-			expectedState: "busy",
+			expectedState: workerStateBusy,
 		},
 		{
 			name:          "idle state",
 			input:         `"idle"`,
-			expectedState: "idle",
+			expectedState: workerStateIdle,
 		},
 		{
 			name:          "done state",
 			input:         `"done"`,
-			expectedState: "done",
+			expectedState: workerStateDone,
 		},
 		{
 			name:             "throttled state with duration",
 			input:            `{"throttled":{"durationSecs":1.5}}`,
-			expectedState:    "throttled",
+			expectedState:    WorkerStateThrottled,
 			expectedDuration: float32Ptr(1.5),
 		},
 		{
 			name:             "throttled state with integer duration",
 			input:            `{"throttled":{"durationSecs":5}}`,
-			expectedState:    "throttled",
+			expectedState:    WorkerStateThrottled,
 			expectedDuration: float32Ptr(5.0),
 		},
 		{
@@ -429,22 +429,22 @@ func TestWorkerState_MarshalJSON(t *testing.T) {
 	}{
 		{
 			name:     "busy state",
-			input:    WorkerState{State: "busy"},
+			input:    WorkerState{State: workerStateBusy},
 			expected: `"busy"`,
 		},
 		{
 			name:     "idle state",
-			input:    WorkerState{State: "idle"},
+			input:    WorkerState{State: workerStateIdle},
 			expected: `"idle"`,
 		},
 		{
 			name:     "done state",
-			input:    WorkerState{State: "done"},
+			input:    WorkerState{State: workerStateDone},
 			expected: `"done"`,
 		},
 		{
 			name:     "throttled state with duration",
-			input:    WorkerState{State: "throttled", DurationSecs: float32Ptr(2.5)},
+			input:    WorkerState{State: WorkerStateThrottled, DurationSecs: float32Ptr(2.5)},
 			expected: `{"throttled":{"durationSecs":2.5}}`,
 		},
 	}

--- a/internal/garage/internal_key_test.go
+++ b/internal/garage/internal_key_test.go
@@ -36,6 +36,7 @@ const (
 	testAccessKeyID    = "GK-TEST-ID"
 	testCachedKeyID    = "CACHED-ID"
 	testCachedSecretAK = "CACHED-SECRET"
+	testOperatorNS     = "garage-operator-system"
 
 	pathCreateKey = "/v2/CreateKey"
 	pathDeleteKey = "/v2/DeleteKey"
@@ -108,7 +109,7 @@ func TestInternalKeyManager_CreatesOnFirstUse(t *testing.T) {
 	defer stop()
 
 	kc := newFakeKubeClient()
-	mgr := NewInternalKeyManager(kc, "garage-operator-system")
+	mgr := NewInternalKeyManager(kc, testOperatorNS)
 	cluster := clusterRef()
 
 	creds, err := mgr.EnsureKey(context.Background(), cluster, admin)
@@ -124,7 +125,7 @@ func TestInternalKeyManager_CreatesOnFirstUse(t *testing.T) {
 
 	var sec corev1.Secret
 	if err := kc.Get(context.Background(), types.NamespacedName{
-		Namespace: "garage-operator-system",
+		Namespace: testOperatorNS,
 		Name:      mgr.SecretName(cluster),
 	}, &sec); err != nil {
 		t.Fatalf("Secret should exist: %v", err)
@@ -148,7 +149,7 @@ func TestInternalKeyManager_ReusesExistingSecret(t *testing.T) {
 	cluster := clusterRef()
 	existing := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "garage-operator-system",
+			Namespace: testOperatorNS,
 			Name:      (&InternalKeyManager{}).SecretName(cluster),
 		},
 		Data: map[string][]byte{
@@ -156,7 +157,7 @@ func TestInternalKeyManager_ReusesExistingSecret(t *testing.T) {
 			internalKeySecretAccessKeyField: []byte(testCachedSecretAK),
 		},
 	}
-	mgr := NewInternalKeyManager(newFakeKubeClient(existing), "garage-operator-system")
+	mgr := NewInternalKeyManager(newFakeKubeClient(existing), testOperatorNS)
 
 	creds, err := mgr.EnsureKey(context.Background(), cluster, admin)
 	if err != nil {
@@ -205,12 +206,12 @@ func TestInternalKeyManager_RecreatesMalformedSecret(t *testing.T) {
 			cluster := clusterRef()
 			malformed := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "garage-operator-system",
+					Namespace: testOperatorNS,
 					Name:      (&InternalKeyManager{}).SecretName(cluster),
 				},
 				Data: tc.data,
 			}
-			mgr := NewInternalKeyManager(newFakeKubeClient(malformed), "garage-operator-system")
+			mgr := NewInternalKeyManager(newFakeKubeClient(malformed), testOperatorNS)
 
 			creds, err := mgr.EnsureKey(context.Background(), cluster, admin)
 			if err != nil {
@@ -237,7 +238,7 @@ func TestInternalKeyManager_MalformedSecretPropagatesStaleKeyDeleteError(t *test
 	cluster := clusterRef()
 	malformed := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "garage-operator-system",
+			Namespace: testOperatorNS,
 			Name:      (&InternalKeyManager{}).SecretName(cluster),
 		},
 		Data: map[string][]byte{
@@ -245,7 +246,7 @@ func TestInternalKeyManager_MalformedSecretPropagatesStaleKeyDeleteError(t *test
 		},
 	}
 	kc := newFakeKubeClient(malformed)
-	mgr := NewInternalKeyManager(kc, "garage-operator-system")
+	mgr := NewInternalKeyManager(kc, testOperatorNS)
 
 	if _, err := mgr.EnsureKey(context.Background(), cluster, admin); err == nil {
 		t.Fatal("expected EnsureKey to fail when stale DeleteKey errors")
@@ -254,7 +255,7 @@ func TestInternalKeyManager_MalformedSecretPropagatesStaleKeyDeleteError(t *test
 		t.Fatalf("DeleteKey id: want %q, got %q", testCachedKeyID, *captured)
 	}
 	// secret must remain so the next reconcile can retry the cleanup
-	if err := kc.Get(context.Background(), types.NamespacedName{Namespace: "garage-operator-system", Name: mgr.SecretName(cluster)}, &corev1.Secret{}); err != nil {
+	if err := kc.Get(context.Background(), types.NamespacedName{Namespace: testOperatorNS, Name: mgr.SecretName(cluster)}, &corev1.Secret{}); err != nil {
 		t.Fatalf("malformed Secret should remain to allow retry: %v", err)
 	}
 }
@@ -263,7 +264,7 @@ func TestInternalKeyManager_DeleteSecret(t *testing.T) {
 	cluster := clusterRef()
 	existing := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "garage-operator-system",
+			Namespace: testOperatorNS,
 			Name:      (&InternalKeyManager{}).SecretName(cluster),
 		},
 		Data: map[string][]byte{
@@ -272,7 +273,7 @@ func TestInternalKeyManager_DeleteSecret(t *testing.T) {
 		},
 	}
 	kc := newFakeKubeClient(existing)
-	mgr := NewInternalKeyManager(kc, "garage-operator-system")
+	mgr := NewInternalKeyManager(kc, testOperatorNS)
 
 	if err := mgr.DeleteSecret(context.Background(), cluster); err != nil {
 		t.Fatalf("DeleteSecret: %v", err)
@@ -280,7 +281,7 @@ func TestInternalKeyManager_DeleteSecret(t *testing.T) {
 
 	var sec corev1.Secret
 	err := kc.Get(context.Background(), types.NamespacedName{
-		Namespace: "garage-operator-system",
+		Namespace: testOperatorNS,
 		Name:      mgr.SecretName(cluster),
 	}, &sec)
 	if err == nil {
@@ -342,7 +343,7 @@ func internalKeySecret(cluster ClusterRef, withFields bool) *corev1.Secret {
 	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "garage-operator-system",
+			Namespace: testOperatorNS,
 			Name:      (&InternalKeyManager{}).SecretName(cluster),
 		},
 		Data: data,
@@ -350,7 +351,6 @@ func internalKeySecret(cluster ClusterRef, withFields bool) *corev1.Secret {
 }
 
 func TestInternalKeyManager_DeleteKey(t *testing.T) {
-	const ns = "garage-operator-system"
 
 	type fakeAdminFnFactory func(t *testing.T) (fn func() *Client, captured *string, builderCalls *int, stop func())
 
@@ -436,7 +436,7 @@ func TestInternalKeyManager_DeleteKey(t *testing.T) {
 				seeds = append(seeds, internalKeySecret(cluster, tc.secretWithSecret))
 			}
 			kc := newFakeKubeClient(seeds...)
-			mgr := NewInternalKeyManager(kc, ns)
+			mgr := NewInternalKeyManager(kc, testOperatorNS)
 
 			fn, captured, calls, stop := tc.adminFactory(t)
 			defer stop()
@@ -453,7 +453,7 @@ func TestInternalKeyManager_DeleteKey(t *testing.T) {
 			if !tc.seedSecret {
 				return
 			}
-			err := kc.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: mgr.SecretName(cluster)}, &corev1.Secret{})
+			err := kc.Get(context.Background(), types.NamespacedName{Namespace: testOperatorNS, Name: mgr.SecretName(cluster)}, &corev1.Secret{})
 			if tc.wantSecretGone && err == nil {
 				t.Fatal("expected Secret to be deleted")
 			}
@@ -512,7 +512,7 @@ func TestInternalKeyManager_RaceLoserDeletesOwnKey(t *testing.T) {
 	defer stop()
 
 	kc := raceClient(winnerID, winnerSecret)
-	mgr := NewInternalKeyManager(kc, "garage-operator-system")
+	mgr := NewInternalKeyManager(kc, testOperatorNS)
 	cluster := clusterRef()
 
 	creds, err := mgr.EnsureKey(context.Background(), cluster, admin)
@@ -531,7 +531,7 @@ func TestInternalKeyManager_RaceLoserDeletesOwnKey(t *testing.T) {
 
 	var sec corev1.Secret
 	if err := kc.Get(context.Background(), types.NamespacedName{
-		Namespace: "garage-operator-system",
+		Namespace: testOperatorNS,
 		Name:      mgr.SecretName(cluster),
 	}, &sec); err != nil {
 		t.Fatalf("winner Secret should exist: %v", err)
@@ -549,7 +549,7 @@ func TestInternalKeyManager_RaceLoserSurvivesDeleteKeyError(t *testing.T) {
 	defer stop()
 
 	kc := raceClient(winnerID, winnerSecret)
-	mgr := NewInternalKeyManager(kc, "garage-operator-system")
+	mgr := NewInternalKeyManager(kc, testOperatorNS)
 
 	creds, err := mgr.EnsureKey(context.Background(), clusterRef(), admin)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `connectGatewayToExternalCluster` was one-directional: it told the gateway to connect to the external storage nodes, but never told the external storage to connect back to the gateway
- This meant external Garage only knew the gateway's pod IP (unreachable from outside the cluster), causing sync failures like `Not connected: <gateway-node-id>`
- Now mirrors the bidirectional pattern already used by `connectGatewayToClusterRef`: after gateway→storage connections, queries gateway status and pushes each gateway node address to the external cluster via its Admin API

Fixes #126.

> **Note for users hitting this issue**: a `publicEndpoint` (LoadBalancer or NodePort) is also required so gateway pods advertise a routable `rpc_public_addr`. Without it, gateway nodes have no external address to push. See the comment on #126 for the config fix.

## Test plan

- [ ] Deploy a gateway cluster with `connectTo.adminApiEndpoint` pointing to an external Garage instance
- [ ] Confirm operator logs show `Gateway-external storage bidirectional connection established` with non-zero `storageToGateway` count
- [ ] Confirm external Garage can sync tables with the gateway (no `Not connected` errors in external logs)
- [ ] Existing unit tests pass (`go test ./...`)