### PR TITLE
fix(types): accept legacy string bucketRef from v1alpha1 resources

### DIFF
--- a/api/v1beta1/garagekey_types.go
+++ b/api/v1beta1/garagekey_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -197,9 +199,9 @@ type SecretTemplate struct {
 
 // BucketRef is a reference to a GarageBucket by name and optional namespace.
 //
-// Upgrade note: in v1alpha1, the namespace was a separate flat field bucketNamespace
-// on BucketPermission. In v1beta1 it is consolidated here as bucketRef.namespace.
-// Delete and recreate GarageKey resources when upgrading from v1alpha1.
+// Upgrade note: in v1alpha1, bucketRef was a plain string (the bucket name).
+// In v1beta1 it is an object with name and optional namespace.
+// Resources with the old string format are accepted and normalised automatically.
 type BucketRef struct {
 	// Name of the GarageBucket.
 	// +required
@@ -209,6 +211,17 @@ type BucketRef struct {
 	// Cross-namespace references require a GarageReferenceGrant in the target namespace.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+}
+
+// UnmarshalJSON accepts both the v1beta1 object form and the legacy v1alpha1
+// plain-string form so that old resources stored in etcd do not crash the
+// informer cache on LIST.
+func (b *BucketRef) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		return json.Unmarshal(data, &b.Name)
+	}
+	type alias BucketRef
+	return json.Unmarshal(data, (*alias)(b))
 }
 
 // BucketPermission grants access to a bucket.

--- a/api/v1beta1/webhook_test.go
+++ b/api/v1beta1/webhook_test.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -887,6 +888,55 @@ func TestGarageCluster_WebAPI_NilEnabled_DefaultsToTrue(t *testing.T) {
 	}
 	if cluster.Spec.WebAPI.Enabled == nil || !*cluster.Spec.WebAPI.Enabled {
 		t.Error("expected WebAPI.Enabled to default to true")
+	}
+}
+
+func TestBucketRef_UnmarshalJSON_StringForm(t *testing.T) {
+	// v1alpha1 stored bucketRef as a plain string. The informer crashes on LIST
+	// if the Go type can't handle it, so we accept the string and map it to Name.
+	var ref BucketRef
+	if err := json.Unmarshal([]byte(`"`+testBucket+`"`), &ref); err != nil {
+		t.Fatalf("unexpected error unmarshaling string bucketRef: %v", err)
+	}
+	if ref.Name != testBucket {
+		t.Errorf("expected Name=my-bucket, got %q", ref.Name)
+	}
+	if ref.Namespace != "" {
+		t.Errorf("expected empty Namespace, got %q", ref.Namespace)
+	}
+}
+
+func TestBucketRef_UnmarshalJSON_ObjectForm(t *testing.T) {
+	var ref BucketRef
+	if err := json.Unmarshal([]byte(`{"name":"`+testBucket+`","namespace":"ns"}`), &ref); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref.Name != testBucket || ref.Namespace != "ns" {
+		t.Errorf("unexpected value: %+v", ref)
+	}
+}
+
+func TestBucketRef_UnmarshalJSON_InGarageKeyList(t *testing.T) {
+	// Simulate what the informer sees when a legacy resource is in etcd.
+	raw := `{
+		"apiVersion": "garage.rajsingh.info/v1beta1",
+		"kind": "GarageKey",
+		"metadata": {"name": "test", "namespace": "default"},
+		"spec": {
+			"clusterRef": {"name": "garage"},
+			"bucketPermissions": [{"bucketRef": "` + testBucket + `", "read": true}]
+		}
+	}`
+	var key GarageKey
+	if err := json.Unmarshal([]byte(raw), &key); err != nil {
+		t.Fatalf("expected no error for legacy string bucketRef, got: %v", err)
+	}
+	if len(key.Spec.BucketPermissions) != 1 {
+		t.Fatal("expected 1 bucket permission")
+	}
+	ref := key.Spec.BucketPermissions[0].BucketRef
+	if ref == nil || ref.Name != testBucket {
+		t.Errorf("expected BucketRef.Name=%s, got %+v", testBucket, ref)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `UnmarshalJSON` to `BucketRef` that silently converts the legacy v1alpha1 plain-string format (`bucketRef: my-bucket`) to the v1beta1 object form (`{name: my-bucket}`)
- Without this, a single unmigrated resource in etcd crashes the entire GarageKey informer on LIST, blocking all key reconciliation across the cluster
- Root cause: Robbinsdale had two GarageKey resources (`keiretsu-top/keiretsu-top-key`, `zot/zot-key`) stored with the old string format that were missed during the v1alpha1→v1beta1 migration

## Test plan

- [ ] `TestBucketRef_UnmarshalJSON_StringForm` — string `"my-bucket"` unmarshals to `{Name: "my-bucket"}`
- [ ] `TestBucketRef_UnmarshalJSON_ObjectForm` — object form still works
- [ ] `TestBucketRef_UnmarshalJSON_InGarageKeyList` — full GarageKey with legacy string bucketRef unmarshals without error
- [ ] All existing webhook tests continue to pass