### PR TITLE
fix(gateway): implement publicEndpoint and surface missing admin token

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -53,6 +53,10 @@ const (
 
 	// ConditionServicesReady indicates all services are created and ready
 	ConditionServicesReady = "ServicesReady"
+
+	// ConditionGatewayConnected indicates a gateway cluster's connection to its storage cluster.
+	// False when the admin token is missing or the connection cannot be established.
+	ConditionGatewayConnected = "GatewayConnected"
 )
 
 // GarageBucket condition types
@@ -152,6 +156,9 @@ const (
 
 	// ReasonValidationFailed indicates validation failed
 	ReasonValidationFailed = "ValidationFailed"
+
+	// ReasonAdminTokenMissing indicates spec.admin.adminTokenSecretRef is required but not configured
+	ReasonAdminTokenMissing = "AdminTokenMissing"
 )
 
 // Annotation keys for operational tasks

--- a/api/v1beta1/garagecluster_types.go
+++ b/api/v1beta1/garagecluster_types.go
@@ -714,7 +714,9 @@ type AdminConfig struct {
 	// AdminTokenSecretRef references the secret the operator uses to authenticate
 	// with Garage's Admin API. The operator reads this token to manage buckets, keys,
 	// and layout on behalf of GarageBucket/GarageKey/GarageNode resources.
-	// If omitted, the operator generates and manages its own token automatically.
+	// Required for gateway clusters that use connectTo — the operator needs admin API
+	// access to issue ConnectNode commands. If omitted for storage clusters, layout
+	// management and bucket/key reconciliation are unavailable.
 	// Use GarageAdminToken to create tokens for external tooling; this field is
 	// specifically for the operator's own access.
 	// +optional

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -151,6 +151,11 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.updateStatus(ctx, cluster, PhaseFailed, err)
 	}
 
+	// Create, update, or delete the dedicated external RPC service for publicEndpoint
+	if err := r.reconcilePublicEndpointService(ctx, cluster); err != nil {
+		return r.updateStatus(ctx, cluster, PhaseFailed, err)
+	}
+
 	// Create or update StatefulSet for Auto layout policy clusters.
 	// For Manual layout policy, GarageNode resources create their own StatefulSets.
 	// Note: Garage does NOT support hot-reload - all config changes require pod restart.
@@ -648,6 +653,10 @@ func (r *GarageClusterReconciler) reconcileConfigMap(ctx context.Context, cluste
 type configContext struct {
 	// ConsulToken is the resolved Consul ACL token from TokenSecretRef
 	ConsulToken string
+	// RPCPublicAddr is the auto-derived rpc_public_addr from publicEndpoint.
+	// Only set when publicEndpoint is configured and an address can be resolved.
+	// Explicit network.rpcPublicAddr takes precedence over this field.
+	RPCPublicAddr string
 }
 
 // buildConfigContext creates a configContext by resolving secrets referenced in the cluster spec.
@@ -681,6 +690,43 @@ func (r *GarageClusterReconciler) buildConfigContext(ctx context.Context, cluste
 		}
 	}
 
+	// Derive rpc_public_addr from publicEndpoint if configured and network.rpcPublicAddr is not set.
+	if cluster.Spec.PublicEndpoint != nil && cluster.Spec.Network.RPCPublicAddr == "" {
+		rpcPort := DefaultRPCPort
+		if cluster.Spec.Network.RPCBindPort != 0 {
+			rpcPort = cluster.Spec.Network.RPCBindPort
+		}
+		switch cluster.Spec.PublicEndpoint.Type {
+		case publicEndpointTypeLoadBalancer:
+			if cluster.Spec.PublicEndpoint.LoadBalancer == nil || !cluster.Spec.PublicEndpoint.LoadBalancer.PerNode {
+				svc := &corev1.Service{}
+				if err := r.Get(ctx, types.NamespacedName{
+					Name:      cluster.Name + "-rpc",
+					Namespace: cluster.Namespace,
+				}, svc); err == nil {
+					for _, ing := range svc.Status.LoadBalancer.Ingress {
+						addr := ing.IP
+						if addr == "" {
+							addr = ing.Hostname
+						}
+						if addr != "" {
+							cfgCtx.RPCPublicAddr = fmt.Sprintf("%s:%d", addr, rpcPort)
+							break
+						}
+					}
+				}
+			}
+		case publicEndpointTypeNodePort:
+			if ep := cluster.Spec.PublicEndpoint.NodePort; ep != nil && len(ep.ExternalAddresses) > 0 {
+				basePort := ep.BasePort
+				if basePort == 0 {
+					basePort = 30901
+				}
+				cfgCtx.RPCPublicAddr = fmt.Sprintf("%s:%d", ep.ExternalAddresses[0], basePort)
+			}
+		}
+	}
+
 	return cfgCtx, nil
 }
 
