### PR TITLE
fix: external gateway reverse ConnectNode, API spam, and reconcile backoff

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -2397,16 +2397,16 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		return ctrl.Result{}, err
 	}
 
+	// External gateway clusters back off to 5m regardless of health: gateways may show
+	// "unavailable" by design (no data stored locally) and that's expected. The drift
+	// check in isExternalGatewayConnected handles reconnection within that window.
+	if cluster.Spec.Gateway && cluster.Spec.ConnectTo != nil && cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
+		return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
+	}
+
 	// Requeue faster when cluster is unhealthy to speed up recovery
 	if cluster.Status.Health != nil && cluster.Status.Health.Status != healthStatusHealthy {
 		return ctrl.Result{RequeueAfter: RequeueAfterUnhealthy}, nil
-	}
-
-	// Back off to 5m for healthy external gateway clusters to avoid hammering the
-	// external admin API. The drift check in isExternalGatewayConnected handles
-	// reconnection within that window when Garage marks a peer as Abandoned.
-	if cluster.Spec.Gateway && cluster.Spec.ConnectTo != nil && cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
-		return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
 	}
 
 	return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
@@ -2931,13 +2931,16 @@ func (r *GarageClusterReconciler) bootstrapCluster(ctx context.Context, cluster 
 	// We also reconnect when health status is "degraded" because a pod restart
 	// may have changed its IP, and even if connectedNodes == len(nodes),
 	// Garage might still be trying to reach the old IP addresses.
+	// For gateway clusters, skip the health-status reconnect trigger: gateways may
+	// permanently show "unavailable" (no data stored) and that's expected. Only
+	// reconnect when a pod is actually disconnected (connectedNodes < expected).
 	var connectedNodes int
 	var healthStatus string
 	if health != nil {
 		connectedNodes = health.ConnectedNodes
 		healthStatus = health.Status
 	}
-	needsReconnect := health == nil || connectedNodes < len(nodes) || healthStatus != healthStatusHealthy
+	needsReconnect := health == nil || connectedNodes < len(nodes) || (!cluster.Spec.Gateway && healthStatus != healthStatusHealthy)
 	if needsReconnect {
 		log.Info("Cluster needs node reconnection", "connected", connectedNodes, "expected", len(nodes), "status", healthStatus)
 		connectNodes(ctx, nodes, adminToken, adminPort, rpcPort)
@@ -3345,7 +3348,10 @@ func (r *GarageClusterReconciler) connectGatewayToClusterRef(ctx context.Context
 // address via HelloMessage, so no override is needed.
 func (r *GarageClusterReconciler) deriveGatewayExternalAddr(ctx context.Context, cluster *garagev1beta1.GarageCluster) string {
 	if cluster.Spec.Network.RPCPublicAddr != "" {
-		return "" // Garage reports this correctly already
+		// Garage advertises rpcPublicAddr via HelloMessage to peers, but GetClusterStatus
+		// returns an empty address for the local node itself. Return it directly so the
+		// operator can pass it to the external cluster's ConnectNode call.
+		return cluster.Spec.Network.RPCPublicAddr
 	}
 	if cluster.Spec.PublicEndpoint == nil {
 		return ""

--- a/internal/controller/publicendpoint_test.go
+++ b/internal/controller/publicendpoint_test.go
@@ -260,6 +260,33 @@ var _ = Describe("publicEndpoint reconciliation", func() {
 			Expect(cond.Reason).To(Equal(garagev1beta1.ReasonAdminTokenMissing))
 		})
 	})
+
+	Context("deriveGatewayExternalAddr", func() {
+		It("returns rpcPublicAddr directly when set", func() {
+			// Regression: previously returned "" when rpcPublicAddr was set, causing the
+			// reverse ConnectNode call to skip gateway nodes with no self-reported address.
+			cluster := &garagev1beta1.GarageCluster{
+				Spec: garagev1beta1.GarageClusterSpec{
+					Gateway: true,
+					Network: garagev1beta1.NetworkConfig{
+						RPCPublicAddr: "192.168.0.53:3901",
+					},
+				},
+			}
+			addr := reconciler.deriveGatewayExternalAddr(ctx, cluster)
+			Expect(addr).To(Equal("192.168.0.53:3901"))
+		})
+
+		It("returns empty when neither rpcPublicAddr nor publicEndpoint is configured", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				Spec: garagev1beta1.GarageClusterSpec{
+					Gateway: true,
+				},
+			}
+			addr := reconciler.deriveGatewayExternalAddr(ctx, cluster)
+			Expect(addr).To(BeEmpty())
+		})
+	})
 })
 
 func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3156,4 +3156,35 @@ spec:
 		}
 		Eventually(verifyBidirectional, 3*time.Minute, 5*time.Second).Should(Succeed())
 	})
