### PR TITLE
feat: implement per-node LoadBalancer public endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,11 @@ spec:
       key: admin-token
 ```
 
-**`network.rpcPublicAddr` is required** for the external cluster to reach the gateway. Without it, Garage advertises the pod IP, which is unreachable from outside Kubernetes. Set it to the externally-routable address of your gateway's RPC service — the LoadBalancer IP, the NodePort address, or a hostname that resolves to either.
+**`network.rpcPublicAddr` or `publicEndpoint` is required** for the external cluster to reach the gateway. Without an externally-routable RPC address, Garage advertises a pod IP, which is unreachable from outside Kubernetes. Set `network.rpcPublicAddr` to the externally-routable address of your gateway's RPC service, or configure `publicEndpoint` so the operator can derive the address from Kubernetes service status.
 
-Alternatively, configure `publicEndpoint` (NodePort or LoadBalancer without `perNode`) and the operator will derive `rpc_public_addr` automatically from the service status.
+For a single shared RPC endpoint, use `publicEndpoint.type: LoadBalancer` without `loadBalancer.perNode`; the operator creates one `<cluster>-rpc` LoadBalancer service and derives one `rpc_public_addr` from it. This is the simplest setup when your infrastructure provides a global/shared load balancer address that can route RPC traffic to the gateway pods.
+
+For per-pod LoadBalancer services, set `publicEndpoint.type: LoadBalancer` and `publicEndpoint.loadBalancer.perNode: true`; the operator creates `<cluster>-0-rpc`, `<cluster>-1-rpc`, etc. In auto-layout `GarageCluster` mode, the pods still share one Garage ConfigMap, so the operator does not write distinct per-pod `rpc_public_addr` values into Garage's config. The per-node service addresses are used by the operator when it asks the external Garage cluster to connect back to each gateway node. For true per-node advertised `rpc_public_addr` in Garage config, use `layoutPolicy: Manual` with `GarageNode` resources, or set explicit per-node addresses.
 
 The operator establishes connectivity in both directions: gateway → external nodes and external cluster → gateway nodes. It also actively monitors the connection and re-establishes it if Garage marks a peer as unreachable.
 
@@ -703,7 +705,7 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
    kubectl create secret generic garage-rpc-secret --from-literal=rpc-secret=$SECRET
    ```
 
-2. For **uniform clusters** (all nodes identical), use `GarageCluster` with a shared `publicEndpoint`:
+2. For **uniform clusters** (all nodes identical), use `GarageCluster` with a shared/global `publicEndpoint`:
    ```yaml
    apiVersion: garage.rajsingh.info/v1beta1
    kind: GarageCluster
@@ -719,7 +721,7 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
          name: garage-rpc-secret
          key: rpc-secret
      publicEndpoint:
-       type: LoadBalancer   # single shared LB; all pods share one external IP
+       type: LoadBalancer   # single shared/global LB; all pods share one external RPC endpoint
      remoteClusters:
        - name: eu-west
          zone: eu-west-1
@@ -734,7 +736,16 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
          key: admin-token
    ```
 