@@ -699,7 +745,7 @@ func (r *GarageClusterReconciler) generateGarageConfig(cluster *garagev1beta1.Ga
 	writeStorageConfig(&config, cluster)
 	writeBlockConfig(&config, cluster)
 	writeSecurityConfig(&config, cluster)
-	writeRPCConfig(&config, cluster)
+	writeRPCConfig(&config, cluster, cfgCtx)
 	writeS3APIConfig(&config, cluster)
 	writeK2VAPIConfig(&config, cluster)
 	writeWebAPIConfig(&config, cluster)
@@ -827,7 +873,7 @@ func writeSecurityConfig(config *strings.Builder, cluster *garagev1beta1.GarageC
 	}
 }
 
-func writeRPCConfig(config *strings.Builder, cluster *garagev1beta1.GarageCluster) {
+func writeRPCConfig(config *strings.Builder, cluster *garagev1beta1.GarageCluster, cfgCtx *configContext) {
 	if cluster.Spec.Network.RPCBindAddress != "" {
 		fmt.Fprintf(config, "rpc_bind_addr = \"%s\"\n", cluster.Spec.Network.RPCBindAddress)
 	} else {
@@ -841,6 +887,8 @@ func writeRPCConfig(config *strings.Builder, cluster *garagev1beta1.GarageCluste
 
 	if cluster.Spec.Network.RPCPublicAddr != "" {
 		fmt.Fprintf(config, "rpc_public_addr = \"%s\"\n", cluster.Spec.Network.RPCPublicAddr)
+	} else if cfgCtx != nil && cfgCtx.RPCPublicAddr != "" {
+		fmt.Fprintf(config, "rpc_public_addr = \"%s\"\n", cfgCtx.RPCPublicAddr)
 	}
 	if cluster.Spec.Network.RPCPublicAddrSubnet != "" {
 		fmt.Fprintf(config, "rpc_public_addr_subnet = \"%s\"\n", cluster.Spec.Network.RPCPublicAddrSubnet)
@@ -1146,7 +1194,7 @@ func (r *GarageClusterReconciler) reconcileHeadlessService(ctx context.Context, 
 			Selector:  selector,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "rpc",
+					Name:       rpcPortName,
 					Port:       rpcPort,
 					TargetPort: intstr.FromInt32(rpcPort),
 					Protocol:   corev1.ProtocolTCP,
@@ -1294,6 +1342,101 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 	return r.Update(ctx, existing)
 }
 
+// reconcilePublicEndpointService manages a dedicated RPC service (<name>-rpc) used to expose
+// the Garage RPC port externally for multi-cluster federation via publicEndpoint.
+// The service is created/updated when publicEndpoint is set and deleted when it is removed.
+func (r *GarageClusterReconciler) reconcilePublicEndpointService(ctx context.Context, cluster *garagev1beta1.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	svcName := cluster.Name + "-rpc"
+
+	if cluster.Spec.PublicEndpoint == nil {
+		// Clean up any existing -rpc service if publicEndpoint was removed
+		existing := &corev1.Service{}
+		if err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: cluster.Namespace}, existing); err == nil {
+			log.Info("Deleting public endpoint RPC service (publicEndpoint removed)", "name", svcName)
+			return r.Delete(ctx, existing)
+		}
+		return nil
+	}
+
+	ep := cluster.Spec.PublicEndpoint
+	rpcPort := DefaultRPCPort
+	if cluster.Spec.Network.RPCBindPort != 0 {
+		rpcPort = cluster.Spec.Network.RPCBindPort
+	}
+
+	var svcType corev1.ServiceType
+	var annotations map[string]string
+	var nodePort int32
+
+	switch ep.Type {
+	case publicEndpointTypeLoadBalancer:
+		if ep.LoadBalancer != nil && ep.LoadBalancer.PerNode {
+			log.Info("publicEndpoint.loadBalancer.perNode is not yet implemented; use network.rpcPublicAddr for per-node addressing")
+			return nil
+		}
+		svcType = corev1.ServiceTypeLoadBalancer
+		if ep.LoadBalancer != nil && ep.LoadBalancer.Annotations != nil {
+			annotations = ep.LoadBalancer.Annotations
+		}
+	case publicEndpointTypeNodePort:
+		svcType = corev1.ServiceTypeNodePort
+		if ep.NodePort != nil && ep.NodePort.BasePort != 0 {
+			nodePort = ep.NodePort.BasePort
+		}
+	default:
+		log.Info("publicEndpoint type is not yet implemented; use network.rpcPublicAddr", "type", ep.Type)
+		return nil
+	}
+
+	port := corev1.ServicePort{
+		Name:       rpcPortName,
+		Port:       rpcPort,
+		TargetPort: intstr.FromInt32(rpcPort),
+		Protocol:   corev1.ProtocolTCP,
+	}
+	if nodePort != 0 {
+		port.NodePort = nodePort
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        svcName,
+			Namespace:   cluster.Namespace,
+			Labels:      r.labelsForCluster(cluster),
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                     svcType,
+			Selector:                 r.selectorLabelsForCluster(cluster),
+			Ports:                    []corev1.ServicePort{port},
+			PublishNotReadyAddresses: true,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cluster, svc, r.Scheme); err != nil {
+		return err
+	}
+
+	existing := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: cluster.Namespace}, existing)
+	if errors.IsNotFound(err) {
+		log.Info("Creating public endpoint RPC service", "name", svcName, "type", svcType)
+		return r.Create(ctx, svc)
+	}
+	if err != nil {
+		return err
+	}
+
+	existing.Spec.Type = svc.Spec.Type
+	existing.Spec.Selector = svc.Spec.Selector
+	existing.Spec.Ports = svc.Spec.Ports
+	existing.Spec.PublishNotReadyAddresses = svc.Spec.PublishNotReadyAddresses
+	existing.Labels = svc.Labels
+	existing.Annotations = svc.Annotations
+	return r.Update(ctx, existing)
+}
+
 // resolveGarageImage determines the container image from image/imageRepository fields.
 // Priority: image > imageRepository + default tag > operatorDefault > hardcoded default.
 func resolveGarageImage(image, imageRepository, operatorDefault string) string {
@@ -1334,7 +1477,7 @@ func buildContainerPorts(cluster *garagev1beta1.GarageCluster) []corev1.Containe
 	if cluster.Spec.Network.RPCBindPort != 0 {
 		rpcPort = cluster.Spec.Network.RPCBindPort
 	}
-	ports = append(ports, corev1.ContainerPort{Name: "rpc", ContainerPort: rpcPort})
+	ports = append(ports, corev1.ContainerPort{Name: rpcPortName, ContainerPort: rpcPort})
 
 	// S3 API port (always enabled - Garage requires the [s3_api] section)
 	s3Port := int32(3900)
@@ -3075,7 +3218,15 @@ func (r *GarageClusterReconciler) reconcileGatewayConnection(ctx context.Context
 	// Get the gateway cluster's admin client
 	gatewayAdminToken, err := r.getAdminToken(ctx, cluster)
 	if err != nil || gatewayAdminToken == "" {
-		log.V(1).Info("Gateway admin token not available, skipping connection")
+		log.Info("Gateway connectTo requires spec.admin.adminTokenSecretRef — connection skipped until configured",
+			"gateway", cluster.Name)
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonAdminTokenMissing,
+			Message:            "spec.admin.adminTokenSecretRef is required for gateway connectTo; the operator needs admin API access to issue ConnectNode commands",
+			ObservedGeneration: cluster.Generation,
+		})
 		return
 	}
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -119,6 +119,12 @@ const (
 	msgWaitingForCluster = "waiting for cluster to be reachable"
 )
 
+// publicEndpoint type string constants
+const (
+	publicEndpointTypeLoadBalancer = "LoadBalancer"
+	publicEndpointTypeNodePort     = "NodePort"
+)
+
 // Secret key name constants for S3 credentials
 const (
 	defaultAccessKeyIDKey     = "access-key-id"

--- a/internal/controller/publicendpoint_test.go
+++ b/internal/controller/publicendpoint_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+)
+
+var _ = Describe("publicEndpoint reconciliation", func() {
+	const (
+		peClusterName = "pe-test-cluster"
+		peNamespace   = testNamespace
+	)
+
+	var (
+		reconciler *GarageClusterReconciler
+		nn         types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		nn = types.NamespacedName{Name: peClusterName, Namespace: peNamespace}
+		reconciler = &GarageClusterReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	})
+
+	AfterEach(func() {
+		cluster := &garagev1beta1.GarageCluster{}
+		if err := k8sClient.Get(ctx, nn, cluster); err == nil {
+			cluster.Finalizers = nil
+			_ = k8sClient.Update(ctx, cluster)
+			_ = k8sClient.Delete(ctx, cluster)
+		}
+		for _, name := range []string{peClusterName, peClusterName + "-headless", peClusterName + "-rpc"} {
+			_ = k8sClient.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: peNamespace}})
+		}
+		_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: peClusterName + "-config", Namespace: peNamespace}})
+		_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: peClusterName + "-rpc-secret", Namespace: peNamespace}})
+	})
+
+	reconcileTwice := func() {
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	Context("LoadBalancer type", func() {
+		It("creates a dedicated RPC service of type LoadBalancer", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					Replicas:    1,
+					Replication: &garagev1beta1.ReplicationConfig{Factor: 1},
+					PublicEndpoint: &garagev1beta1.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			Expect(rpcSvc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+			Expect(rpcSvc.Spec.Ports).To(ContainElement(
+				HaveField("Port", int32(3901)),
+			))
+		})
+
+		It("sets rpc_public_addr in config once the LB service has an external IP", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					Replicas:    1,
+					Replication: &garagev1beta1.ReplicationConfig{Factor: 1},
+					PublicEndpoint: &garagev1beta1.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			// Simulate LoadBalancer getting an external IP
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			rpcSvc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.0.0.5"}}
+			Expect(k8sClient.Status().Update(ctx, rpcSvc)).To(Succeed())
+
+			// Reconcile again so config is regenerated with the LB IP
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-config", Namespace: peNamespace}, cm)).To(Succeed())
+			Expect(cm.Data["garage.toml"]).To(ContainSubstring(`rpc_public_addr = "10.0.0.5:3901"`))
+		})
+
+		It("prefers explicit network.rpcPublicAddr over publicEndpoint auto-derived address", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					Replicas:    1,
+					Replication: &garagev1beta1.ReplicationConfig{Factor: 1},
+					Network: garagev1beta1.NetworkConfig{
+						RPCPublicAddr: "explicit.example.com:3901",
+					},
+					PublicEndpoint: &garagev1beta1.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			// Simulate LB IP assignment
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			rpcSvc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.0.0.5"}}
+			Expect(k8sClient.Status().Update(ctx, rpcSvc)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-config", Namespace: peNamespace}, cm)).To(Succeed())
+			Expect(cm.Data["garage.toml"]).To(ContainSubstring(`rpc_public_addr = "explicit.example.com:3901"`))
+			Expect(cm.Data["garage.toml"]).NotTo(ContainSubstring("10.0.0.5"))
+		})
+	})
+
+	Context("NodePort type", func() {
+		It("creates a NodePort RPC service and sets rpc_public_addr from externalAddresses", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					Replicas:    1,
+					Replication: &garagev1beta1.ReplicationConfig{Factor: 1},
+					PublicEndpoint: &garagev1beta1.PublicEndpointConfig{
+						Type: publicEndpointTypeNodePort,
+						NodePort: &garagev1beta1.NodePortEndpointConfig{
+							ExternalAddresses: []string{"k8s-node.example.com"},
+							BasePort:          30901,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			Expect(rpcSvc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-config", Namespace: peNamespace}, cm)).To(Succeed())
+			Expect(cm.Data["garage.toml"]).To(ContainSubstring(`rpc_public_addr = "k8s-node.example.com:30901"`))
+		})
+	})
+
+	Context("cleanup", func() {
+		It("deletes the RPC service when publicEndpoint is removed from the spec", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					Replicas:    1,
+					Replication: &garagev1beta1.ReplicationConfig{Factor: 1},
+					PublicEndpoint: &garagev1beta1.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			// Verify RPC service was created
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+
+			// Remove publicEndpoint
+			updated := &garagev1beta1.GarageCluster{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+			updated.Spec.PublicEndpoint = nil
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// RPC service should be gone
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, &corev1.Service{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("gateway connectTo missing admin token", func() {
+		It("sets GatewayConnected=False condition when connectTo is configured but admin token is missing", func() {
+			// Create the RPC secret that connectTo references
+			rpcSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "pe-unraid-rpc-secret", Namespace: peNamespace},
+				StringData: map[string]string{"rpc-secret": strings.Repeat("a", 64)},
+			}
+			_ = k8sClient.Delete(ctx, rpcSecret)
+			Expect(k8sClient.Create(ctx, rpcSecret)).To(Succeed())
+
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					Replicas:    1,
+					Gateway:     true,
+					Replication: &garagev1beta1.ReplicationConfig{Factor: 1},
+					ConnectTo: &garagev1beta1.ConnectToConfig{
+						RPCSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "pe-unraid-rpc-secret"},
+							Key:                  "rpc-secret",
+						},
+						AdminAPIEndpoint: "http://192.168.0.13:3903",
+						AdminTokenSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "pe-unraid-admin-token"},
+							Key:                  "admin-token",
+						},
+					},
+					// No spec.admin configured — gateway's own admin API is unauthenticated/unconfigured
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			updated := &garagev1beta1.GarageCluster{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+
+			cond := findCondition(updated.Status.Conditions, garagev1beta1.ConditionGatewayConnected)
+			Expect(cond).NotTo(BeNil(), "GatewayConnected condition should be set")
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(garagev1beta1.ReasonAdminTokenMissing))
+		})
+	})
+})
+
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented external-cluster gateway setups from working (reported in #126):

- **`publicEndpoint` was a no-op** — the field was defined in the API but the controller never read it. A dedicated `<name>-rpc` Service (LoadBalancer or NodePort type) is now created when `publicEndpoint` is configured, and `rpc_public_addr` is auto-derived from its external IP / externalAddresses. Explicit `network.rpcPublicAddr` still takes precedence.

- **Silent skip when admin token missing** — `reconcileGatewayConnection` returned silently at `V(1)` log level when `spec.admin.adminTokenSecretRef` was not configured. It now logs at `Info` level and sets a `GatewayConnected=False` / `AdminTokenMissing` status condition, making the missing config immediately visible via `kubectl get garagecluster`.

- **Misleading `AdminTokenSecretRef` comment** — the field comment claimed "auto-generates if omitted"; updated to clarify it is required for gateway `connectTo` clusters.

## What the user in #126 needs to add

```yaml
spec:
  admin:
    adminTokenSecretRef:
      name: garage-gateway-admin-token   # create this secret
      key: admin-token
```

```bash
kubectl create secret generic garage-gateway-admin-token \
  --from-literal=admin-token=$(openssl rand -hex 32) \
  -n garage-operator-system
```

With this, the operator will authenticate to the gateway's own admin API and issue `ConnectNode` to connect it to the Unraid cluster on each reconcile.

## Test plan

- [x] `publicEndpoint reconciliation / LoadBalancer type / creates a dedicated RPC service of type LoadBalancer`
- [x] `publicEndpoint reconciliation / LoadBalancer type / sets rpc_public_addr in config once the LB service has an external IP`
- [x] `publicEndpoint reconciliation / LoadBalancer type / prefers explicit network.rpcPublicAddr over publicEndpoint auto-derived address`
- [x] `publicEndpoint reconciliation / NodePort type / creates a NodePort RPC service and sets rpc_public_addr from externalAddresses`
- [x] `publicEndpoint reconciliation / cleanup / deletes the RPC service when publicEndpoint is removed from the spec`
- [x] `publicEndpoint reconciliation / gateway connectTo missing admin token / sets GatewayConnected=False condition`
- [x] Full test suite passes (`go test ./...`)