### PR TITLE
fix(controller): propagate paths[].volume config to data PVC template

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -1858,31 +1858,74 @@ func buildMetadataPVC(cluster *garagev1beta1.GarageCluster) corev1.PersistentVol
 	return pvc
 }
 
-// buildDataPVC creates the data PVC template
+// firstDataPathVolume returns the volume config of the first data path that
+// declares one, or nil. Used as a fallback when top-level data fields are unset
+// but the user configured paths[].volume — matches the v1alpha1 behavior from #51.
+func firstDataPathVolume(cluster *garagev1beta1.GarageCluster) *garagev1beta1.DataPathVolumeConfig {
+	data := cluster.Spec.Storage.Data
+	if data == nil {
+		return nil
+	}
+	for i := range data.Paths {
+		if data.Paths[i].Volume != nil {
+			return data.Paths[i].Volume
+		}
+	}
+	return nil
+}
+
+// buildDataPVC creates the data PVC template.
+//
+// Precedence for each field: top-level Storage.Data wins; otherwise fall back
+// to the first paths[].volume that defines it. This mirrors buildMetadataPVC
+// behavior and restores the v1alpha1 fix from #51 lost in the v1beta1 rewrite.
 func buildDataPVC(cluster *garagev1beta1.GarageCluster) corev1.PersistentVolumeClaim {
 	size := resource.MustParse("100Gi")
 
 	var sc *string
 	var accessModes []corev1.PersistentVolumeAccessMode
+	pathVol := firstDataPathVolume(cluster)
 	if data := cluster.Spec.Storage.Data; data != nil {
 		if data.Size != nil && !data.Size.IsZero() {
 			size = *data.Size
+		} else if pathVol != nil && pathVol.Size != nil && !pathVol.Size.IsZero() {
+			size = *pathVol.Size
 		}
 		sc = data.StorageClassName
+		if sc == nil && pathVol != nil {
+			sc = pathVol.StorageClassName
+		}
 		accessModes = data.AccessModes
+		if len(accessModes) == 0 && pathVol != nil {
+			accessModes = pathVol.AccessModes
+		}
 	}
 
 	pvc := buildBasePVC(dataVolName, size, sc, accessModes)
 
 	if data := cluster.Spec.Storage.Data; data != nil {
-		if data.Selector != nil {
-			pvc.Spec.Selector = data.Selector
+		selector := data.Selector
+		if selector == nil && pathVol != nil {
+			selector = pathVol.Selector
 		}
-		if len(data.Labels) > 0 {
-			pvc.Labels = data.Labels
+		if selector != nil {
+			pvc.Spec.Selector = selector
 		}
-		if len(data.Annotations) > 0 {
-			pvc.Annotations = data.Annotations
+
+		labels := data.Labels
+		if len(labels) == 0 && pathVol != nil {
+			labels = pathVol.Labels
+		}
+		if len(labels) > 0 {
+			pvc.Labels = labels
+		}
+
+		annotations := data.Annotations
+		if len(annotations) == 0 && pathVol != nil {
+			annotations = pathVol.Annotations
+		}
+		if len(annotations) > 0 {
+			pvc.Annotations = annotations
 		}
 	}
 

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -612,6 +612,7 @@ func TestBuildVolumeClaimTemplates(t *testing.T) {
 }
 
 func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
+	const fastTier = "fast"
 	encryptedSC := "rook-ceph-block-encrypted"
 	fastSC := testStorageClass
 
@@ -680,7 +681,7 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 				Storage: garagev1beta1.StorageConfig{
 					Data: &garagev1beta1.VolumeConfig{
 						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"tier": "fast"},
+							MatchLabels: map[string]string{"tier": fastTier},
 						},
 					},
 				},
@@ -690,7 +691,7 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 		if pvc.Spec.Selector == nil {
 			t.Fatal("Selector is nil, want non-nil")
 		}
-		if pvc.Spec.Selector.MatchLabels["tier"] != "fast" {
+		if pvc.Spec.Selector.MatchLabels["tier"] != fastTier {
 			t.Errorf("Selector.MatchLabels = %v, want tier=fast", pvc.Spec.Selector.MatchLabels)
 		}
 	})
@@ -753,6 +754,133 @@ func TestBuildDataPVC_PathVolumeConfig(t *testing.T) {
 		pvc := buildDataPVC(cluster)
 		if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != encryptedSC {
 			t.Errorf("StorageClassName = %v, want %q", pvc.Spec.StorageClassName, encryptedSC)
+		}
+	})
+
+	t.Run("paths[].volume.storageClassName applied when top-level unset (issue #162)", func(t *testing.T) {
+		cluster := &garagev1beta1.GarageCluster{
+			Spec: garagev1beta1.GarageClusterSpec{
+				Storage: garagev1beta1.StorageConfig{
+					Data: &garagev1beta1.VolumeConfig{
+						Paths: []garagev1beta1.DataPath{
+							{
+								Path:     dataPath,
+								Capacity: ptrQuantity(resource.MustParse("50Gi")),
+								Volume: &garagev1beta1.DataPathVolumeConfig{
+									StorageClassName: &encryptedSC,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		pvc := buildDataPVC(cluster)
+		if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != encryptedSC {
+			t.Errorf("StorageClassName = %v, want %q (path-level fallback)", pvc.Spec.StorageClassName, encryptedSC)
+		}
+	})
+
+	t.Run("paths[].volume.accessModes applied when top-level unset", func(t *testing.T) {
+		cluster := &garagev1beta1.GarageCluster{
+			Spec: garagev1beta1.GarageClusterSpec{
+				Storage: garagev1beta1.StorageConfig{
+					Data: &garagev1beta1.VolumeConfig{
+						Paths: []garagev1beta1.DataPath{
+							{
+								Path: dataPath,
+								Volume: &garagev1beta1.DataPathVolumeConfig{
+									AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		pvc := buildDataPVC(cluster)
+		if len(pvc.Spec.AccessModes) != 1 || pvc.Spec.AccessModes[0] != corev1.ReadWriteMany {
+			t.Errorf("AccessModes = %v, want [ReadWriteMany] (path-level fallback)", pvc.Spec.AccessModes)
+		}
+	})
+
+	t.Run("paths[].volume.selector applied when top-level unset", func(t *testing.T) {
+		cluster := &garagev1beta1.GarageCluster{
+			Spec: garagev1beta1.GarageClusterSpec{
+				Storage: garagev1beta1.StorageConfig{
+					Data: &garagev1beta1.VolumeConfig{
+						Paths: []garagev1beta1.DataPath{
+							{
+								Path: dataPath,
+								Volume: &garagev1beta1.DataPathVolumeConfig{
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"tier": fastTier},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		pvc := buildDataPVC(cluster)
+		if pvc.Spec.Selector == nil || pvc.Spec.Selector.MatchLabels["tier"] != fastTier {
+			t.Errorf("Selector = %v, want tier=fast (path-level fallback)", pvc.Spec.Selector)
+		}
+	})
+
+	t.Run("paths[].volume.size applied when top-level size unset", func(t *testing.T) {
+		cluster := &garagev1beta1.GarageCluster{
+			Spec: garagev1beta1.GarageClusterSpec{
+				Storage: garagev1beta1.StorageConfig{
+					Data: &garagev1beta1.VolumeConfig{
+						Paths: []garagev1beta1.DataPath{
+							{
+								Path: dataPath,
+								Volume: &garagev1beta1.DataPathVolumeConfig{
+									Size: ptrQuantity(resource.MustParse("250Gi")),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		pvc := buildDataPVC(cluster)
+		got := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		if got.String() != "250Gi" {
+			t.Errorf("size = %q, want %q (path-level fallback)", got.String(), "250Gi")
+		}
+	})
+
+	t.Run("first path with volume wins when multiple paths present", func(t *testing.T) {
+		other := "other-sc"
+		cluster := &garagev1beta1.GarageCluster{
+			Spec: garagev1beta1.GarageClusterSpec{
+				Storage: garagev1beta1.StorageConfig{
+					Data: &garagev1beta1.VolumeConfig{
+						Paths: []garagev1beta1.DataPath{
+							{Path: "/data/a", Capacity: ptrQuantity(resource.MustParse("50Gi"))},
+							{
+								Path: "/data/b",
+								Volume: &garagev1beta1.DataPathVolumeConfig{
+									StorageClassName: &encryptedSC,
+								},
+							},
+							{
+								Path: "/data/c",
+								Volume: &garagev1beta1.DataPathVolumeConfig{
+									StorageClassName: &other,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		pvc := buildDataPVC(cluster)
+		if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != encryptedSC {
+			t.Errorf("StorageClassName = %v, want %q (first path with volume wins)", pvc.Spec.StorageClassName, encryptedSC)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `buildDataPVC` now reads `storageClassName`, `accessModes`, `selector`, `size`, `labels`, and `annotations` from the first `storage.data.paths[].volume` that defines them when the top-level `storage.data` field is unset.
- Top-level `storage.data.*` retains precedence over path-level config.
- Adds a `firstDataPathVolume` helper, mirroring the precedence model `buildMetadataPVC` already uses for its own fields.

## Root Cause

The v1alpha1 fix from #51 propagated `paths[].volume` config into the data PVC template. That fallback was lost during the v1beta1 rewrite of `buildDataPVC` — only top-level `Storage.Data.*` was read, so users who only set `storage.data.paths[0].volume.storageClassName` silently got the cluster default StorageClass.

Fixes #162.

## Test plan

- [x] `make test` — all unit + envtest suites pass
- [x] `make lint` — 0 issues
- [x] 6 new sub-tests under `TestBuildDataPVC_PathVolumeConfig` cover the fallback paths (storageClassName, accessModes, selector, size, first-path-with-volume wins). Existing tests confirm top-level precedence is preserved.