### PR TITLE
fix(gateway): bidirectional ConnectNode for external storage clusters

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -202,6 +202,55 @@ jobs:
           path: /tmp/e2e-debug/
           retention-days: 7
 
+  e2e-external-gateway:
+    name: External Gateway E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+          version: v0.31.0
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+
+      - name: Run external gateway e2e tests
+        run: make test-e2e-external-gateway
+
+      - name: Collect debug info
+        if: failure()
+        run: |
+          mkdir -p /tmp/e2e-debug
+          kind get clusters > /tmp/e2e-debug/clusters.txt 2>&1 || true
+          for cluster in $(kind get clusters 2>/dev/null); do
+            kubectl --context "kind-$cluster" get all -A > "/tmp/e2e-debug/${cluster}-resources.txt" 2>&1 || true
+            kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=200 > "/tmp/e2e-debug/${cluster}-operator.txt" 2>&1 || true
+            kubectl --context "kind-$cluster" get garagecluster -A -o yaml > "/tmp/e2e-debug/${cluster}-garageclusters.txt" 2>&1 || true
+          done
+          docker logs garage-ext-gw-e2e-external-garage > /tmp/e2e-debug/external-garage.txt 2>&1 || true
+
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: external-gateway-e2e-logs
+          path: /tmp/e2e-debug/
+          retention-days: 7
+
   e2e-ipv6:
     name: IPv6 Dual-Stack E2E Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,11 @@ test-e2e-ipv6: ## Run IPv6 dual-stack E2E tests (kind cluster with IPv6 primary 
 	@chmod +x hack/e2e-ipv6.sh
 	@hack/e2e-ipv6.sh
 
+.PHONY: test-e2e-external-gateway
+test-e2e-external-gateway: ## Run external gateway E2E tests (gateway → Docker Garage node)
+	@chmod +x hack/e2e-external-gateway.sh
+	@hack/e2e-external-gateway.sh
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
 	"$(GOLANGCI_LINT)" run