-3. For **per-node external IPs** (recommended for federation: avoids stale address accumulation), use `layoutPolicy: Manual` with individual `GarageNode` resources — each node gets its own LoadBalancer service and `rpc_public_addr`:
+   Shared LoadBalancer mode is intentionally still supported. It is the smallest configuration when your load balancer provides one stable, externally-routable RPC endpoint for the cluster. If you need one externally-routable RPC endpoint per pod, add:
+   ```yaml
+   publicEndpoint:
+     type: LoadBalancer
+     loadBalancer:
+       perNode: true
+   ```
+   In auto-layout `GarageCluster` mode, this creates one LoadBalancer service per StatefulSet pod and the operator uses those addresses for reverse `ConnectClusterNodes` calls. The Garage pods still share a single ConfigMap, so this mode does not write distinct per-pod `rpc_public_addr` values into Garage's own config.
+
+3. For **per-node advertised RPC addresses** (recommended when every storage node needs its own stable public address in Garage config), use `layoutPolicy: Manual` with individual `GarageNode` resources — each node gets its own LoadBalancer service and `rpc_public_addr`:
    ```yaml
    # GarageCluster (no replicas, no publicEndpoint)
    apiVersion: garage.rajsingh.info/v1beta1

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -179,8 +179,8 @@ const (
 	// ReasonGatewayNodesOffline indicates no nodes are connected in either direction
 	ReasonGatewayNodesOffline = "NodesOffline"
 
-	// ReasonPerNodeNotImplemented indicates publicEndpoint.loadBalancer.perNode is not yet supported;
-	// use network.rpcPublicAddr as a workaround
+	// ReasonPerNodeNotImplemented indicates a reconciler version does not support
+	// publicEndpoint.loadBalancer.perNode.
 	ReasonPerNodeNotImplemented = "PerNodeNotImplemented"
 )
 

--- a/api/v1beta1/garagecluster_types.go
+++ b/api/v1beta1/garagecluster_types.go
@@ -958,7 +958,7 @@ type LoggingConfig struct {
 // PublicEndpointConfig defines how this cluster's nodes are exposed to remote clusters
 // for RPC communication. Choose the type based on your infrastructure:
 //
-//   - LoadBalancer: cloud-managed LB per node (most reliable, works everywhere)
+//   - LoadBalancer: cloud-managed RPC LoadBalancer; optionally one per node
 //   - NodePort: map each pod to a K8s node port (cheaper, requires stable node IPs)
 //   - ExternalIP: explicit pod→IP mapping (bare-metal or custom routing)
 //   - Headless: rely on DNS headless service (requires each node to be DNS-resolvable)
@@ -985,10 +985,12 @@ type PublicEndpointConfig struct {
 type LoadBalancerEndpointConfig struct {
 	ServiceMeta `json:",inline"`
 
-	// PerNode creates a separate LoadBalancer service per Garage node.
-	// Recommended for multi-cluster federation: each remote node gets a stable IP that
-	// survives pod restarts, preventing address accumulation in Garage's peer table.
-	// When false, a single shared LoadBalancer is used (simpler but less reliable for RPC).
+	// PerNode creates a separate LoadBalancer service per GarageCluster pod instead
+	// of one shared LoadBalancer service. In auto-layout GarageCluster mode, those
+	// services are used for operator-driven reverse ConnectClusterNodes calls; the
+	// pods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr
+	// values are not written into Garage config. Use Manual layout with GarageNode
+	// resources when each node also needs its own advertised rpc_public_addr.
 	// +optional
 	PerNode bool `json:"perNode"`
 }

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -6000,10 +6000,12 @@ spec:
                         type: object
                       perNode:
                         description: |-
-                          PerNode creates a separate LoadBalancer service per Garage node.
-                          Recommended for multi-cluster federation: each remote node gets a stable IP that
-                          survives pod restarts, preventing address accumulation in Garage's peer table.
-                          When false, a single shared LoadBalancer is used (simpler but less reliable for RPC).
+                          PerNode creates a separate LoadBalancer service per GarageCluster pod instead
+                          of one shared LoadBalancer service. In auto-layout GarageCluster mode, those
+                          services are used for operator-driven reverse ConnectClusterNodes calls; the
+                          pods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr
+                          values are not written into Garage config. Use Manual layout with GarageNode
+                          resources when each node also needs its own advertised rpc_public_addr.
                         type: boolean
                     type: object
                   nodePort:

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
@@ -2913,10 +2913,12 @@ spec:
                         type: object
                       perNode:
                         description: |-
-                          PerNode creates a separate LoadBalancer service per Garage node.
-                          Recommended for multi-cluster federation: each remote node gets a stable IP that
-                          survives pod restarts, preventing address accumulation in Garage's peer table.
-                          When false, a single shared LoadBalancer is used (simpler but less reliable for RPC).
+                          PerNode creates a separate LoadBalancer service per GarageCluster pod instead
+                          of one shared LoadBalancer service. In auto-layout GarageCluster mode, those
+                          services are used for operator-driven reverse ConnectClusterNodes calls; the
+                          pods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr
+                          values are not written into Garage config. Use Manual layout with GarageNode
+                          resources when each node also needs its own advertised rpc_public_addr.
                         type: boolean
                     type: object
                   nodePort:

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -6000,10 +6000,12 @@ spec:
                         type: object
                       perNode:
                         description: |-
-                          PerNode creates a separate LoadBalancer service per Garage node.
-                          Recommended for multi-cluster federation: each remote node gets a stable IP that
-                          survives pod restarts, preventing address accumulation in Garage's peer table.
-                          When false, a single shared LoadBalancer is used (simpler but less reliable for RPC).
+                          PerNode creates a separate LoadBalancer service per GarageCluster pod instead
+                          of one shared LoadBalancer service. In auto-layout GarageCluster mode, those
+                          services are used for operator-driven reverse ConnectClusterNodes calls; the
+                          pods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr
+                          values are not written into Garage config. Use Manual layout with GarageNode
+                          resources when each node also needs its own advertised rpc_public_addr.
                         type: boolean
                     type: object
                   nodePort:

--- a/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
@@ -2913,10 +2913,12 @@ spec:
                         type: object
                       perNode:
                         description: |-
-                          PerNode creates a separate LoadBalancer service per Garage node.
-                          Recommended for multi-cluster federation: each remote node gets a stable IP that
-                          survives pod restarts, preventing address accumulation in Garage's peer table.
-                          When false, a single shared LoadBalancer is used (simpler but less reliable for RPC).
+                          PerNode creates a separate LoadBalancer service per GarageCluster pod instead
+                          of one shared LoadBalancer service. In auto-layout GarageCluster mode, those
+                          services are used for operator-driven reverse ConnectClusterNodes calls; the
+                          pods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr
+                          values are not written into Garage config. Use Manual layout with GarageNode
+                          resources when each node also needs its own advertised rpc_public_addr.
                         type: boolean
                     type: object
                   nodePort:

--- a/config/samples/garage_v1beta1_garagecluster.yaml
+++ b/config/samples/garage_v1beta1_garagecluster.yaml
@@ -109,7 +109,9 @@ spec:
     loadBalancer:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
-      perNode: true  # Each node gets its own LB for direct routing
+      # false/omitted: one shared <cluster>-rpc LoadBalancer service
+      # true: one <pod-name>-rpc LoadBalancer service per StatefulSet pod
+      perNode: true
 
   # Remote clusters in other K8s clusters
   # Nodes are auto-discovered via Admin API

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1316,13 +1317,7 @@ func (r *GarageClusterReconciler) reconcilePublicEndpointService(ctx context.Con
 	svcName := cluster.Name + "-rpc"
 
 	if cluster.Spec.PublicEndpoint == nil {
-		// Clean up any existing -rpc service if publicEndpoint was removed
-		existing := &corev1.Service{}
-		if err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: cluster.Namespace}, existing); err == nil {
-			log.Info("Deleting public endpoint RPC service (publicEndpoint removed)", "name", svcName)
-			return r.Delete(ctx, existing)
-		}
-		return nil
+		return r.deletePublicEndpointServices(ctx, cluster)
 	}
 
 	ep := cluster.Spec.PublicEndpoint
@@ -1338,11 +1333,14 @@ func (r *GarageClusterReconciler) reconcilePublicEndpointService(ctx context.Con
 	switch ep.Type {
 	case publicEndpointTypeLoadBalancer:
 		if ep.LoadBalancer != nil && ep.LoadBalancer.PerNode {
+			if err := r.reconcilePerNodeLoadBalancerServices(ctx, cluster, rpcPort, ep.LoadBalancer.ServiceMeta); err != nil {
+				return err
+			}
 			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 				Type:               garagev1beta1.ConditionPublicEndpointReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             garagev1beta1.ReasonPerNodeNotImplemented,
-				Message:            "publicEndpoint.loadBalancer.perNode is not yet implemented; set network.rpcPublicAddr to the externally-routable RPC address",
+				Status:             metav1.ConditionTrue,
+				Reason:             garagev1beta1.ReasonReconcileSuccess,
+				Message:            "Per-node LoadBalancer RPC services are reconciled",
 				ObservedGeneration: cluster.Generation,
 			})
 			return nil
@@ -1391,6 +1389,127 @@ func (r *GarageClusterReconciler) reconcilePublicEndpointService(ctx context.Con
 
 	log.Info("Reconciling public endpoint RPC service", "name", svcName, "type", svcType)
 	return reconcileService(ctx, r.Client, svc, cluster, r.Scheme)
+}
+
+func (r *GarageClusterReconciler) reconcilePerNodeLoadBalancerServices(ctx context.Context, cluster *garagev1beta1.GarageCluster, rpcPort int32, svcMeta garagev1beta1.ServiceMeta) error {
+	log := logf.FromContext(ctx)
+
+	if err := r.deletePublicEndpointService(ctx, cluster, cluster.Name+"-rpc"); err != nil {
+		return err
+	}
+
+	replicas := cluster.Spec.Replicas
+	if replicas == 0 {
+		replicas = 3
+	}
+	desired := make(map[string]struct{}, replicas)
+
+	for i := int32(0); i < replicas; i++ {
+		podName := fmt.Sprintf("%s-%d", cluster.Name, i)
+		svcName := podName + "-rpc"
+		desired[svcName] = struct{}{}
+
+		selector := r.selectorLabelsForCluster(cluster)
+		selector["statefulset.kubernetes.io/pod-name"] = podName
+
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        svcName,
+				Namespace:   cluster.Namespace,
+				Labels:      mergeLabels(r.labelsForCluster(cluster), svcMeta.Labels),
+				Annotations: svcMeta.Annotations,
+			},
+			Spec: corev1.ServiceSpec{
+				Type:                     corev1.ServiceTypeLoadBalancer,
+				Selector:                 selector,
+				Ports:                    []corev1.ServicePort{rpcServicePort(rpcPort, 0)},
+				PublishNotReadyAddresses: true,
+			},
+		}
+
+		log.Info("Reconciling per-node public endpoint RPC service", "name", svcName, "pod", podName, "type", corev1.ServiceTypeLoadBalancer)
+		if err := reconcileService(ctx, r.Client, svc, cluster, r.Scheme); err != nil {
+			return err
+		}
+	}
+
+	serviceList := &corev1.ServiceList{}
+	if err := r.List(ctx, serviceList, client.InNamespace(cluster.Namespace), client.MatchingLabels(r.labelsForCluster(cluster))); err != nil {
+		return err
+	}
+	for i := range serviceList.Items {
+		svc := &serviceList.Items[i]
+		if !isClusterPerNodeRPCServiceName(cluster.Name, svc.Name) {
+			continue
+		}
+		if _, ok := desired[svc.Name]; ok {
+			continue
+		}
+		log.Info("Deleting stale per-node public endpoint RPC service", "name", svc.Name)
+		if err := r.Delete(ctx, svc); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *GarageClusterReconciler) deletePublicEndpointServices(ctx context.Context, cluster *garagev1beta1.GarageCluster) error {
+	if err := r.deletePublicEndpointService(ctx, cluster, cluster.Name+"-rpc"); err != nil {
+		return err
+	}
+
+	serviceList := &corev1.ServiceList{}
+	if err := r.List(ctx, serviceList, client.InNamespace(cluster.Namespace), client.MatchingLabels(r.labelsForCluster(cluster))); err != nil {
+		return err
+	}
+	for i := range serviceList.Items {
+		svc := &serviceList.Items[i]
+		if !isClusterPerNodeRPCServiceName(cluster.Name, svc.Name) {
+			continue
+		}
+		if err := r.Delete(ctx, svc); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *GarageClusterReconciler) deletePublicEndpointService(ctx context.Context, cluster *garagev1beta1.GarageCluster, name string) error {
+	existing := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: cluster.Namespace}, existing); err == nil {
+		return r.Delete(ctx, existing)
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func rpcServicePort(rpcPort, nodePort int32) corev1.ServicePort {
+	port := corev1.ServicePort{
+		Name:       rpcPortName,
+		Port:       rpcPort,
+		TargetPort: intstr.FromInt32(rpcPort),
+		Protocol:   corev1.ProtocolTCP,
+	}
+	if nodePort != 0 {
+		port.NodePort = nodePort
+	}
+	return port
+}
+
+func isClusterPerNodeRPCServiceName(clusterName, serviceName string) bool {
+	prefix := clusterName + "-"
+	suffix := "-rpc"
+	if !strings.HasPrefix(serviceName, prefix) || !strings.HasSuffix(serviceName, suffix) {
+		return false
+	}
+	ordinal := strings.TrimSuffix(strings.TrimPrefix(serviceName, prefix), suffix)
+	if ordinal == "" {
+		return false
+	}
+	_, err := strconv.Atoi(ordinal)
+	return err == nil
 }
 
 // resolveGarageImage determines the container image from image/imageRepository fields.
@@ -3380,20 +3499,9 @@ func (r *GarageClusterReconciler) deriveGatewayExternalAddr(ctx context.Context,
 	switch cluster.Spec.PublicEndpoint.Type {
 	case publicEndpointTypeLoadBalancer:
 		if cluster.Spec.PublicEndpoint.LoadBalancer != nil && cluster.Spec.PublicEndpoint.LoadBalancer.PerNode {
-			return "" // not yet implemented
+			return r.loadBalancerServiceAddr(ctx, cluster.Namespace, cluster.Name+"-0-rpc", rpcPort)
 		}
-		svc := &corev1.Service{}
-		if err := r.Get(ctx, types.NamespacedName{Name: cluster.Name + "-rpc", Namespace: cluster.Namespace}, svc); err == nil {
-			for _, ing := range svc.Status.LoadBalancer.Ingress {
-				addr := ing.IP
-				if addr == "" {
-					addr = ing.Hostname
-				}
-				if addr != "" {
-					return fmt.Sprintf("%s:%d", addr, rpcPort)
-				}
-			}
-		}
+		return r.loadBalancerServiceAddr(ctx, cluster.Namespace, cluster.Name+"-rpc", rpcPort)
 	case publicEndpointTypeNodePort:
 		if ep := cluster.Spec.PublicEndpoint.NodePort; ep != nil && len(ep.ExternalAddresses) > 0 {
 			basePort := ep.BasePort
@@ -3404,6 +3512,45 @@ func (r *GarageClusterReconciler) deriveGatewayExternalAddr(ctx context.Context,
 		}
 	}
 
+	return ""
+}
+
+func (r *GarageClusterReconciler) deriveGatewayExternalAddrForNode(ctx context.Context, cluster *garagev1beta1.GarageCluster, node garage.NodeInfo) string {
+	if cluster.Spec.Network.RPCPublicAddr != "" {
+		return cluster.Spec.Network.RPCPublicAddr
+	}
+	if cluster.Spec.PublicEndpoint == nil ||
+		cluster.Spec.PublicEndpoint.Type != publicEndpointTypeLoadBalancer ||
+		cluster.Spec.PublicEndpoint.LoadBalancer == nil ||
+		!cluster.Spec.PublicEndpoint.LoadBalancer.PerNode {
+		return r.deriveGatewayExternalAddr(ctx, cluster)
+	}
+
+	rpcPort := DefaultRPCPort
+	if cluster.Spec.Network.RPCBindPort != 0 {
+		rpcPort = cluster.Spec.Network.RPCBindPort
+	}
+
+	if node.Hostname != nil && *node.Hostname != "" {
+		return r.loadBalancerServiceAddr(ctx, cluster.Namespace, *node.Hostname+"-rpc", rpcPort)
+	}
+	return r.loadBalancerServiceAddr(ctx, cluster.Namespace, cluster.Name+"-0-rpc", rpcPort)
+}
+
+func (r *GarageClusterReconciler) loadBalancerServiceAddr(ctx context.Context, namespace, name string, rpcPort int32) string {
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, svc); err != nil {
+		return ""
+	}
+	for _, ing := range svc.Status.LoadBalancer.Ingress {
+		addr := ing.IP
+		if addr == "" {
+			addr = ing.Hostname
+		}
+		if addr != "" {
+			return fmt.Sprintf("%s:%d", addr, rpcPort)
+		}
+	}
 	return ""
 }
 
@@ -3456,13 +3603,12 @@ func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Co
 		return
 	}
 
-	// Derive the operator-known external address for this gateway cluster.
-	// Used to override internal (pod/service) IPs that Garage may report when
-	// rpc_public_addr is not set — such addresses are unreachable from external clusters.
-	overrideAddr := r.deriveGatewayExternalAddr(ctx, cluster)
-
 	connectedToGateway := 0
 	for _, node := range gatewayStatus.Nodes {
+		// Derive the operator-known external address for this gateway node. Used to
+		// override internal (pod/service) IPs or an empty self-address from Garage.
+		overrideAddr := r.deriveGatewayExternalAddrForNode(ctx, cluster, node)
+
 		addr := ""
 		if node.Address != nil {
 			addr = *node.Address

--- a/internal/controller/publicendpoint_test.go
+++ b/internal/controller/publicendpoint_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 var _ = Describe("publicEndpoint reconciliation", func() {
@@ -56,7 +57,7 @@ var _ = Describe("publicEndpoint reconciliation", func() {
 			_ = k8sClient.Update(ctx, cluster)
 			_ = k8sClient.Delete(ctx, cluster)
 		}
-		for _, name := range []string{peClusterName, peClusterName + "-headless", peClusterName + "-rpc"} {
+		for _, name := range []string{peClusterName, peClusterName + "-headless", peClusterName + "-rpc", peClusterName + "-0-rpc", peClusterName + "-1-rpc", peClusterName + "-2-rpc"} {
 			_ = k8sClient.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: peNamespace}})
 		}
 		_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: peClusterName + "-config", Namespace: peNamespace}})
@@ -152,6 +153,55 @@ var _ = Describe("publicEndpoint reconciliation", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-config", Namespace: peNamespace}, cm)).To(Succeed())
 			Expect(cm.Data["garage.toml"]).To(ContainSubstring(`rpc_public_addr = "explicit.example.com:3901"`))
 			Expect(cm.Data["garage.toml"]).NotTo(ContainSubstring("10.0.0.5"))
+		})
+
+		It("creates per-node LoadBalancer RPC services when perNode is true", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					Replicas:    2,
+					Replication: &garagev1beta1.ReplicationConfig{Factor: 1},
+					PublicEndpoint: &garagev1beta1.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+						LoadBalancer: &garagev1beta1.LoadBalancerEndpointConfig{
+							PerNode: true,
+							ServiceMeta: garagev1beta1.ServiceMeta{
+								Annotations: map[string]string{"metallb.universe.tf/address-pool": "garage-rpc"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			shared := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName + "-rpc", Namespace: peNamespace},
+				Spec: corev1.ServiceSpec{
+					Type:  corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{{Name: rpcPortName, Port: 3901}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, shared)).To(Succeed())
+
+			reconcileTwice()
+
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, &corev1.Service{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			for _, podName := range []string{peClusterName + "-0", peClusterName + "-1"} {
+				rpcSvc := &corev1.Service{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: podName + "-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+				Expect(rpcSvc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+				Expect(rpcSvc.Spec.Selector).To(HaveKeyWithValue("statefulset.kubernetes.io/pod-name", podName))
+				Expect(rpcSvc.Spec.Ports).To(ContainElement(HaveField("Port", int32(3901))))
+				Expect(rpcSvc.Annotations).To(HaveKeyWithValue("metallb.universe.tf/address-pool", "garage-rpc"))
+			}
+
+			updated := &garagev1beta1.GarageCluster{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+			cond := findCondition(updated.Status.Conditions, garagev1beta1.ConditionPublicEndpointReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
 	})
 
@@ -286,8 +336,42 @@ var _ = Describe("publicEndpoint reconciliation", func() {
 			addr := reconciler.deriveGatewayExternalAddr(ctx, cluster)
 			Expect(addr).To(BeEmpty())
 		})
+
+		It("returns the matching per-node LoadBalancer address when perNode is true", func() {
+			cluster := &garagev1beta1.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta1.GarageClusterSpec{
+					PublicEndpoint: &garagev1beta1.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+						LoadBalancer: &garagev1beta1.LoadBalancerEndpointConfig{
+							PerNode: true,
+						},
+					},
+				},
+			}
+
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName + "-0-rpc", Namespace: peNamespace},
+				Spec: corev1.ServiceSpec{
+					Type:  corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{{Name: rpcPortName, Port: 3901}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, svc)).To(Succeed())
+			svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.0.0.6"}}
+			Expect(k8sClient.Status().Update(ctx, svc)).To(Succeed())
+
+			addr := reconciler.deriveGatewayExternalAddrForNode(ctx, cluster, garage.NodeInfo{
+				Hostname: ptrString(peClusterName + "-0"),
+			})
+			Expect(addr).To(Equal("10.0.0.6:3901"))
+		})
 	})
 })
+
+func ptrString(v string) *string {
+	return &v
+}
 
 func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
 	for i := range conditions {

--- a/schemas/garagecluster_v1beta1.json
+++ b/schemas/garagecluster_v1beta1.json
@@ -1772,7 +1772,7 @@
                   "type": "object"
                 },
                 "perNode": {
-                  "description": "PerNode creates a separate LoadBalancer service per Garage node.\nRecommended for multi-cluster federation: each remote node gets a stable IP that\nsurvives pod restarts, preventing address accumulation in Garage's peer table.\nWhen false, a single shared LoadBalancer is used (simpler but less reliable for RPC).",
+                  "description": "PerNode creates a separate LoadBalancer service per GarageCluster pod instead\nof one shared LoadBalancer service. In auto-layout GarageCluster mode, those\nservices are used for operator-driven reverse ConnectClusterNodes calls; the\npods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr\nvalues are not written into Garage config. Use Manual layout with GarageNode\nresources when each node also needs its own advertised rpc_public_addr.",
                   "type": "boolean"
                 }
               },

--- a/schemas/garagenode_v1beta1.json
+++ b/schemas/garagenode_v1beta1.json
@@ -1186,7 +1186,7 @@
                   "type": "object"
                 },
                 "perNode": {
-                  "description": "PerNode creates a separate LoadBalancer service per Garage node.\nRecommended for multi-cluster federation: each remote node gets a stable IP that\nsurvives pod restarts, preventing address accumulation in Garage's peer table.\nWhen false, a single shared LoadBalancer is used (simpler but less reliable for RPC).",
+                  "description": "PerNode creates a separate LoadBalancer service per GarageCluster pod instead\nof one shared LoadBalancer service. In auto-layout GarageCluster mode, those\nservices are used for operator-driven reverse ConnectClusterNodes calls; the\npods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr\nvalues are not written into Garage config. Use Manual layout with GarageNode\nresources when each node also needs its own advertised rpc_public_addr.",
                   "type": "boolean"
                 }
               },


### PR DESCRIPTION
## Summary

Implements `spec.publicEndpoint.loadBalancer.perNode: true` for `GarageCluster`.

When enabled, the operator now:

- creates one LoadBalancer RPC Service per StatefulSet pod, named `<pod-name>-rpc`
- selects each pod using `statefulset.kubernetes.io/pod-name`
- removes the shared `<cluster>-rpc` Service when switching to per-node mode
- removes stale per-node RPC Services after scale-down
- marks `PublicEndpointReady=True` once per-node services are reconciled
- uses the matching per-node LoadBalancer address for gateway reverse `ConnectClusterNodes` calls when Garage reports a gateway self-address as empty/internal

This also documents the two LoadBalancer modes:

- `publicEndpoint.type: LoadBalancer` without `loadBalancer.perNode` keeps the existing shared/global `<cluster>-rpc` LoadBalancer behavior
- `publicEndpoint.type: LoadBalancer` with `loadBalancer.perNode: true` creates `<cluster>-0-rpc`, `<cluster>-1-rpc`, etc.

## Why

`publicEndpoint.loadBalancer.perNode: true` was documented in the API but previously surfaced as not implemented. That made LoadBalancer-based external gateway setups rely on a manual `network.rpcPublicAddr` workaround instead of operator-managed RPC exposure.

This adds the service reconciliation path and the address lookup needed by gateway-to-external connection reconciliation.

## Upstream Garage validation

This was checked against the upstream Garage source in `../garage`:

- Garage's admin API accepts connect requests as `node_id@addr` through `/v2/ConnectClusterNodes`
- `ConnectClusterNodes` can return HTTP 200 while individual results contain `success:false`, which is now handled by the client after PR #152
- `GetClusterStatus` reports the local node address from Garage's configured `rpc_public_addr`; connected remote peer addresses come from the active connection address
- Garage's official config docs define `rpc_public_addr` as the address and port other nodes use for RPC

Important boundary: in auto-layout `GarageCluster` mode, all pods still share one Garage ConfigMap. This PR therefore creates per-node LoadBalancer Services and uses their addresses for operator-driven reverse `ConnectClusterNodes` calls, but it does not write distinct per-pod `rpc_public_addr` values into Garage's config. For true per-node advertised `rpc_public_addr`, use `layoutPolicy: Manual` with `GarageNode` resources or explicit per-node addresses.

## Notes

The LoadBalancer controller still needs to assign reachable external IPs/hostnames, and those addresses must be reachable by external Garage nodes on the RPC port.

Shared/global LoadBalancer mode is still supported and remains the simpler option when one stable external RPC endpoint is sufficient.

## Testing

- `go test ./internal/controller -run 'Test|publicEndpoint'`
- `go test ./internal/controller ./internal/garage`
- `go test ./api/... ./internal/controller ./internal/garage`
