### PR TITLE
fix: design audit — orphaned resources, missing watches, and webhook gaps

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -154,6 +154,9 @@ const (
 	// ReasonClusterNotReady indicates the Garage cluster is not ready
 	ReasonClusterNotReady = "ClusterNotReady"
 
+	// ReasonClusterDeleting indicates the referenced Garage cluster is being deleted
+	ReasonClusterDeleting = "ClusterDeleting"
+
 	// ReasonExpired indicates the resource has expired
 	ReasonExpired = "Expired"
 

--- a/api/v1beta1/garagecluster_webhook.go
+++ b/api/v1beta1/garagecluster_webhook.go
@@ -158,6 +158,10 @@ func (r *GarageCluster) validateGarageCluster() (admission.Warnings, error) {
 		return warnings, err
 	}
 
+	if err := r.validateLayoutManagement(); err != nil {
+		return warnings, err
+	}
+
 	if r.isMetadataEphemeral() {
 		warnings = append(warnings, "storage.metadata.type=EmptyDir: Node identity will be lost on pod restart")
 	}
@@ -331,6 +335,29 @@ func (r *GarageCluster) validateAPIs() error {
 	if r.Spec.Admin != nil && r.Spec.Admin.BindAddress != "" {
 		if err := validateBindAddress(r.Spec.Admin.BindAddress, "admin"); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *GarageCluster) validateLayoutManagement() error {
+	lm := r.Spec.LayoutManagement
+	if lm == nil {
+		return nil
+	}
+
+	if lm.MinNodesHealthy < 0 {
+		return fmt.Errorf("layoutManagement.minNodesHealthy: must be non-negative, got %d", lm.MinNodesHealthy)
+	}
+
+	if lm.MinNodesHealthy > 0 {
+		replicas := int(r.Spec.Replicas)
+		if replicas == 0 {
+			replicas = 3 // webhook default
+		}
+		if lm.MinNodesHealthy > replicas {
+			return fmt.Errorf("layoutManagement.minNodesHealthy (%d) cannot exceed replicas (%d) — layout changes would never be applied", lm.MinNodesHealthy, replicas)
 		}
 	}
 

--- a/api/v1beta1/garagekey_webhook.go
+++ b/api/v1beta1/garagekey_webhook.go
@@ -150,6 +150,12 @@ func (v *GarageKeyValidator) validateGarageKey(ctx context.Context, obj *GarageK
 				"You can grant access via GarageKey.bucketPermissions, GarageKey.allBuckets, or GarageBucket.keyPermissions.")
 	}
 
+	if len(obj.Spec.BucketPermissions) > 0 && obj.Spec.AllBuckets != nil {
+		warnings = append(warnings,
+			"Both allBuckets and bucketPermissions are set. allBuckets grants a baseline permission set on every bucket; "+
+				"bucketPermissions entries are applied on top. Verify this is intentional.")
+	}
+
 	return warnings, nil
 }
 

--- a/api/v1beta1/webhook_test.go
+++ b/api/v1beta1/webhook_test.go
@@ -940,6 +940,41 @@ func TestBucketRef_UnmarshalJSON_InGarageKeyList(t *testing.T) {
 	}
 }
 
+func TestGarageCluster_ValidateLayoutManagement(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas int32
+		lm       *LayoutManagementConfig
+		wantErr  bool
+		errMsg   string
+	}{
+		{"nil layoutManagement is valid", 3, nil, false, ""},
+		{"minNodesHealthy=0 is valid", 3, &LayoutManagementConfig{MinNodesHealthy: 0}, false, ""},
+		{"minNodesHealthy equals replicas is valid", 3, &LayoutManagementConfig{MinNodesHealthy: 3}, false, ""},
+		{"minNodesHealthy less than replicas is valid", 5, &LayoutManagementConfig{MinNodesHealthy: 3}, false, ""},
+		{"minNodesHealthy exceeds replicas is rejected", 3, &LayoutManagementConfig{MinNodesHealthy: 4}, true, "cannot exceed replicas"},
+		{"minNodesHealthy=1 with default replicas(0→3) is valid", 0, &LayoutManagementConfig{MinNodesHealthy: 1}, false, ""},
+		{"minNodesHealthy=4 with default replicas(0→3) is rejected", 0, &LayoutManagementConfig{MinNodesHealthy: 4}, true, "cannot exceed replicas"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &GarageCluster{
+				Spec: GarageClusterSpec{
+					Replicas:         tt.replicas,
+					LayoutManagement: tt.lm,
+				},
+			}
+			err := cluster.validateLayoutManagement()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateLayoutManagement() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("validateLayoutManagement() error = %v, want containing %q", err, tt.errMsg)
+			}
+		})
+	}
+}
+
 func TestGarageCluster_Storage_PathsOnMetadataRejected(t *testing.T) {
 	v := &GarageClusterValidator{}
 	size := resource.MustParse("10Gi")

--- a/api/v1beta1/webhook_test.go
+++ b/api/v1beta1/webhook_test.go
@@ -622,6 +622,38 @@ func TestGarageKeyValidator_NoBucketPermissionsWarning(t *testing.T) {
 	}
 }
 