--- a/hack/e2e-external-gateway.sh
+++ b/hack/e2e-external-gateway.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+set -euo pipefail
+
+# E2E test: K8s gateway cluster connecting to an external (Docker) Garage node.
+# This validates the bidirectional ConnectNode fix — the external cluster must
+# see the K8s gateway as online, not just the other way around.
+#
+# Network topology:
+#   Kind pods (10.244.0.0/16) — MASQUERADE through kind node → Garage container (172.30.0.200:3901)
+#   Garage container (172.30.0.200) → kind node NodePort (172.30.0.x:30901) → gateway pod
+#
+# Usage: ./hack/e2e-external-gateway.sh [--no-cleanup] [--skip-build]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CLUSTER_NAME="garage-ext-gw-e2e"
+NAMESPACE="garage-operator-system"
+TEST_NAMESPACE="garage-ext-gw-test"
+DOCKER_NETWORK="garage-ext-gw-net"
+GARAGE_CONTAINER="${CLUSTER_NAME}-external-garage"
+GARAGE_IMAGE="dxflrs/garage:v2.2.0"
+
+# Static IP for the external Garage container on the Docker bridge network.
+# Far from the typical range kind nodes get (.1–.50) to avoid collision.
+GARAGE_STATIC_IP="172.30.0.200"
+GARAGE_RPC_PORT=3901
+GARAGE_ADMIN_PORT=3903
+GARAGE_ADMIN_HOST_PORT=39030  # host port for the test to query directly
+GATEWAY_RPC_NODEPORT=30901
+
+TIMEOUT=180
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+CLEANUP=true
+SKIP_BUILD=false
+for arg in "$@"; do
+    case $arg in
+        --no-cleanup) CLEANUP=false ;;
+        --skip-build) SKIP_BUILD=true ;;
+        --help|-h)
+            echo "Usage: $0 [--no-cleanup] [--skip-build]"
+            exit 0
+            ;;
+    esac
+done
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+TMPDIR_GARAGE=""
+
+cleanup() {
+    if [ "$CLEANUP" = true ]; then
+        log_info "Cleaning up..."
+        docker rm -f "$GARAGE_CONTAINER" 2>/dev/null || true
+        kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+        docker network rm "$DOCKER_NETWORK" 2>/dev/null || true
+        [ -n "$TMPDIR_GARAGE" ] && rm -rf "$TMPDIR_GARAGE"
+    else
+        log_warn "Skipping cleanup. Resources still running:"
+        log_warn "  docker rm -f $GARAGE_CONTAINER"
+        log_warn "  kind delete cluster --name $CLUSTER_NAME"
+        log_warn "  docker network rm $DOCKER_NETWORK"
+    fi
+}
+trap cleanup EXIT
+
+# ============================================================================
+# Setup
+# ============================================================================
+
+cd "$ROOT_DIR"
+
+RPC_SECRET=$(openssl rand -hex 32)
+EXTERNAL_ADMIN_TOKEN="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+log_info "=== Step 1: Docker bridge network ==="
+docker network rm "$DOCKER_NETWORK" 2>/dev/null || true
+docker network create --subnet "172.30.0.0/24" "$DOCKER_NETWORK"
+
+log_info "=== Step 2: Kind cluster ==="
+kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+cat <<EOF | kind create cluster --name "$CLUSTER_NAME" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/16"
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: ${GATEWAY_RPC_NODEPORT}
+    hostPort: 0
+    protocol: TCP
+EOF
+
+log_info "=== Step 3: Connect kind node to Docker network ==="
+docker network connect "$DOCKER_NETWORK" "${CLUSTER_NAME}-control-plane"
+
+KIND_NODE_DOCKER_IP=$(docker inspect \
+    -f "{{with index .NetworkSettings.Networks \"${DOCKER_NETWORK}\"}}{{.IPAddress}}{{end}}" \
+    "${CLUSTER_NAME}-control-plane")
+log_info "Kind node Docker IP: $KIND_NODE_DOCKER_IP"
+
+GATEWAY_RPC_PUBLIC_ADDR="${KIND_NODE_DOCKER_IP}:${GATEWAY_RPC_NODEPORT}"
+
+log_info "=== Step 4: External Garage container ==="
+TMPDIR_GARAGE=$(mktemp -d)
+mkdir -p "$TMPDIR_GARAGE/meta" "$TMPDIR_GARAGE/data"
+
+cat > "$TMPDIR_GARAGE/garage.toml" <<EOF
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+replication_factor = 1
+
+[network]
+rpc_bind_addr = "0.0.0.0:${GARAGE_RPC_PORT}"
+rpc_public_addr = "${GARAGE_STATIC_IP}:${GARAGE_RPC_PORT}"
+rpc_secret = "${RPC_SECRET}"
+
+[s3_api]
+s3_region = "us-east-1"
+api_bind_addr = "0.0.0.0:3900"
+root_domain = ".s3.local"
+
+[admin]
+api_bind_addr = "0.0.0.0:${GARAGE_ADMIN_PORT}"
+admin_token = "${EXTERNAL_ADMIN_TOKEN}"
+EOF
+
+docker run -d \
+    --name "$GARAGE_CONTAINER" \
+    --network "$DOCKER_NETWORK" \
+    --ip "$GARAGE_STATIC_IP" \
+    -v "$TMPDIR_GARAGE/garage.toml:/etc/garage.toml:ro" \
+    -v "$TMPDIR_GARAGE/meta:/var/lib/garage/meta" \
+    -v "$TMPDIR_GARAGE/data:/var/lib/garage/data" \
+    -p "127.0.0.1:${GARAGE_ADMIN_HOST_PORT}:${GARAGE_ADMIN_PORT}" \
+    "$GARAGE_IMAGE" -c /etc/garage.toml server
+
+# Wait for external Garage to be ready
+log_info "Waiting for external Garage admin API..."
+end=$((SECONDS + 60))
+while [ $SECONDS -lt $end ]; do
+    if curl -sf -H "Authorization: Bearer ${EXTERNAL_ADMIN_TOKEN}" \
+        "http://localhost:${GARAGE_ADMIN_HOST_PORT}/v2/GetClusterHealth" >/dev/null 2>&1; then
+        log_info "External Garage is ready"
+        break
+    fi
+    sleep 2
+done
+
+# Apply layout so the external Garage node is active
+log_info "Applying initial layout on external Garage..."
+EXTERNAL_NODE_ID=$(curl -sf \
+    -H "Authorization: Bearer ${EXTERNAL_ADMIN_TOKEN}" \
+    "http://localhost:${GARAGE_ADMIN_HOST_PORT}/v2/GetClusterStatus" | \
+    python3 -c "import sys,json; nodes=json.load(sys.stdin)['nodes']; print(nodes[0]['id'])" 2>/dev/null || true)
+log_info "External Garage node ID: ${EXTERNAL_NODE_ID:0:16}..."
+
+if [ -n "$EXTERNAL_NODE_ID" ]; then
+    curl -sf -X POST \
+        -H "Authorization: Bearer ${EXTERNAL_ADMIN_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "http://localhost:${GARAGE_ADMIN_HOST_PORT}/v2/UpdateClusterLayout" \
+        -d "[{\"id\":\"${EXTERNAL_NODE_ID}\",\"zone\":\"external\",\"capacity\":1073741824}]" >/dev/null || true
+    curl -sf -X POST \
+        -H "Authorization: Bearer ${EXTERNAL_ADMIN_TOKEN}" \
+        "http://localhost:${GARAGE_ADMIN_HOST_PORT}/v2/ApplyClusterLayout" \
+        -d '{"version":1}' >/dev/null || true
+fi
+
+log_info "=== Step 5: Build operator image ==="
+if [ "$SKIP_BUILD" = false ]; then
+    docker build -t garage-operator:e2e .
+fi
+kind load docker-image garage-operator:e2e --name "$CLUSTER_NAME"
+
+log_info "=== Step 6: Deploy operator ==="
+helm install garage-operator charts/garage-operator \
+    --namespace "$NAMESPACE" \
+    --create-namespace \
+    -f charts/garage-operator/values-e2e.yaml \
+    --wait --timeout 120s
+
+log_info "=== Step 7: Run Ginkgo tests ==="
+export EXTERNAL_GARAGE_OPERATOR_ENDPOINT="http://${GARAGE_STATIC_IP}:${GARAGE_ADMIN_PORT}"
+export EXTERNAL_GARAGE_HOST_ENDPOINT="http://localhost:${GARAGE_ADMIN_HOST_PORT}"
+export EXTERNAL_GARAGE_TOKEN="${EXTERNAL_ADMIN_TOKEN}"
+export EXTERNAL_RPC_SECRET="${RPC_SECRET}"
+export EXTERNAL_GARAGE_RPC_ADDR="${GARAGE_STATIC_IP}:${GARAGE_RPC_PORT}"
+export GATEWAY_RPC_PUBLIC_ADDR="${GATEWAY_RPC_PUBLIC_ADDR}"
+export GATEWAY_RPC_NODEPORT="${GATEWAY_RPC_NODEPORT}"
+export E2E_TEST_NAMESPACE="${TEST_NAMESPACE}"
+
+go test -tags=e2e ./test/e2e/ -v -ginkgo.v \
+    -ginkgo.label-filter=external-gateway \
+    -timeout 10m

