### PR TITLE
fix(gateway): improve external cluster connectivity and reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,12 +74,19 @@ config/samples/         # Example CRs
 
 ### Network Solutions
 
-**LoadBalancer per Node** (most reliable):
+**LoadBalancer per Node** (not yet implemented — sets `ConditionPublicEndpointReady=False`):
 ```yaml
 publicEndpoint:
   type: LoadBalancer
   loadBalancer:
-    perNode: true
+    perNode: true  # NOT IMPLEMENTED — use network.rpcPublicAddr instead
+```
+
+**LoadBalancer shared** (single LB IP, all pods):
+```yaml
+publicEndpoint:
+  type: LoadBalancer
+  # operator auto-derives rpc_public_addr from the LB service ingress IP
 ```
 
 **NodePort** (cheaper):
@@ -132,6 +139,16 @@ spec:
 ### Node Identity Persistence
 
 **Critical**: Garage nodes store their identity (Ed25519 keypair) in `metadata_dir/node_key`. This node ID is permanent and used for cluster membership. Gateway clusters use StatefulSet with a metadata PVC to preserve node identity across pod restarts. Without persistent metadata, each pod restart would generate a new node ID, causing stale nodes in the layout.
+
+### External Gateway Connectivity
+
+When `connectTo.adminApiEndpoint` is set, the operator calls `ConnectNode` in both directions (gateway → external AND external → gateway). The reverse direction requires the gateway to have an externally-routable address set via `network.rpcPublicAddr` or a working `publicEndpoint`. Without it, Garage advertises the pod IP, which is unreachable from outside K8s.
+
+**Reconciliation behavior:**
+- `ConditionGatewayConnected` is set True/False/PartiallyConnected based on results
+- When True, the operator skips ConnectNode calls and only does a lightweight `isUp` check
+- Healthy external gateway clusters requeue at 5m (not 1m) to avoid hammering the external admin API
+- Garage marks peers `Abandoned` after 10 failed retries and never retries again — the operator's 5m drift check is the only recovery path at that point
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ connectTo:
 
 ### External Storage (NAS, Bare Metal)
 
-To connect a gateway to a Garage instance running outside Kubernetes (e.g., on a NAS or bare-metal server), use `bootstrapPeers` instead of `clusterRef`. Get the node ID from your external Garage with `garage node id`.
+To connect a gateway to a Garage instance running outside Kubernetes (e.g., on a NAS or bare-metal server), use `adminApiEndpoint` with `rpcSecretRef`. The operator discovers nodes via the admin API and establishes bidirectional RPC connectivity on each reconcile.
 
 ```yaml
 apiVersion: garage.rajsingh.info/v1beta1
@@ -250,15 +250,30 @@ spec:
     rpcSecretRef:
       name: garage-rpc-secret
       key: rpc-secret
-    bootstrapPeers:
-      - "563e1ac825ee3323aa441e72c26d1030d6d4414aeb3dd25287c531e7fc2bc95d@nas.local:3901"
+    adminApiEndpoint: "http://nas.local:3903"
+    adminTokenSecretRef:
+      name: external-admin-token
+      key: admin-token
+  # Required: tell the external cluster how to reach the gateway back.
+  # Without this, the gateway connects outward but the external node cannot
+  # route S3 requests back through the gateway.
+  network:
+    rpcPublicAddr: "<external-ip-or-hostname>:3901"
+    service:
+      type: LoadBalancer  # or NodePort
   admin:
     adminTokenSecretRef:
       name: garage-admin-token
       key: admin-token
 ```
 
-The gateway pods will connect to the external nodes via the RPC port and register as gateway nodes in the existing cluster layout.
+**`network.rpcPublicAddr` is required** for the external cluster to reach the gateway. Without it, Garage advertises the pod IP, which is unreachable from outside Kubernetes. Set it to the externally-routable address of your gateway's RPC service — the LoadBalancer IP, the NodePort address, or a hostname that resolves to either.
+
+Alternatively, configure `publicEndpoint` (NodePort or LoadBalancer without `perNode`) and the operator will derive `rpc_public_addr` automatically from the service status.
+
+The operator establishes connectivity in both directions: gateway → external nodes and external cluster → gateway nodes. It also actively monitors the connection and re-establishes it if Garage marks a peer as unreachable.
+
+> **Note:** `bootstrapPeers` is also accepted for one-shot bootstrapping when you know the node ID in advance, but `adminApiEndpoint` is preferred — it works without knowing node IDs upfront and keeps the connection stable across restarts.
 
 ## Manual Node Layout (GarageNode)
 
@@ -703,10 +718,12 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
        rpcSecretRef:
          name: garage-rpc-secret
          key: rpc-secret
