### PR TITLE
fix: surface ConnectClusterNodes result failures

### DIFF
--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -1094,6 +1094,13 @@ func (c *Client) ConnectNode(ctx context.Context, nodeID, address string) (*Conn
 		return nil, fmt.Errorf("empty response from ConnectClusterNodes")
 	}
 
+	if !results[0].Success {
+		if results[0].Error != nil && *results[0].Error != "" {
+			return &results[0], fmt.Errorf("ConnectClusterNodes failed: %s", *results[0].Error)
+		}
+		return &results[0], fmt.Errorf("ConnectClusterNodes failed")
+	}
+
 	return &results[0], nil
 }
 

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -507,3 +507,39 @@ func TestLaunchScrubCommand_RequestBody(t *testing.T) {
 		})
 	}
 }
+
+func TestConnectNode_ReturnsErrorWhenGarageReportsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/ConnectClusterNodes" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+
+		var body []string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if len(body) != 1 || body[0] != "abc123@192.168.0.53:3901" {
+			t.Fatalf("unexpected request body: %#v", body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"success":false,"error":"Error establishing RPC connection"}]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	result, err := c.ConnectNode(context.Background(), "abc123", "192.168.0.53:3901")
+
+	if err == nil {
+		t.Fatal("expected ConnectNode to return an error")
+	}
+	if result == nil {
+		t.Fatal("expected ConnectNode to return the Garage response")
+	}
+	if result.Success {
+		t.Fatal("expected result.Success to be false")
+	}
+	if got := err.Error(); got != "ConnectClusterNodes failed: Error establishing RPC connection" {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

This fixes a misleading success path in the Garage admin API client. Garage's `/v2/ConnectClusterNodes` endpoint can return HTTP 200 while reporting per-node failures in the response body:

```json
[{"success": false, "error": "..."}]
```

The operator previously treated that as a successful `ConnectNode` call. That could make gateway/external-cluster reconciliation logs and counters report progress even when Garage had rejected or failed the actual RPC connection attempt.

With this change, `ConnectNode` now returns an error when the first result has `success:false`, preserving Garage's error message for controller logs and status handling.

## Why

While reproducing an external gateway setup with an external Garage node and a Kubernetes LoadBalancer RPC address, the gateway side could see the external node, but the external cluster still showed the gateway node as offline. Better error propagation is needed so the operator reports the actual `ConnectClusterNodes` result instead of optimistic counters.

## Testing

- `go test ./internal/garage`
- `go test ./internal/controller -run 'Test|publicEndpoint|federation'`
- external-gateway E2E on current `main` passes
- reproduced the historical LoadBalancer failure on `v0.4.6` with a MetalLB-backed external gateway setup