--- a/hack/e2e-external-gateway.sh
+++ b/hack/e2e-external-gateway.sh
@@ -142,7 +142,8 @@ docker run -d \
     -v "$TMPDIR_GARAGE/meta:/var/lib/garage/meta" \
     -v "$TMPDIR_GARAGE/data:/var/lib/garage/data" \
     -p "127.0.0.1:${GARAGE_ADMIN_HOST_PORT}:${GARAGE_ADMIN_PORT}" \
-    "$GARAGE_IMAGE" -c /etc/garage.toml server
+    "$GARAGE_IMAGE" \
+    /garage server
 
 # Wait for external Garage to be ready
 log_info "Waiting for external Garage admin API..."

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3393,6 +3393,7 @@ func (r *GarageClusterReconciler) connectGatewayToClusterRef(ctx context.Context
 }
 
 // connectGatewayToExternalCluster connects a gateway to an external storage cluster via Admin API endpoint.
+// Bidirectional: gateway → external nodes AND external cluster → gateway nodes.
 func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Context, cluster *garagev1beta1.GarageCluster, gatewayClient *garage.Client) {
 	log := logf.FromContext(ctx)
 
@@ -3403,26 +3404,52 @@ func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Co
 	}
 
 	// Get external cluster status for node discovery
-	status, err := externalClient.GetClusterStatus(ctx)
+	externalStatus, err := externalClient.GetClusterStatus(ctx)
 	if err != nil {
 		log.V(1).Info("Failed to get external cluster status", "endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint, "error", err)
 		return
 	}
 
-	// Connect gateway to each external node
-	connectedCount := 0
-	for _, node := range status.Nodes {
+	// Connect gateway → each external node
+	connectedToExternal := 0
+	for _, node := range externalStatus.Nodes {
 		if node.Address != nil && *node.Address != "" {
 			if _, err := gatewayClient.ConnectNode(ctx, node.ID, *node.Address); err != nil {
-				log.V(1).Info("Failed to connect to external node", "nodeID", node.ID[:16]+"...", "address", *node.Address, "error", err)
+				log.V(1).Info("Failed to connect gateway to external node", "nodeID", node.ID[:16]+"...", "address", *node.Address, "error", err)
 			} else {
-				connectedCount++
+				connectedToExternal++
 			}
 		}
 	}
 
-	if connectedCount > 0 {
-		log.Info("Gateway connected to external storage cluster", "endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint, "nodesConnected", connectedCount)
+	// Connect external cluster → each gateway node (reverse direction).
+	// Without this, the external cluster never learns the gateway's address and
+	// shows it as offline even after the gateway successfully reaches out.
+	gatewayStatus, err := gatewayClient.GetClusterStatus(ctx)
+	if err != nil {
+		log.V(1).Info("Failed to get gateway cluster status for reverse connection", "error", err)
+		if connectedToExternal > 0 {
+			log.Info("Gateway connected to external storage cluster (one-way)", "endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint, "nodesConnected", connectedToExternal)
+		}
+		return
+	}
+
+	connectedToGateway := 0
+	for _, node := range gatewayStatus.Nodes {
+		if node.Address != nil && *node.Address != "" {
+			if _, err := externalClient.ConnectNode(ctx, node.ID, *node.Address); err != nil {
+				log.V(1).Info("Failed to connect external cluster to gateway node", "nodeID", node.ID[:16]+"...", "address", *node.Address, "error", err)
+			} else {
+				connectedToGateway++
+			}
+		}
+	}
+
+	if connectedToExternal > 0 || connectedToGateway > 0 {
+		log.Info("Gateway-external bidirectional connection established",
+			"endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint,
+			"gatewayToExternal", connectedToExternal,
+			"externalToGateway", connectedToGateway)
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,6 +22,8 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -2707,5 +2709,205 @@ spec:
 			}
 			Eventually(verifyStatefulSetDeleted, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
+	})
+})
+
+// External gateway tests require a Docker-based Garage node running alongside the kind cluster.
+// The hack/e2e-external-gateway.sh script sets up the infrastructure and exports the env vars below.
+var _ = Describe("External Gateway Cluster", Ordered, Label("external-gateway"), func() {
+	const gatewayClusterName = "ext-gateway"
+
+	var (
+		testNamespace        string
+		operatorEndpoint     string // operator→Garage: http://<docker-ip>:3903
+		hostEndpoint         string // test→Garage:    http://localhost:<host-port>
+		externalToken        string
+		rpcSecret            string
+		gatewayRPCPublicAddr string
+		gatewayRPCNodePort   string
+	)
+
+	BeforeAll(func() {
+		operatorEndpoint = os.Getenv("EXTERNAL_GARAGE_OPERATOR_ENDPOINT")
+		hostEndpoint = os.Getenv("EXTERNAL_GARAGE_HOST_ENDPOINT")
+		externalToken = os.Getenv("EXTERNAL_GARAGE_TOKEN")
+		rpcSecret = os.Getenv("EXTERNAL_RPC_SECRET")
+		gatewayRPCPublicAddr = os.Getenv("GATEWAY_RPC_PUBLIC_ADDR")
+		gatewayRPCNodePort = os.Getenv("GATEWAY_RPC_NODEPORT")
+		testNamespace = os.Getenv("E2E_TEST_NAMESPACE")
+		if testNamespace == "" {
+			testNamespace = "garage-ext-gw-test"
+		}
+
+		if operatorEndpoint == "" || hostEndpoint == "" || rpcSecret == "" || gatewayRPCPublicAddr == "" {
+			Skip("external gateway env vars not set — run via hack/e2e-external-gateway.sh")
+		}
+
+		By("creating test namespace")
+		cmd := exec.Command("kubectl", "create", "ns", testNamespace)
+		_, _ = utils.Run(cmd)
+	})
+
+	AfterAll(func() {
+		cmd := exec.Command("kubectl", "delete", "garagecluster", gatewayClusterName, "-n", testNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+		time.Sleep(5 * time.Second)
+		cmd = exec.Command("kubectl", "delete", "ns", testNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+	})
+
+	It("should create gateway cluster connecting to external Garage node", func() {
+		By("creating RPC secret")
+		rpcSecretYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ext-rpc-secret
+  namespace: %s
+type: Opaque
+stringData:
+  rpc-secret: "%s"
+`, testNamespace, rpcSecret)
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(rpcSecretYAML)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating admin token secret for external Garage")
+		tokenSecretYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ext-admin-token
+  namespace: %s
+type: Opaque
+stringData:
+  admin-token: "%s"
+`, testNamespace, externalToken)
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(tokenSecretYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		nodePortStr := "30901"
+		if gatewayRPCNodePort != "" {
+			nodePortStr = gatewayRPCNodePort
+		}
+
+		By("creating gateway GarageCluster with connectTo.adminApiEndpoint")
+		gatewayYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: 1
+  image: dxflrs/garage:v2.2.0
+  gateway: true
+
+  connectTo:
+    rpcSecretRef:
+      name: ext-rpc-secret
+      key: rpc-secret
+    adminApiEndpoint: '%s'
+    adminTokenSecretRef:
+      name: ext-admin-token
+      key: admin-token
+
+  replication:
+    factor: 1
+
+  network:
+    rpcPublicAddr: %s
+    rpcBindPort: 3901
+    service:
+      type: NodePort
+
+  publicEndpoint:
+    type: NodePort
+    nodePort:
+      basePort: %s
+
+  admin:
+    adminTokenSecretRef:
+      name: ext-admin-token
+      key: admin-token
+
+  security:
+    allowInsecureSecretPermissions: true
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 64Mi
+`, gatewayClusterName, testNamespace, operatorEndpoint, gatewayRPCPublicAddr, nodePortStr)
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(gatewayYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should reach Running phase", func() {
+		verifyRunning := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagecluster", gatewayClusterName,
+				"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Running"), "gateway phase: %s", output)
+		}
+		Eventually(verifyRunning, 5*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("should show the external node as connected (gateway perspective)", func() {
+		verifyConnected := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagecluster", gatewayClusterName,
+				"-n", testNamespace, "-o", "jsonpath={.status.health.connectedNodes}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			// Gateway sees itself + the external storage node = 2 connected nodes
+			g.Expect(output).To(Equal("2"), "expected 2 connected nodes (gateway + external), got %s", output)
+		}
+		Eventually(verifyConnected, 3*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("should appear as online in the external Garage cluster (bidirectional)", func() {
+		// This is the key assertion for the bidirectionality fix.
+		// The external Garage must have an outgoing RPC connection to the gateway — not just the reverse.
+		verifyBidirectional := func(g Gomega) {
+			req, err := http.NewRequest(http.MethodGet, hostEndpoint+"/v2/GetClusterStatus", nil)
+			g.Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+externalToken)
+
+			resp, err := http.DefaultClient.Do(req)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			var status struct {
+				Nodes []struct {
+					ID   string `json:"id"`
+					IsUp bool   `json:"isUp"`
+				} `json:"nodes"`
+			}
+			g.Expect(json.Unmarshal(body, &status)).To(Succeed())
+
+			// The external cluster should know about 2 nodes: itself + the gateway.
+			// At least one of the non-self nodes must be up.
+			g.Expect(status.Nodes).To(HaveLen(2), "external cluster should see 2 nodes (itself + gateway), got %d", len(status.Nodes))
+
+			upCount := 0
+			for _, n := range status.Nodes {
+				if n.IsUp {
+					upCount++
+				}
+			}
+			g.Expect(upCount).To(BeNumerically(">=", 2),
+				"expected both nodes up in external cluster, only %d up", upCount)
+		}
+		Eventually(verifyBidirectional, 3*time.Minute, 5*time.Second).Should(Succeed())
 	})
 })


### PR DESCRIPTION
## Summary

`connectGatewayToExternalCluster` only called `ConnectNode` on the gateway (gateway → external), but never on the external cluster (external → gateway). This caused the gateway to appear as **offline** from the external node's perspective — the external node never received an explicit instruction to connect back.

`connectGatewayToClusterRef` (in-cluster variant) already does this bidirectionally. This PR applies the same pattern to the external cluster path.

Fixes #126.