### PR TITLE
fix(bucket): two-phase creation to eliminate orphaned buckets

### DIFF
--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -232,8 +232,24 @@ func (r *GarageBucketReconciler) reconcileBucket(ctx context.Context, bucket *ga
 		alias = bucket.Spec.GlobalAlias
 	}
 
+	prevBucketID := bucket.Status.BucketID
 	existingBucket, err := r.getOrCreateBucket(ctx, bucket, garageClient, alias)
 	if err != nil {
+		return err
+	}
+
+	// Persist status.BucketID immediately whenever it is newly learned or created.
+	// Without this, a crash between creation and the end-of-reconcile status write
+	// causes the next reconcile to lose track of the bucket and create a duplicate.
+	if bucket.Status.BucketID != prevBucketID {
+		if err := r.Status().Update(ctx, bucket); err != nil {
+			return fmt.Errorf("failed to persist bucket ID: %w", err)
+		}
+	}
+
+	// Ensure the global alias is set. This is an explicit idempotent step because
+	// CreateBucket no longer sets the alias atomically — see getOrCreateBucket for why.
+	if err := r.reconcileGlobalAlias(ctx, garageClient, existingBucket.ID, alias, existingBucket.GlobalAliases); err != nil {
 		return err
 	}
 
@@ -303,22 +319,37 @@ func (r *GarageBucketReconciler) getOrCreateBucket(ctx context.Context, bucket *
 		return nil, fmt.Errorf("failed to get bucket by alias %s: %w", alias, err)
 	}
 
+	// Create without a global alias so Garage only performs one atomic write
+	// (inserting the bucket record). The Garage CreateBucket handler is not
+	// atomic: it writes the bucket record first and then sets the alias in a
+	// separate step. If the alias step fails, Garage returns an error but the
+	// bare bucket record already exists — producing an orphan with no alias
+	// that the operator cannot find on the next reconcile, which then creates
+	// another orphan, and so on. Separating creation from alias-setting (via
+	// reconcileGlobalAlias) eliminates this failure mode.
 	log.Info("Creating bucket", "alias", alias)
-	created, err := garageClient.CreateBucket(ctx, garage.CreateBucketRequest{GlobalAlias: alias})
+	created, err := garageClient.CreateBucket(ctx, garage.CreateBucketRequest{})
 	if err != nil {
-		if garage.IsConflict(err) {
-			log.Info("Bucket creation conflict, fetching existing bucket", "alias", alias)
-			existing, getErr := garageClient.GetBucket(ctx, garage.GetBucketRequest{GlobalAlias: alias})
-			if getErr != nil {
-				return nil, fmt.Errorf("failed to create bucket (conflict) and failed to get existing bucket: %w (original: %v)", getErr, err)
-			}
-			bucket.Status.BucketID = existing.ID
-			return existing, nil
-		}
 		return nil, fmt.Errorf("failed to create bucket: %w", err)
 	}
 	bucket.Status.BucketID = created.ID
 	return created, nil
+}
+
+func (r *GarageBucketReconciler) reconcileGlobalAlias(ctx context.Context, garageClient *garage.Client, bucketID, alias string, currentAliases []string) error {
+	for _, a := range currentAliases {
+		if a == alias {
+			return nil
+		}
+	}
+	_, err := garageClient.AddBucketAlias(ctx, garage.AddBucketAliasRequest{
+		BucketID:    bucketID,
+		GlobalAlias: alias,
+	})
+	if err != nil && !garage.IsConflict(err) {
+		return fmt.Errorf("failed to set global alias %q on bucket %s: %w", alias, bucketID, err)
+	}
+	return nil
 }
 
 func (r *GarageBucketReconciler) updateBucketSettings(ctx context.Context, bucket *garagev1beta1.GarageBucket, garageClient *garage.Client, existingBucket *garage.Bucket) error {


### PR DESCRIPTION
## Problem

Garage's `CreateBucket` handler is **not atomic**: it inserts the bucket record first, then sets the global alias in a separate step. If the alias step fails during cluster recovery (transient errors, node unavailability), Garage returns an error to the operator but the bare bucket record already exists.

The operator had no way to track this partially-created bucket. On every retry it would:
1. `GetBucket(ID)` → miss (status.BucketID was never persisted — creation returned an error)
2. `GetBucket(alias)` → 404 (alias was never set)
3. `CreateBucket(alias)` → another bare orphan

This is what produced ~2900 empty orphaned buckets during the recent post-recovery rebalance (all created 2026-05-06, no aliases, no objects).

## Fix

Three changes together eliminate this failure mode:

**1. Create bucket without alias (`getOrCreateBucket`)**
`CreateBucketRequest{}` instead of `CreateBucketRequest{GlobalAlias: alias}`. Garage then only performs one atomic write (`bucket_table.insert`). Either the whole operation succeeds and returns an ID, or nothing is written. The alias conflict handling is also removed since an alias-less create can never conflict on alias.

**2. Immediately persist `status.BucketID` (`reconcileBucket`)**
After `getOrCreateBucket` returns, if the bucket ID was newly learned/created, we call `r.Status().Update` before any other Garage operations. This closes the crash window: if the operator restarts between creation and the end-of-reconcile status write, the next reconcile finds the bucket by ID rather than creating another.

**3. Idempotent `reconcileGlobalAlias` step**
A new explicit step sets the global alias via `AddBucketAlias` after the status is persisted. `AddBucketAlias` is safe to retry — conflicts (alias already set) are treated as success.

## Before / After

| Scenario | Before | After |
|---|---|---|
| `CreateBucket` alias step fails | orphan created | error propagated, retry finds by ID |
| Operator crashes after creation | orphan on next reconcile | next reconcile finds by ID |
| Normal create path | bucket + alias in one call | bucket created, then alias set idempotently |

## Testing

- `go build ./...` passes clean
- Existing tests are infra-integration tests (require envtest binary not available locally) — no test regressions from build

## Related

Follows up on #146 (`fix(bucket): don't create new bucket on transient Garage errors`) which fixed the transient-error fallthrough. This PR fixes the remaining failure mode where `CreateBucket` itself partially succeeds inside Garage.