+     # publicEndpoint.loadBalancer.perNode is not yet implemented.
+     # Use network.rpcPublicAddr or a single shared LoadBalancer instead:
+     network:
+       rpcPublicAddr: "<node-external-ip>:3901"
      publicEndpoint:
        type: LoadBalancer
-       loadBalancer:
-         perNode: true
      remoteClusters:
        - name: eu-west
          zone: eu-west-1

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -159,6 +159,19 @@ const (
 
 	// ReasonAdminTokenMissing indicates spec.admin.adminTokenSecretRef is required but not configured
 	ReasonAdminTokenMissing = "AdminTokenMissing"
+
+	// ReasonAdminUnreachable indicates the external cluster's admin API cannot be reached
+	ReasonAdminUnreachable = "AdminUnreachable"
+
+	// ReasonGatewayConnected indicates bidirectional RPC connectivity is established
+	ReasonGatewayConnected = "Connected"
+
+	// ReasonGatewayPartiallyConnected indicates only gateway→external is working;
+	// the external cluster cannot reach the gateway (check publicEndpoint / rpcPublicAddr)
+	ReasonGatewayPartiallyConnected = "PartiallyConnected"
+
+	// ReasonGatewayNodesOffline indicates no nodes are connected in either direction
+	ReasonGatewayNodesOffline = "NodesOffline"
 )
 
 // Annotation keys for operational tasks

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -57,6 +57,9 @@ const (
 	// ConditionGatewayConnected indicates a gateway cluster's connection to its storage cluster.
 	// False when the admin token is missing or the connection cannot be established.
 	ConditionGatewayConnected = "GatewayConnected"
+
+	// ConditionPublicEndpointReady indicates the publicEndpoint configuration is valid and operational.
+	ConditionPublicEndpointReady = "PublicEndpointReady"
 )
 
 // GarageBucket condition types
@@ -172,6 +175,10 @@ const (
 
 	// ReasonGatewayNodesOffline indicates no nodes are connected in either direction
 	ReasonGatewayNodesOffline = "NodesOffline"
+
+	// ReasonPerNodeNotImplemented indicates publicEndpoint.loadBalancer.perNode is not yet supported;
+	// use network.rpcPublicAddr as a workaround
+	ReasonPerNodeNotImplemented = "PerNodeNotImplemented"
 )
 
 // Annotation keys for operational tasks

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -1372,7 +1372,13 @@ func (r *GarageClusterReconciler) reconcilePublicEndpointService(ctx context.Con
 	switch ep.Type {
 	case publicEndpointTypeLoadBalancer:
 		if ep.LoadBalancer != nil && ep.LoadBalancer.PerNode {
-			log.Info("publicEndpoint.loadBalancer.perNode is not yet implemented; use network.rpcPublicAddr for per-node addressing")
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:               garagev1beta1.ConditionPublicEndpointReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             garagev1beta1.ReasonPerNodeNotImplemented,
+				Message:            "publicEndpoint.loadBalancer.perNode is not yet implemented; set network.rpcPublicAddr to the externally-routable RPC address",
+				ObservedGeneration: cluster.Generation,
+			})
 			return nil
 		}
 		svcType = corev1.ServiceTypeLoadBalancer

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3392,6 +3392,54 @@ func (r *GarageClusterReconciler) connectGatewayToClusterRef(ctx context.Context
 	}
 }
 
+// deriveGatewayExternalAddr returns the externally-routable RPC address for this gateway cluster
+// as known to the operator (from publicEndpoint service status or nodePort config).
+// Returns empty when the address cannot be determined — the caller should then trust whatever
+// Garage itself reports. When network.rpcPublicAddr is set, Garage already advertises the correct
+// address via HelloMessage, so no override is needed.
+func (r *GarageClusterReconciler) deriveGatewayExternalAddr(ctx context.Context, cluster *garagev1beta1.GarageCluster) string {
+	if cluster.Spec.Network.RPCPublicAddr != "" {
+		return "" // Garage reports this correctly already
+	}
+	if cluster.Spec.PublicEndpoint == nil {
+		return ""
+	}
+
+	rpcPort := DefaultRPCPort
+	if cluster.Spec.Network.RPCBindPort != 0 {
+		rpcPort = cluster.Spec.Network.RPCBindPort
+	}
+
+	switch cluster.Spec.PublicEndpoint.Type {
+	case publicEndpointTypeLoadBalancer:
+		if cluster.Spec.PublicEndpoint.LoadBalancer != nil && cluster.Spec.PublicEndpoint.LoadBalancer.PerNode {
+			return "" // not yet implemented
+		}
+		svc := &corev1.Service{}
+		if err := r.Get(ctx, types.NamespacedName{Name: cluster.Name + "-rpc", Namespace: cluster.Namespace}, svc); err == nil {
+			for _, ing := range svc.Status.LoadBalancer.Ingress {
+				addr := ing.IP
+				if addr == "" {
+					addr = ing.Hostname
+				}
+				if addr != "" {
+					return fmt.Sprintf("%s:%d", addr, rpcPort)
+				}
+			}
+		}
+	case publicEndpointTypeNodePort:
+		if ep := cluster.Spec.PublicEndpoint.NodePort; ep != nil && len(ep.ExternalAddresses) > 0 {
+			basePort := ep.BasePort
+			if basePort == 0 {
+				basePort = 30901
+			}
+			return fmt.Sprintf("%s:%d", ep.ExternalAddresses[0], basePort)
+		}
+	}
+
+	return ""
+}
+
 // connectGatewayToExternalCluster connects a gateway to an external storage cluster via Admin API endpoint.
 // Bidirectional: gateway → external nodes AND external cluster → gateway nodes.
 func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Context, cluster *garagev1beta1.GarageCluster, gatewayClient *garage.Client) {
@@ -3434,14 +3482,40 @@ func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Co
 		return
 	}
 