+func TestGarageKeyValidator_AllBucketsAndBucketPermissionsBothSet_Warning(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(fakeScheme(t)).Build()
+	v := &GarageKeyValidator{Client: c}
+	key := &GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: testKey, Namespace: testWebhookNS},
+		Spec: GarageKeySpec{
+			ClusterRef: ClusterReference{Name: testCluster},
+			AllBuckets: &AllBucketsPermission{Read: true},
+			BucketPermissions: []BucketPermission{
+				{BucketRef: &BucketRef{Name: testBucket}, Write: true},
+			},
+		},
+	}
+	warnings, err := v.validateGarageKey(context.Background(), key)
+	if err != nil {
+		t.Errorf("both set is not an error, got: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Error("expected a warning when both allBuckets and bucketPermissions are set")
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "allBuckets") && strings.Contains(w, "bucketPermissions") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning mentioning allBuckets and bucketPermissions, got: %v", warnings)
+	}
+}
+
 func TestValidateKeyPermissions(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -94,9 +94,30 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Now check cluster error for non-deletion cases
 	if clusterErr != nil {
 		if errors.IsNotFound(clusterErr) {
+			log.Info("Referenced cluster not found, waiting", "cluster", bucket.Spec.ClusterRef.Name, "namespace", clusterNamespace)
 			return r.updateStatusWaiting(ctx, bucket)
 		}
-		return r.updateStatus(ctx, bucket, PhaseFailed, fmt.Errorf("cluster not found: %w", clusterErr))
+		return r.updateStatus(ctx, bucket, PhaseFailed, fmt.Errorf("failed to get cluster: %w", clusterErr))
+	}
+
+	// Set owner reference from bucket to cluster so the bucket is GC'd when the cluster is deleted.
+	// Kubernetes forbids cross-namespace owner references, so only set if same namespace.
+	// Skip if the cluster is being deleted — setting an ownerRef to a deleting object is
+	// pointless and we want the ClusterDeleting guard below to run without interference.
+	if clusterNamespace == bucket.Namespace && cluster.DeletionTimestamp.IsZero() {
+		if !ownerRefExists(bucket, cluster.UID) {
+			if err := controllerutil.SetOwnerReference(cluster, bucket, r.Scheme); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to set owner reference: %w", err)
+			}
+			if err := r.Update(ctx, bucket); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to update bucket with owner reference: %w", err)
+			}
+			// Re-enqueue so we continue with the updated object.
+			return ctrl.Result{Requeue: true}, nil
+		}
+	} else if clusterNamespace != bucket.Namespace {
+		log.V(1).Info("Skipping owner reference: bucket and cluster are in different namespaces",
+			"bucketNamespace", bucket.Namespace, "clusterNamespace", clusterNamespace)
 	}
 
 	// Guard against calling the Garage API before the cluster layout has converged.
@@ -106,16 +127,25 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// and leak a fresh cross-namespace Secret under the dying UID.
 	if !bucket.DeletionTimestamp.IsZero() {
 		// Allow deletions to proceed regardless of cluster health.
-	} else if !cluster.DeletionTimestamp.IsZero() || cluster.Status.Phase != PhaseRunning {
-		msg := "waiting for cluster to reach Running phase"
-		if !cluster.DeletionTimestamp.IsZero() {
-			msg = "garage cluster is being deleted"
+	} else if !cluster.DeletionTimestamp.IsZero() {
+		meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+			Type:               PhaseReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonClusterDeleting,
+			Message:            "referenced cluster is being deleted",
+			ObservedGeneration: bucket.Generation,
+		})
+		bucket.Status.Phase = PhasePending
+		if err := UpdateStatusWithRetry(ctx, r.Client, bucket); err != nil {
+			return ctrl.Result{}, err
 		}
+		return ctrl.Result{RequeueAfter: RequeueAfterUnhealthy}, nil
+	} else if cluster.Status.Phase != PhaseRunning {
 		meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
 			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
 			Reason:             garagev1beta1.ReasonClusterNotReady,
-			Message:            msg,
+			Message:            "waiting for cluster to reach Running phase",
 			ObservedGeneration: bucket.Generation,
 		})
 		bucket.Status.Phase = PhasePending
@@ -795,6 +825,16 @@ func (r *GarageBucketReconciler) handleBucketAnnotations(ctx context.Context, bu
 		"olderThanSecs", olderThan,
 		"uploadsDeleted", result.UploadsDeleted)
 	return nil
