### PR TITLE
fix: keep bucket v1alpha1 CRD version for upgrades

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -99,6 +99,26 @@ See the [README](README.md#namespace-isolation) for setup details.
 
 The operator's HelmRelease uses `crds: CreateReplace` but Kubernetes blocks removing a version from a CRD's `spec.versions` while objects are still stored in etcd in that format. The upgrade handles this in two steps.
 
+#### Upgrade blocker: v0.4.7/v0.4.8 GarageBucket CRD
+
+Do not use v0.4.7 or v0.4.8 as the target version when upgrading a cluster that has ever stored `GarageBucket` objects as `v1alpha1`. Those releases accidentally removed `v1alpha1` from the `GarageBucket` CRD's `spec.versions`.
+
+Kubernetes rejects that CRD update when `garagebuckets.garage.rajsingh.info/status.storedVersions` still contains `v1alpha1`, even if `kubectl get garagebuckets.v1alpha1.garage.rajsingh.info` returns no objects. The apiserver validates the CRD status storage-version list, not just the currently visible objects.
+
+The failure looks like:
+
+```text
+CustomResourceDefinition.apiextensions.k8s.io "garagebuckets.garage.rajsingh.info" is invalid:
+status.storedVersions[0]: Invalid value: "v1alpha1": missing from spec.versions
+```
+
+Upgrade directly to the first release after v0.4.8 that restores the `GarageBucket` `v1alpha1` compatibility entry, or apply a CRD that includes both:
+
+- `v1alpha1` with `storage: false`
+- `v1beta1` with `storage: true`
+
+After that CRD is accepted, continue the object migration below. Do not manually remove `v1alpha1` from `status.storedVersions` unless you have performed a proper Kubernetes storage migration and verified no data remains persisted in that version.
+
 #### Flux
 
 **Step 1 — Deploy v0.4.1** (adds `v1alpha1` as `served: false, storage: false`):

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -99,9 +99,9 @@ See the [README](README.md#namespace-isolation) for setup details.
 
 The operator's HelmRelease uses `crds: CreateReplace` but Kubernetes blocks removing a version from a CRD's `spec.versions` while objects are still stored in etcd in that format. The upgrade handles this in two steps.
 
-#### Upgrade blocker: v0.4.7/v0.4.8 GarageBucket CRD
+#### Known upgrade issue: GarageBucket CRD in v0.4.7/v0.4.8
 
-Do not use v0.4.7 or v0.4.8 as the target version when upgrading a cluster that has ever stored `GarageBucket` objects as `v1alpha1`. Those releases accidentally removed `v1alpha1` from the `GarageBucket` CRD's `spec.versions`.
+v0.4.7 and v0.4.8 accidentally removed `v1alpha1` from the `GarageBucket` CRD's `spec.versions`. That is fine for fresh installs and for clusters whose CRD storage-version status has already been fully migrated, but it blocks upgrades from clusters that still record `GarageBucket` `v1alpha1` in CRD status.
 
 Kubernetes rejects that CRD update when `garagebuckets.garage.rajsingh.info/status.storedVersions` still contains `v1alpha1`, even if `kubectl get garagebuckets.v1alpha1.garage.rajsingh.info` returns no objects. The apiserver validates the CRD status storage-version list, not just the currently visible objects.
 
@@ -112,7 +112,7 @@ CustomResourceDefinition.apiextensions.k8s.io "garagebuckets.garage.rajsingh.inf
 status.storedVersions[0]: Invalid value: "v1alpha1": missing from spec.versions
 ```
 
-Upgrade directly to the first release after v0.4.8 that restores the `GarageBucket` `v1alpha1` compatibility entry, or apply a CRD that includes both:
+If you hit this error while targeting v0.4.7 or v0.4.8, upgrade directly to the first release after v0.4.8 that restores the `GarageBucket` `v1alpha1` compatibility entry, or apply a CRD that includes both:
 
 - `v1alpha1` with `storage: false`
 - `v1beta1` with `storage: true`

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ dev-run: install ## Run operator locally against the dev cluster (without deploy
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	@python3 hack/preserve-crd-compat-versions.py
 	@if [ -d "$(HELM_CHART_DIR)/crd-bases" ]; then \
 		cp config/crd/bases/*.yaml $(HELM_CHART_DIR)/crd-bases/ && \
 		echo "CRDs synced to Helm chart"; \

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
@@ -26,6 +26,385 @@ spec:
     - jsonPath: .status.size
       name: Size
       type: string
+    - jsonPath: .status.objectCount
+      name: Objects
+      type: integer
+    - jsonPath: .status.websiteEnabled
+      name: Website
+      type: boolean
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GarageBucket is the Schema for the garagebuckets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GarageBucketSpec defines the desired state of GarageBucket
+            properties:
+              clusterRef:
+                description: ClusterRef references the GarageCluster this bucket belongs
+                  to
+                properties:
+                  kubeConfigSecretRef:
+                    description: |-
+                      KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
+                      Only used for cross-cluster references in multi-cluster federation scenarios.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: Name of the GarageCluster
+                    type: string
+                  namespace:
+                    description: Namespace of the GarageCluster (defaults to the same
+                      namespace as the referencing resource)
+                    type: string
+                required:
+                - name
+                type: object
+              globalAlias:
+                description: |-
+                  GlobalAlias is the global alias for this bucket (optional)
+                  If not set, the bucket name from metadata.name is used
+                type: string
+              keyPermissions:
+                description: |-
+                  KeyPermissions grants access to specific GarageKeys.
+
+                  Note: Permissions can be granted from either direction:
+                  - Here (GarageBucket.keyPermissions): Grant keys access to this bucket
+                  - On GarageKey (GarageKey.bucketPermissions): Grant the key access to buckets
+
+                  Both approaches are equivalent and result in the same Garage API calls.
+                  Use whichever is more convenient for your workflow:
+                  - Bucket-centric: Define all key access on the bucket
+                  - Key-centric: Define all bucket access on the key
+
+                  If the same permission is defined in both places, they are merged (not conflicting).
+                items:
+                  description: KeyPermission grants access to a key
+                  properties:
+                    keyRef:
+                      description: KeyRef references the GarageKey by name
+                      type: string
+                    owner:
+                      description: Owner allows bucket owner operations
+                      type: boolean
+                    read:
+                      description: Read allows reading objects
+                      type: boolean
+                    write:
+                      description: Write allows writing objects
+                      type: boolean
+                  required:
+                  - keyRef
+                  type: object
+                type: array
+              localAliases:
+                description: LocalAliases are per-key local aliases for this bucket
+                items:
+                  description: LocalAlias represents a per-key local alias for a bucket
+                  properties:
+                    alias:
+                      description: Alias is the local alias name
+                      type: string
+                    keyRef:
+                      description: KeyRef references the GarageKey
+                      type: string
+                  required:
+                  - alias
+                  - keyRef
+                  type: object
+                type: array
+              quotas:
+                description: Quotas configures bucket quotas
+                properties:
+                  maxObjects:
+                    description: MaxObjects is the maximum number of objects
+                    format: int64
+                    type: integer
+                  maxSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxSize is the maximum bucket size in bytes
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              website:
+                description: |-
+                  Website configures static website hosting for this bucket.
+                  Note: Only indexDocument and errorDocument are supported via the Admin API.
+                  For advanced features (routing rules, redirectAll), use S3 PutBucketWebsite API directly.
+                properties:
+                  enabled:
+                    description: Enabled enables static website hosting
+                    type: boolean
+                  errorDocument:
+                    description: ErrorDocument is the error document to serve for
+                      404s
+                    type: string
+                  indexDocument:
+                    default: index.html
+                    description: 'IndexDocument is the default index document (default:
+                      index.html)'
+                    type: string
+                type: object
+            required:
+            - clusterRef
+            type: object
+          status:
+            description: GarageBucketStatus defines the observed state of GarageBucket
+            properties:
+              bucketId:
+                description: BucketID is the internal Garage bucket ID
+                type: string
+              conditions:
+                description: Conditions represent the current state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              createdAt:
+                description: CreatedAt is when the bucket was created in Garage
+                format: date-time
+                type: string
+              globalAlias:
+                description: GlobalAlias is the assigned global alias
+                type: string
+              incompleteUploadBytes:
+                description: IncompleteUploadBytes is the total bytes in incomplete
+                  multipart uploads
+                format: int64
+                type: integer
+              incompleteUploadParts:
+                description: IncompleteUploadParts is the count of parts in incomplete
+                  multipart uploads
+                format: int64
+                type: integer
+              incompleteUploads:
+                description: IncompleteUploads is the count of incomplete multipart
+                  uploads
+                format: int64
+                type: integer
+              keys:
+                description: Keys contains keys with access to this bucket
+                items:
+                  description: BucketKeyStatus shows key access status
+                  properties:
+                    keyId:
+                      description: KeyID is the access key ID
+                      type: string
+                    name:
+                      description: Name is the key name
+                      type: string
+                    permissions:
+                      description: Permissions granted to this key
+                      properties:
+                        owner:
+                          description: Owner permission
+                          type: boolean
+                        read:
+                          description: Read permission
+                          type: boolean
+                        write:
+                          description: Write permission
+                          type: boolean
+                      type: object
+                  type: object
+                type: array
+              localAliases:
+                description: LocalAliases tracks per-key local aliases for this bucket
+                items:
+                  description: LocalAliasStatus shows the status of a local alias
+                    for this bucket
+                  properties:
+                    alias:
+                      description: Alias is the local alias name
+                      type: string
+                    keyId:
+                      description: KeyID is the access key ID that owns this alias
+                      type: string
+                    keyName:
+                      description: KeyName is the friendly name of the key
+                      type: string
+                  type: object
+                type: array
+              objectCount:
+                description: ObjectCount is the current object count
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase
+                type: string
+              quotaUsage:
+                description: QuotaUsage shows current quota consumption
+                properties:
+                  objectCount:
+                    description: ObjectCount is the current object count
+                    format: int64
+                    type: integer
+                  objectLimit:
+                    description: ObjectLimit is the configured object limit (0 = unlimited)
+                    format: int64
+                    type: integer
+                  objectPercent:
+                    description: ObjectPercent is the percentage of object quota used
+                    format: int32
+                    type: integer
+                  sizeBytes:
+                    description: SizeBytes is the current size in bytes
+                    format: int64
+                    type: integer
+                  sizeLimit:
+                    description: SizeLimit is the configured size limit in bytes (0
+                      = unlimited)
+                    format: int64
+                    type: integer
+                  sizePercent:
+                    description: SizePercent is the percentage of size quota used
+                    format: int32
+                    type: integer
+                type: object
+              size:
+                description: Size is the current bucket size
+                type: string
+              websiteConfig:
+                description: WebsiteConfig shows the current website configuration
+                  details
+                properties:
+                  errorDocument:
+                    description: ErrorDocument is the configured error document
+                    type: string
+                  indexDocument:
+                    description: IndexDocument is the configured index document
+                    type: string
+                type: object
+              websiteEnabled:
+                description: WebsiteEnabled indicates if website hosting is currently
+                  enabled
+                type: boolean
+              websiteUrl:
+                description: WebsiteURL is the computed website URL (if website hosting
+                  is enabled)
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterRef.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.globalAlias
+      name: Alias
+      type: string
+    - jsonPath: .status.size
+      name: Size
+      type: string
     - jsonPath: .status.quotaUsage.objectCount
       name: Objects
       type: integer

--- a/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
@@ -26,6 +26,385 @@ spec:
     - jsonPath: .status.size
       name: Size
       type: string
+    - jsonPath: .status.objectCount
+      name: Objects
+      type: integer
+    - jsonPath: .status.websiteEnabled
+      name: Website
+      type: boolean
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GarageBucket is the Schema for the garagebuckets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GarageBucketSpec defines the desired state of GarageBucket
+            properties:
+              clusterRef:
+                description: ClusterRef references the GarageCluster this bucket belongs
+                  to
+                properties:
+                  kubeConfigSecretRef:
+                    description: |-
+                      KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
+                      Only used for cross-cluster references in multi-cluster federation scenarios.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: Name of the GarageCluster
+                    type: string
+                  namespace:
+                    description: Namespace of the GarageCluster (defaults to the same
+                      namespace as the referencing resource)
+                    type: string
+                required:
+                - name
+                type: object
+              globalAlias:
+                description: |-
+                  GlobalAlias is the global alias for this bucket (optional)
+                  If not set, the bucket name from metadata.name is used
+                type: string
+              keyPermissions:
+                description: |-
+                  KeyPermissions grants access to specific GarageKeys.
+
+                  Note: Permissions can be granted from either direction:
+                  - Here (GarageBucket.keyPermissions): Grant keys access to this bucket
+                  - On GarageKey (GarageKey.bucketPermissions): Grant the key access to buckets
+
+                  Both approaches are equivalent and result in the same Garage API calls.
+                  Use whichever is more convenient for your workflow:
+                  - Bucket-centric: Define all key access on the bucket
+                  - Key-centric: Define all bucket access on the key
+
+                  If the same permission is defined in both places, they are merged (not conflicting).
+                items:
+                  description: KeyPermission grants access to a key
+                  properties:
+                    keyRef:
+                      description: KeyRef references the GarageKey by name
+                      type: string
+                    owner:
+                      description: Owner allows bucket owner operations
+                      type: boolean
+                    read:
+                      description: Read allows reading objects
+                      type: boolean
+                    write:
+                      description: Write allows writing objects
+                      type: boolean
+                  required:
+                  - keyRef
+                  type: object
+                type: array
+              localAliases:
+                description: LocalAliases are per-key local aliases for this bucket
+                items:
+                  description: LocalAlias represents a per-key local alias for a bucket
+                  properties:
+                    alias:
+                      description: Alias is the local alias name
+                      type: string
+                    keyRef:
+                      description: KeyRef references the GarageKey
+                      type: string
+                  required:
+                  - alias
+                  - keyRef
+                  type: object
+                type: array
+              quotas:
+                description: Quotas configures bucket quotas
+                properties:
+                  maxObjects:
+                    description: MaxObjects is the maximum number of objects
+                    format: int64
+                    type: integer
+                  maxSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxSize is the maximum bucket size in bytes
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              website:
+                description: |-
+                  Website configures static website hosting for this bucket.
+                  Note: Only indexDocument and errorDocument are supported via the Admin API.
+                  For advanced features (routing rules, redirectAll), use S3 PutBucketWebsite API directly.
+                properties:
+                  enabled:
+                    description: Enabled enables static website hosting
+                    type: boolean
+                  errorDocument:
+                    description: ErrorDocument is the error document to serve for
+                      404s
+                    type: string
+                  indexDocument:
+                    default: index.html
+                    description: 'IndexDocument is the default index document (default:
+                      index.html)'
+                    type: string
+                type: object
+            required:
+            - clusterRef
+            type: object
+          status:
+            description: GarageBucketStatus defines the observed state of GarageBucket
+            properties:
+              bucketId:
+                description: BucketID is the internal Garage bucket ID
+                type: string
+              conditions:
+                description: Conditions represent the current state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              createdAt:
+                description: CreatedAt is when the bucket was created in Garage
+                format: date-time
+                type: string
+              globalAlias:
+                description: GlobalAlias is the assigned global alias
+                type: string
+              incompleteUploadBytes:
+                description: IncompleteUploadBytes is the total bytes in incomplete
+                  multipart uploads
+                format: int64
+                type: integer
+              incompleteUploadParts:
+                description: IncompleteUploadParts is the count of parts in incomplete
+                  multipart uploads
+                format: int64
+                type: integer
+              incompleteUploads:
+                description: IncompleteUploads is the count of incomplete multipart
+                  uploads
+                format: int64
+                type: integer
+              keys:
+                description: Keys contains keys with access to this bucket
+                items:
+                  description: BucketKeyStatus shows key access status
+                  properties:
+                    keyId:
+                      description: KeyID is the access key ID
+                      type: string
+                    name:
+                      description: Name is the key name
+                      type: string
+                    permissions:
+                      description: Permissions granted to this key
+                      properties:
+                        owner:
+                          description: Owner permission
+                          type: boolean
+                        read:
+                          description: Read permission
+                          type: boolean
+                        write:
+                          description: Write permission
+                          type: boolean
+                      type: object
+                  type: object
+                type: array
+              localAliases:
+                description: LocalAliases tracks per-key local aliases for this bucket
+                items:
+                  description: LocalAliasStatus shows the status of a local alias
+                    for this bucket
+                  properties:
+                    alias:
+                      description: Alias is the local alias name
+                      type: string
+                    keyId:
+                      description: KeyID is the access key ID that owns this alias
+                      type: string
+                    keyName:
+                      description: KeyName is the friendly name of the key
+                      type: string
+                  type: object
+                type: array
+              objectCount:
+                description: ObjectCount is the current object count
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase
+                type: string
+              quotaUsage:
+                description: QuotaUsage shows current quota consumption
+                properties:
+                  objectCount:
+                    description: ObjectCount is the current object count
+                    format: int64
+                    type: integer
+                  objectLimit:
+                    description: ObjectLimit is the configured object limit (0 = unlimited)
+                    format: int64
+                    type: integer
+                  objectPercent:
+                    description: ObjectPercent is the percentage of object quota used
+                    format: int32
+                    type: integer
+                  sizeBytes:
+                    description: SizeBytes is the current size in bytes
+                    format: int64
+                    type: integer
+                  sizeLimit:
+                    description: SizeLimit is the configured size limit in bytes (0
+                      = unlimited)
+                    format: int64
+                    type: integer
+                  sizePercent:
+                    description: SizePercent is the percentage of size quota used
+                    format: int32
+                    type: integer
+                type: object
+              size:
+                description: Size is the current bucket size
+                type: string
+              websiteConfig:
+                description: WebsiteConfig shows the current website configuration
+                  details
+                properties:
+                  errorDocument:
+                    description: ErrorDocument is the configured error document
+                    type: string
+                  indexDocument:
+                    description: IndexDocument is the configured index document
+                    type: string
+                type: object
+              websiteEnabled:
+                description: WebsiteEnabled indicates if website hosting is currently
+                  enabled
+                type: boolean
+              websiteUrl:
+                description: WebsiteURL is the computed website URL (if website hosting
+                  is enabled)
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterRef.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.globalAlias
+      name: Alias
+      type: string
+    - jsonPath: .status.size
+      name: Size
+      type: string
     - jsonPath: .status.quotaUsage.objectCount
       name: Objects
       type: integer

--- a/config/crd/compat/garagebucket_v1alpha1_version.yaml
+++ b/config/crd/compat/garagebucket_v1alpha1_version.yaml
@@ -1,0 +1,379 @@
+- additionalPrinterColumns:
+  - jsonPath: .spec.clusterRef.name
+    name: Cluster
+    type: string
+  - jsonPath: .status.globalAlias
+    name: Alias
+    type: string
+  - jsonPath: .status.size
+    name: Size
+    type: string
+  - jsonPath: .status.objectCount
+    name: Objects
+    type: integer
+  - jsonPath: .status.websiteEnabled
+    name: Website
+    type: boolean
+  - jsonPath: .status.phase
+    name: Phase
+    type: string
+  - jsonPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  name: v1alpha1
+  schema:
+    openAPIV3Schema:
+      description: GarageBucket is the Schema for the garagebuckets API
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GarageBucketSpec defines the desired state of GarageBucket
+          properties:
+            clusterRef:
+              description: ClusterRef references the GarageCluster this bucket belongs
+                to
+              properties:
+                kubeConfigSecretRef:
+                  description: |-
+                    KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
+                    Only used for cross-cluster references in multi-cluster federation scenarios.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or its key must be
+                        defined
+                      type: boolean
+                  required:
+                  - key
+                  type: object
+                  x-kubernetes-map-type: atomic
+                name:
+                  description: Name of the GarageCluster
+                  type: string
+                namespace:
+                  description: Namespace of the GarageCluster (defaults to the same
+                    namespace as the referencing resource)
+                  type: string
+              required:
+              - name
+              type: object
+            globalAlias:
+              description: |-
+                GlobalAlias is the global alias for this bucket (optional)
+                If not set, the bucket name from metadata.name is used
+              type: string
+            keyPermissions:
+              description: |-
+                KeyPermissions grants access to specific GarageKeys.
+
+                Note: Permissions can be granted from either direction:
+                - Here (GarageBucket.keyPermissions): Grant keys access to this bucket
+                - On GarageKey (GarageKey.bucketPermissions): Grant the key access to buckets
+
+                Both approaches are equivalent and result in the same Garage API calls.
+                Use whichever is more convenient for your workflow:
+                - Bucket-centric: Define all key access on the bucket
+                - Key-centric: Define all bucket access on the key
+
+                If the same permission is defined in both places, they are merged (not conflicting).
+              items:
+                description: KeyPermission grants access to a key
+                properties:
+                  keyRef:
+                    description: KeyRef references the GarageKey by name
+                    type: string
+                  owner:
+                    description: Owner allows bucket owner operations
+                    type: boolean
+                  read:
+                    description: Read allows reading objects
+                    type: boolean
+                  write:
+                    description: Write allows writing objects
+                    type: boolean
+                required:
+                - keyRef
+                type: object
+              type: array
+            localAliases:
+              description: LocalAliases are per-key local aliases for this bucket
+              items:
+                description: LocalAlias represents a per-key local alias for a bucket
+                properties:
+                  alias:
+                    description: Alias is the local alias name
+                    type: string
+                  keyRef:
+                    description: KeyRef references the GarageKey
+                    type: string
+                required:
+                - alias
+                - keyRef
+                type: object
+              type: array
+            quotas:
+              description: Quotas configures bucket quotas
+              properties:
+                maxObjects:
+                  description: MaxObjects is the maximum number of objects
+                  format: int64
+                  type: integer
+                maxSize:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: MaxSize is the maximum bucket size in bytes
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
+            website:
+              description: |-
+                Website configures static website hosting for this bucket.
+                Note: Only indexDocument and errorDocument are supported via the Admin API.
+                For advanced features (routing rules, redirectAll), use S3 PutBucketWebsite API directly.
+              properties:
+                enabled:
+                  description: Enabled enables static website hosting
+                  type: boolean
+                errorDocument:
+                  description: ErrorDocument is the error document to serve for
+                    404s
+                  type: string
+                indexDocument:
+                  default: index.html
+                  description: 'IndexDocument is the default index document (default:
+                    index.html)'
+                  type: string
+              type: object
+          required:
+          - clusterRef
+          type: object
+        status:
+          description: GarageBucketStatus defines the observed state of GarageBucket
+          properties:
+            bucketId:
+              description: BucketID is the internal Garage bucket ID
+              type: string
+            conditions:
+              description: Conditions represent the current state
+              items:
+                description: Condition contains details for one aspect of the current
+                  state of this API Resource.
+                properties:
+                  lastTransitionTime:
+                    description: |-
+                      lastTransitionTime is the last time the condition transitioned from one status to another.
+                      This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: |-
+                      message is a human readable message indicating details about the transition.
+                      This may be an empty string.
+                    maxLength: 32768
+                    type: string
+                  observedGeneration:
+                    description: |-
+                      observedGeneration represents the .metadata.generation that the condition was set based upon.
+                      For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                      with respect to the current state of the instance.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reason:
+                    description: |-
+                      reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                      Producers of specific condition types may define expected values and meanings for this field,
+                      and whether the values are considered a guaranteed API.
+                      The value should be a CamelCase string.
+                      This field may not be empty.
+                    maxLength: 1024
+                    minLength: 1
+                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                    maxLength: 316
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            createdAt:
+              description: CreatedAt is when the bucket was created in Garage
+              format: date-time
+              type: string
+            globalAlias:
+              description: GlobalAlias is the assigned global alias
+              type: string
+            incompleteUploadBytes:
+              description: IncompleteUploadBytes is the total bytes in incomplete
+                multipart uploads
+              format: int64
+              type: integer
+            incompleteUploadParts:
+              description: IncompleteUploadParts is the count of parts in incomplete
+                multipart uploads
+              format: int64
+              type: integer
+            incompleteUploads:
+              description: IncompleteUploads is the count of incomplete multipart
+                uploads
+              format: int64
+              type: integer
+            keys:
+              description: Keys contains keys with access to this bucket
+              items:
+                description: BucketKeyStatus shows key access status
+                properties:
+                  keyId:
+                    description: KeyID is the access key ID
+                    type: string
+                  name:
+                    description: Name is the key name
+                    type: string
+                  permissions:
+                    description: Permissions granted to this key
+                    properties:
+                      owner:
+                        description: Owner permission
+                        type: boolean
+                      read:
+                        description: Read permission
+                        type: boolean
+                      write:
+                        description: Write permission
+                        type: boolean
+                    type: object
+                type: object
+              type: array
+            localAliases:
+              description: LocalAliases tracks per-key local aliases for this bucket
+              items:
+                description: LocalAliasStatus shows the status of a local alias
+                  for this bucket
+                properties:
+                  alias:
+                    description: Alias is the local alias name
+                    type: string
+                  keyId:
+                    description: KeyID is the access key ID that owns this alias
+                    type: string
+                  keyName:
+                    description: KeyName is the friendly name of the key
+                    type: string
+                type: object
+              type: array
+            objectCount:
+              description: ObjectCount is the current object count
+              format: int64
+              type: integer
+            observedGeneration:
+              description: ObservedGeneration is the last observed generation
+              format: int64
+              type: integer
+            phase:
+              description: Phase represents the current phase
+              type: string
+            quotaUsage:
+              description: QuotaUsage shows current quota consumption
+              properties:
+                objectCount:
+                  description: ObjectCount is the current object count
+                  format: int64
+                  type: integer
+                objectLimit:
+                  description: ObjectLimit is the configured object limit (0 = unlimited)
+                  format: int64
+                  type: integer
+                objectPercent:
+                  description: ObjectPercent is the percentage of object quota used
+                  format: int32
+                  type: integer
+                sizeBytes:
+                  description: SizeBytes is the current size in bytes
+                  format: int64
+                  type: integer
+                sizeLimit:
+                  description: SizeLimit is the configured size limit in bytes (0
+                    = unlimited)
+                  format: int64
+                  type: integer
+                sizePercent:
+                  description: SizePercent is the percentage of size quota used
+                  format: int32
+                  type: integer
+              type: object
+            size:
+              description: Size is the current bucket size
+              type: string
+            websiteConfig:
+              description: WebsiteConfig shows the current website configuration
+                details
+              properties:
+                errorDocument:
+                  description: ErrorDocument is the configured error document
+                  type: string
+                indexDocument:
+                  description: IndexDocument is the configured index document
+                  type: string
+              type: object
+            websiteEnabled:
+              description: WebsiteEnabled indicates if website hosting is currently
+                enabled
+              type: boolean
+            websiteUrl:
+              description: WebsiteURL is the computed website URL (if website hosting
+                is enabled)
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  served: true
+  storage: false
+  subresources:
+    status: {}

--- a/hack/preserve-crd-compat-versions.py
+++ b/hack/preserve-crd-compat-versions.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Re-apply compatibility-only CRD versions after controller-gen.
+
+controller-gen only emits versions backed by Go API packages. We intentionally
+keep a small number of old, non-storage versions in CRDs so Kubernetes accepts
+upgrades from clusters whose CRD status.storedVersions still mentions them.
+"""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+COMPAT_VERSIONS = {
+    "garage.rajsingh.info_garagebuckets.yaml": ROOT
+    / "config/crd/compat/garagebucket_v1alpha1_version.yaml",
+}
+
+
+def version_name_present(crd_text: str, version_name: str) -> bool:
+    return f"\n    name: {version_name}\n" in crd_text or crd_text.startswith(
+        f"    name: {version_name}\n"
+    )
+
+
+def main() -> int:
+    crd_dir = ROOT / "config/crd/bases"
+    changed = False
+
+    for crd_name, compat_path in COMPAT_VERSIONS.items():
+        crd_path = crd_dir / crd_name
+        if not crd_path.exists():
+            print(f"missing CRD: {crd_path}", file=sys.stderr)
+            return 1
+
+        crd_text = crd_path.read_text()
+        compat_text = compat_path.read_text().rstrip() + "\n"
+        version_name = None
+        for line in compat_text.splitlines():
+            if line.startswith("  name: "):
+                version_name = line.removeprefix("  name: ").strip()
+                break
+
+        if not version_name:
+            print(f"cannot find version name in {compat_path}", file=sys.stderr)
+            return 1
+        if version_name_present(crd_text, version_name):
+            continue
+        if "  versions:\n" not in crd_text:
+            print(f"cannot find spec.versions in {crd_path}", file=sys.stderr)
+            return 1
+
+        indented_compat = "".join(f"  {line}\n" for line in compat_text.splitlines())
+        crd_path.write_text(
+            crd_text.replace("  versions:\n", f"  versions:\n{indented_compat}", 1)
+        )
+        changed = True
+        print(f"preserved {crd_name} version {version_name}")
+
+    if not changed:
+        print("CRD compatibility versions already present")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Restores the `v1alpha1` compatibility entry to the `GarageBucket` CRD in both:

- `config/crd/bases/garage.rajsingh.info_garagebuckets.yaml`
- `charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml`

The restored version is `served: true` and `storage: false`; `v1beta1` remains the storage version.

This also makes the fix generation-safe:

- adds `config/crd/compat/garagebucket_v1alpha1_version.yaml`
- adds `hack/preserve-crd-compat-versions.py`
- runs that helper from `make manifests` after `controller-gen` and before Helm CRD sync/schema generation

Also updates `MIGRATION.md` with a specific v0.4.7/v0.4.8 upgrade issue note. Those releases are affected upgrade targets for clusters whose CRD status still records `GarageBucket` `v1alpha1`; fresh installs are not affected.

## Why

Kubernetes requires every value in `status.storedVersions` to remain listed in `spec.versions` until storage migration has removed that version from CRD status. Some clusters upgrading from 0.4.6 still have `v1alpha1` recorded in `garagebuckets.garage.rajsingh.info/status.storedVersions`, so the 0.4.7/0.4.8 CRD replacement is rejected before Helm/Argo can complete the upgrade.

Other migrated CRDs already keep their `v1alpha1` compatibility entries; `GarageBucket` was the outlier.

Fixes #156.

## Validation

- `make manifests`
- `make helm-verify-crd-bases`
- `helm lint charts/garage-operator`
- `helm template garage-operator charts/garage-operator --namespace garage-operator-system`
- confirmed rendered `GarageBucket` CRD includes both `v1alpha1` (`storage: false`) and `v1beta1` (`storage: true`)