+	// Derive the operator-known external address for this gateway cluster.
+	// Used to override internal (pod/service) IPs that Garage may report when
+	// rpc_public_addr is not set — such addresses are unreachable from external clusters.
+	overrideAddr := r.deriveGatewayExternalAddr(ctx, cluster)
+
 	connectedToGateway := 0
 	for _, node := range gatewayStatus.Nodes {
-		if node.Address != nil && *node.Address != "" {
-			if _, err := externalClient.ConnectNode(ctx, node.ID, *node.Address); err != nil {
-				log.V(1).Info("Failed to connect external cluster to gateway node", "nodeID", node.ID[:16]+"...", "address", *node.Address, "error", err)
+		addr := ""
+		if node.Address != nil {
+			addr = *node.Address
+		}
+
+		if isLikelyInternalAddr(addr) {
+			if overrideAddr != "" {
+				log.V(1).Info("Gateway node has internal address; using operator-derived external address",
+					"nodeID", node.ID[:16]+"...", "reported", addr, "override", overrideAddr)
+				addr = overrideAddr
 			} else {
-				connectedToGateway++
+				log.V(1).Info("Gateway node address is internal and no publicEndpoint configured; skipping reverse connect",
+					"nodeID", node.ID[:16]+"...", "address", addr)
+				continue
 			}
+		} else if addr == "" {
+			if overrideAddr != "" {
+				addr = overrideAddr
+			} else {
+				continue
+			}
+		}
+
+		if _, err := externalClient.ConnectNode(ctx, node.ID, addr); err != nil {
+			log.V(1).Info("Failed to connect external cluster to gateway node", "nodeID", node.ID[:16]+"...", "address", addr, "error", err)
+		} else {
+			connectedToGateway++
 		}
 	}
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -2503,7 +2503,13 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		return ctrl.Result{RequeueAfter: RequeueAfterUnhealthy}, nil
 	}
 
-	// Requeue for periodic health checks
+	// Back off to 5m for healthy external gateway clusters to avoid hammering the
+	// external admin API. The drift check in isExternalGatewayConnected handles
+	// reconnection within that window when Garage marks a peer as Abandoned.
+	if cluster.Spec.Gateway && cluster.Spec.ConnectTo != nil && cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
+		return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
+	}
+
 	return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 }
 
@@ -3279,8 +3285,49 @@ func (r *GarageClusterReconciler) reconcileGatewayConnection(ctx context.Context
 			}
 		}
 	} else if cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
+		// When the gateway is already connected, do a lightweight isUp check before
+		// issuing ConnectNode calls. Garage marks peers Abandoned after 10 retries and
+		// never retries again, so the operator must rescue dead connections — but we
+		// only need to act when something is actually down.
+		cond := meta.FindStatusCondition(cluster.Status.Conditions, garagev1beta1.ConditionGatewayConnected)
+		if cond != nil && cond.Status == metav1.ConditionTrue {
+			if r.isExternalGatewayConnected(ctx, cluster, gatewayClient) {
+				return
+			}
+			log.Info("External gateway connection degraded, re-establishing", "endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint)
+		}
 		r.connectGatewayToExternalCluster(ctx, cluster, gatewayClient)
 	}