+
+	It("should set GatewayConnected condition to True", func() {
+		// Regression: externalToGateway=0 caused the condition to stay PartiallyConnected
+		// (False) indefinitely. deriveGatewayExternalAddr was returning "" when rpcPublicAddr
+		// was set, so the reverse ConnectNode call skipped gateway nodes that report no
+		// self-address in GetClusterStatus.
+		verifyCondition := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagecluster", gatewayClusterName,
+				"-n", testNamespace,
+				"-o", `jsonpath={.status.conditions[?(@.type=="GatewayConnected")].status}`)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"), "GatewayConnected not True: %s", output)
+		}
+		Eventually(verifyCondition, 3*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("should not continuously spam the external admin API after connection is established", func() {
+		// Regression: GatewayConnected=False triggered 10s reconciles and called
+		// ConnectClusterNodes on every cycle. With GatewayConnected=True the operator
+		// runs a lightweight isUp check instead and backs off to 5 minutes. Verify the
+		// condition stays True for a 30s window — any flip indicates rapid reconcile.
+		Consistently(func() string {
+			cmd := exec.Command("kubectl", "get", "garagecluster", gatewayClusterName,
+				"-n", testNamespace,
+				"-o", `jsonpath={.status.conditions[?(@.type=="GatewayConnected")].status}`)
+			output, _ := utils.Run(cmd)
+			return output
+		}, 30*time.Second, 5*time.Second).Should(Equal("True"),
+			"GatewayConnected flipped — rapid reconcile may be calling ConnectNode repeatedly")
+	})
 })


### PR DESCRIPTION
## Summary

Fixes three bugs in external gateway clusters (`connectTo.adminApiEndpoint`) reported in #126, and closes the test coverage gaps that let them slip through.

### Bug 1 — reverse ConnectNode was always skipped when `rpcPublicAddr` is set

`deriveGatewayExternalAddr` returned `""` when `network.rpcPublicAddr` was configured, reasoning that Garage advertises the address via HelloMessage. That's true for peer learning, but `GetClusterStatus` returns no address for the *local* node itself. So the loop that tells the external cluster to connect back to the gateway hit `addr == "" && overrideAddr == ""` → `continue` on every reconcile — `externalToGateway` stayed 0, `GatewayConnected` condition stayed `False`.

Fix: return `rpcPublicAddr` directly from `deriveGatewayExternalAddr` so the reverse `ConnectNode` call gets a usable address.

### Bug 2 — `bootstrapCluster` spammed `connectNodes` for gateway clusters

The `needsReconnect` check fired whenever `healthStatus != "healthy"`. Gateway clusters permanently report `"unavailable"` (no local data, can't serve independently), so `connectNodes` was called on every reconcile even when all pods were connected. Added `!cluster.Spec.Gateway` gate — gateways only reconnect when `connectedNodes < expected`.

### Bug 3 — `RequeueAfterUnhealthy` (10s) shadowed `RequeueAfterLong` (5m)

The 5-minute backoff for external gateways was checked *after* the health status check. Since health is always `"unavailable"` for gateways, the 10s path always won. Swapped the order so external gateways always get 5-minute requeue intervals.

### Why the e2e test didn't catch this

The existing bidirectionality test checked Garage-level `isUp` via `GetClusterStatus` on the external node. This passes even with `externalToGateway=0` because the gateway's outgoing connection propagates the address via HelloMessage — Garage establishes bidirectional connectivity without the operator's explicit reverse `ConnectNode`. The operator's `GatewayConnected` condition, however, stayed `False` permanently.

## Test plan

- [x] Unit test: `deriveGatewayExternalAddr` returns `rpcPublicAddr` when set (not `""`)
- [x] e2e: `GatewayConnected` condition reaches `True` after connection established
- [x] e2e: `GatewayConnected` stays `True` for 30s (catches rapid-reconcile condition flipping)
- [x] `./hack/e2e-external-gateway.sh` — all 6 specs pass
- [x] `go test ./internal/controller/...` — passes

Closes #126