+}
+
+// ownerRefExists reports whether obj already has an owner reference with the given UID.
+func ownerRefExists(obj client.Object, uid types.UID) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == uid {
+			return true
+		}
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -230,13 +230,13 @@ var _ = Describe("GarageBucket Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 
-			By("Verifying the reconciler bailed out with ClusterNotReady before calling Garage")
+			By("Verifying the reconciler bailed out with ClusterDeleting before calling Garage")
 			updated := &garagev1beta1.GarageBucket{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
 			Expect(updated.Status.Phase).To(Equal(PhasePending))
 			ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
 			Expect(ready).NotTo(BeNil())
-			Expect(ready.Reason).To(Equal(garagev1beta1.ReasonClusterNotReady))
+			Expect(ready.Reason).To(Equal(garagev1beta1.ReasonClusterDeleting))
 			Expect(ready.Message).To(ContainSubstring("being deleted"))
 		})
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -44,7 +44,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	"github.com/rajsinghtech/garage-operator/internal/garage"
@@ -4531,6 +4533,20 @@ func (r *GarageClusterReconciler) handleSkipDeadNodes(ctx context.Context, clust
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GarageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// PVCs are created by the StatefulSet's volumeClaimTemplates and are therefore not
+	// directly owned by GarageCluster (the ownerRef points to the StatefulSet). Use a
+	// label-based mapper so PVC status changes (e.g., resize completing) retrigger
+	// reconciliation of the owning cluster without waiting for the next scheduled requeue.
+	pvcMapper := handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+		clusterName, ok := obj.GetLabels()[labelCluster]
+		if !ok || clusterName == "" {
+			return nil
+		}
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Name: clusterName, Namespace: obj.GetNamespace()},
+		}}
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&garagev1beta1.GarageCluster{}).
 		Owns(&appsv1.StatefulSet{}).
@@ -4538,6 +4554,7 @@ func (r *GarageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
+		Watches(&corev1.PersistentVolumeClaim{}, pvcMapper).
 		Named("garagecluster").
 		Complete(r)
 }

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -101,15 +101,19 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.updateStatus(ctx, key, PhaseFailed, fmt.Errorf("cluster not found: %w", clusterErr))
 	}
 
-	// Guard against calling the Garage API before the cluster layout has converged.
+	// Guard against calling the Garage API before the cluster layout has converged,
+	// or when the cluster is being deleted (avoids "connection refused" from a dying admin API).
 	if !key.DeletionTimestamp.IsZero() {
 		// Allow deletions to proceed regardless of cluster health.
-	} else if cluster.Status.Phase != PhaseRunning {
+	} else if !cluster.DeletionTimestamp.IsZero() || cluster.Status.Phase != PhaseRunning {
 		msg := "waiting for cluster to reach Running phase"
+		if !cluster.DeletionTimestamp.IsZero() {
+			msg = "garage cluster is being deleted"
+		}
 		meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
 			Type:               PhaseReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "ClusterNotReady",
+			Reason:             garagev1beta1.ReasonClusterNotReady,
 			Message:            msg,
 			ObservedGeneration: key.Generation,
 		})


### PR DESCRIPTION
Addresses 4 of the 8 issues found in the design audit (issue #3 — GarageNode cross-namespace webhook — was already implemented; issue #6 — `adminApiEndpoint` naming — is a breaking API change deferred to a separate discussion).

## Changes

**`fix(controller): watch PVCs for cluster reconcile, guard key controller on cluster deletion`**
- Added a label-based `Watches` on `PersistentVolumeClaim` in `SetupWithManager` so `reconcilePVCExpansion` retrigggers when a PVC's status changes externally (e.g. a resize completes)
- When a GarageCluster's `DeletionTimestamp` is set, the GarageKey controller now returns early with `ReasonClusterNotReady` instead of hammering a dying admin API with "connection refused" errors

**`fix(bucket): set owner ref to cluster and distinguish cluster-deleting status`**
- GarageBucket now sets a non-controlling owner reference to its GarageCluster (same-namespace only — cross-namespace refs are forbidden by Kubernetes), enabling GC when the cluster is deleted
- Bucket status now sets `ReasonClusterDeleting` (new constant) when the referenced cluster has a `DeletionTimestamp`, rather than leaving conditions stale or reusing the generic `ReasonClusterNotReady`

**`fix(webhook): reject minNodesHealthy exceeding replicas`**
- `layoutManagement.minNodesHealthy > spec.replicas` is now a webhook validation error with a clear message; treats `replicas=0` as the default of 3

**`feat(webhook): warn when both allBuckets and bucketPermissions are set on GarageKey`**
- Returns an `admission.Warning` (not an error) when both are set simultaneously, consistent with the existing "neither set" warning pattern

## Skipped / deferred
- Issue #3 (GarageNode cross-namespace clusterRef) — already implemented in `garagenode_webhook.go`
- Issue #6 (`adminApiEndpoint` field naming) — breaking API change, needs migration guide and version discussion