+}
+
+// isExternalGatewayConnected checks whether all gateway nodes appear as isUp in the
+// external cluster's view. Returns false on any API error or if any node is offline,
+// which triggers a full reconnect via connectGatewayToExternalCluster.
+func (r *GarageClusterReconciler) isExternalGatewayConnected(ctx context.Context, cluster *garagev1beta1.GarageCluster, gatewayClient *garage.Client) bool {
+	externalClient, err := r.getExternalStorageClient(ctx, cluster)
+	if err != nil {
+		return false
+	}
+	gatewayStatus, err := gatewayClient.GetClusterStatus(ctx)
+	if err != nil || len(gatewayStatus.Nodes) == 0 {
+		return false
+	}
+	externalStatus, err := externalClient.GetClusterStatus(ctx)
+	if err != nil {
+		return false
+	}
+	upInExternal := make(map[string]bool, len(externalStatus.Nodes))
+	for _, n := range externalStatus.Nodes {
+		if n.IsUp {
+			upInExternal[n.ID] = true
+		}
+	}
+	for _, n := range gatewayStatus.Nodes {
+		if !upInExternal[n.ID] {
+			return false
+		}
+	}
+	return true
 }
 
 // connectGatewayToClusterRef connects a gateway to a storage cluster referenced by clusterRef.
@@ -3448,6 +3495,13 @@ func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Co
 	externalClient, err := r.getExternalStorageClient(ctx, cluster)
 	if err != nil {
 		log.V(1).Info("Failed to connect to external storage cluster", "error", err)
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonAdminUnreachable,
+			Message:            fmt.Sprintf("External cluster admin API unreachable: %v", err),
+			ObservedGeneration: cluster.Generation,
+		})
 		return
 	}
 
@@ -3524,6 +3578,33 @@ func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Co
 			"endpoint", cluster.Spec.ConnectTo.AdminAPIEndpoint,
 			"gatewayToExternal", connectedToExternal,
 			"externalToGateway", connectedToGateway)
+	}
+
+	switch {
+	case connectedToGateway > 0:
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionTrue,
+			Reason:             garagev1beta1.ReasonGatewayConnected,
+			Message:            fmt.Sprintf("Bidirectional connection established (%d gateway→external, %d external→gateway)", connectedToExternal, connectedToGateway),
+			ObservedGeneration: cluster.Generation,
+		})
+	case connectedToExternal > 0:
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonGatewayPartiallyConnected,
+			Message:            "Gateway can reach external cluster but external cluster cannot reach gateway — check publicEndpoint or network.rpcPublicAddr",
+			ObservedGeneration: cluster.Generation,
+		})
+	default:
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonGatewayNodesOffline,
+			Message:            "No nodes connected between gateway and external cluster",
+			ObservedGeneration: cluster.Generation,
+		})
 	}
 }
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -154,6 +154,22 @@ var validScrubCommands = map[string]bool{
 	garagev1beta1.ScrubCommandCancel: true,
 }
 
+// isLikelyInternalAddr returns true when addr looks like a pod or service IP
+// rather than an externally-routable address. Hostnames are assumed external.
+// Used to detect when Garage is advertising a pod IP that is unreachable from
+// an external cluster (i.e. rpc_public_addr was not set in the config).
+func isLikelyInternalAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false // hostname — assume external
+	}
+	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()
+}
+
 // Default Garage ports
 const (
 	DefaultS3Port    = int32(3900)


### PR DESCRIPTION
Addresses follow-up issues from #137 based on RogerSik's continued testing (issue #126).

## Changes

**1. Validate and override internal addresses in reverse ConnectNode**

When `rpc_public_addr` is not set in a gateway cluster's config, Garage advertises the pod IP in `GetClusterStatus`. The reverse `ConnectNode` call (external cluster → gateway) was passing this unreachable pod IP to the external cluster.

- `isLikelyInternalAddr` detects RFC1918/loopback addresses
- `deriveGatewayExternalAddr` reads the operator-known external address from the `publicEndpoint` LB service status or `NodePort` externalAddresses
- Reverse ConnectNode now overrides internal addresses with the operator-derived address, or skips the node with a log message if no external address is available

**2. Gate ConnectNode calls on condition check, back off to 5m when healthy**

External gateway clusters were reconciling every 1m and making 9–13 HTTP calls to the external admin API each time, causing nonstop log spam on the external node.

- `connectGatewayToExternalCluster` now sets `ConditionGatewayConnected` (True / PartiallyConnected / NodesOffline / AdminUnreachable)
- `reconcileGatewayConnection` checks the condition before issuing ConnectNode calls — when True, `isExternalGatewayConnected` does a lightweight `GetClusterStatus` check and skips ConnectNode if all gateway nodes are already `isUp` in the external cluster's view
- Healthy external gateway clusters requeue at 5m instead of 1m; the drift check still runs every 5m to rescue peers Garage has marked `Abandoned` (Garage never retries after 10 failed attempts)

**3. Surface perNode-not-implemented as status condition**

`publicEndpoint.loadBalancer.perNode: true` was silently doing nothing (log-only warning). Now sets `ConditionPublicEndpointReady=False, Reason=PerNodeNotImplemented` so the misconfiguration is visible in `kubectl describe`.

## Testing

All unit tests pass. The external gateway E2E test added in #137 covers the bidirectional connectivity scenario.