### PR TITLE
fix: include reference grants in namespace RBAC

### DIFF
--- a/charts/garage-operator/templates/namespace-rbac.yaml
+++ b/charts/garage-operator/templates/namespace-rbac.yaml
@@ -87,6 +87,7 @@ rules:
   - garageclusters
   - garagekeys
   - garagenodes
+  - garagereferencegrants
   verbs:
   - create
   - delete
@@ -115,6 +116,7 @@ rules:
   - garageclusters/status
   - garagekeys/status
   - garagenodes/status
+  - garagereferencegrants/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
## Summary

Fixes namespace-scoped Helm RBAC for installs using `watchNamespaces`.

The namespace-scoped Role now includes:

- `garagereferencegrants` with the same manager verbs as the cluster-scoped ClusterRole
- `garagereferencegrants/status` for status reconciliation

## Why

`GarageReferenceGrant` was added to the controller manager cache, but the namespace-scoped Helm Role template did not grant access to that resource. In installs like:

```yaml
watchNamespaces:
  - garage-s3
leaderElection:
  enabled: false
```

the manager could start without a ClusterRole and then repeatedly fail to list/watch `GarageReferenceGrant` in the watched namespace.

Fixes #154.

## Validation

- `helm lint charts/garage-operator`
- `helm template garage-operator charts/garage-operator --namespace garage-s3 --set 'watchNamespaces[0]=garage-s3' --set leaderElection.enabled=false`
- confirmed the rendered `Role` in `garage-s3` includes `garagereferencegrants` and `garagereferencegrants/status`
