### PR TITLE
fix(controller): tier-scope API Service + gateway readiness probe

### DIFF
--- a/internal/controller/garagecluster_apiservice_test.go
+++ b/internal/controller/garagecluster_apiservice_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+// These tests cover the tier-scoping behavior of the in-cluster API Services.
+// The historical <cr> Service selected on instance=<cr> alone, which matches
+// BOTH storage StatefulSet pods AND gateway Deployment pods. That round-robined
+// admin/S3 traffic through gateway pods even when the storage tier was
+// directly reachable. The fix scopes <cr> to the storage tier and adds a
+// sibling <cr>-gateway Service for the gateway tier.
+var _ = Describe("GarageCluster API Service tier scoping", func() {
+	const ns = testNamespace
+
+	var reconciler *GarageClusterReconciler
+	BeforeEach(func() {
+		reconciler = &GarageClusterReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	})
+
+	cleanupSvcs := func(name string) {
+		_ = k8sClient.Delete(ctx, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		})
+		_ = k8sClient.Delete(ctx, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name + "-gateway", Namespace: ns},
+		})
+		gc := &garagev1beta2.GarageCluster{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, gc); err == nil {
+			gc.Finalizers = nil
+			_ = k8sClient.Update(ctx, gc)
+			_ = k8sClient.Delete(ctx, gc)
+		}
+	}
+
+	// createCluster persists the CR so reconcileService can set an
+	// OwnerReference with a real UID.
+	createCluster := func(c *garagev1beta2.GarageCluster) {
+		Expect(k8sClient.Create(ctx, c)).To(Succeed())
+	}
+
+	Context("unified cluster (storage + gateway)", func() {
+		const name = "tier-svc-unified"
+
+		AfterEach(func() {
+			cleanupSvcs(name)
+		})
+
+		It("creates <cr> with tier:storage and <cr>-gateway with tier:gateway, same port set", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 3,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 2},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 3},
+				},
+			}
+			createCluster(cluster)
+
+			Expect(reconciler.reconcileAPIService(ctx, cluster)).To(Succeed())
+			Expect(reconciler.reconcileGatewayAPIService(ctx, cluster)).To(Succeed())
+
+			storageSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, storageSvc)).To(Succeed())
+			Expect(storageSvc.Spec.Selector).To(HaveKeyWithValue(labelTier, tierStorage))
+			Expect(storageSvc.Spec.Selector).NotTo(HaveKey(labelAppManagedBy))
+
+			gatewaySvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-gateway", Namespace: ns}, gatewaySvc)).To(Succeed())
+			Expect(gatewaySvc.Spec.Selector).To(HaveKeyWithValue(labelTier, tierGateway))
+
+			// Port sets must match exactly so in-cluster clients can target
+			// either tier interchangeably.
+			Expect(servicePortNames(storageSvc)).To(Equal(servicePortNames(gatewaySvc)))
+			Expect(servicePortNames(storageSvc)).To(ContainElements("s3", adminPortName, "web"))
+		})
+	})
+
+	Context("storage-only cluster", func() {
+		const name = "tier-svc-storage-only"
+
+		AfterEach(func() {
+			cleanupSvcs(name)
+		})
+
+		It("creates <cr> with tier:storage and no <cr>-gateway Service", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 3,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 3},
+				},
+			}
+			createCluster(cluster)
+
+			Expect(reconciler.reconcileAPIService(ctx, cluster)).To(Succeed())
+			// Mirror the controller loop: when no gateway tier, ensure the
+			// sibling service is absent (and stays absent).
+			Expect(reconciler.deleteGatewayAPIService(ctx, cluster)).To(Succeed())
+
+			storageSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, storageSvc)).To(Succeed())
+			Expect(storageSvc.Spec.Selector).To(HaveKeyWithValue(labelTier, tierStorage))
+
+			gatewaySvc := &corev1.Service{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-gateway", Namespace: ns}, gatewaySvc)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "<cr>-gateway Service must not exist for storage-only clusters")
+		})
+	})
+
+	Context("edge-gateway cluster (no storage, has connectTo)", func() {
+		const name = "tier-svc-edge-gateway"
+
+		AfterEach(func() {
+			cleanupSvcs(name)
+		})
+
+		It("creates <cr> with tier:gateway and no <cr>-gateway Service", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 1},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+					ConnectTo: &garagev1beta2.ConnectToConfig{
+						BootstrapPeers: []string{
+							"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef@example.com:3901",
+						},
+					},
+				},
+			}
+			createCluster(cluster)
+
+			Expect(reconciler.reconcileAPIService(ctx, cluster)).To(Succeed())
+			Expect(reconciler.deleteGatewayAPIService(ctx, cluster)).To(Succeed())
+
+			primarySvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, primarySvc)).To(Succeed())
+			// Edge gateway has no local storage tier — primary <cr> points at
+			// the gateway pods directly.
+			Expect(primarySvc.Spec.Selector).To(HaveKeyWithValue(labelTier, tierGateway))
+
+			gatewaySvc := &corev1.Service{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-gateway", Namespace: ns}, gatewaySvc)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "<cr>-gateway Service is redundant for edge-gateway clusters")
+		})
+	})
+
+	Context("removing the gateway tier from a unified CR", func() {
+		const name = "tier-svc-shrink"
+
+		AfterEach(func() {
+			cleanupSvcs(name)
+		})
+
+		It("deletes the <cr>-gateway Service", func() {
+			unified := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 3,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 2},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 3},
+				},
+			}
+			createCluster(unified)
+			Expect(reconciler.reconcileAPIService(ctx, unified)).To(Succeed())
+			Expect(reconciler.reconcileGatewayAPIService(ctx, unified)).To(Succeed())
+
+			gatewaySvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-gateway", Namespace: ns}, gatewaySvc)).To(Succeed())
+
+			// User edits the CR and removes spec.gateway.
+			shrunk := unified.DeepCopy()
+			shrunk.Spec.Gateway = nil
+			Expect(reconciler.deleteGatewayAPIService(ctx, shrunk)).To(Succeed())
+
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-gateway", Namespace: ns}, gatewaySvc)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("Manual layout policy", func() {
+		const name = "tier-svc-manual"
+
+		AfterEach(func() {
+			cleanupSvcs(name)
+		})
+
+		It("preserves the legacy {labelCluster: name} selector instead of a tier filter", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: garagev1beta2.GarageClusterSpec{
+					LayoutPolicy: LayoutPolicyManual,
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 1,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				},
+			}
+			createCluster(cluster)
+
+			Expect(reconciler.reconcileAPIService(ctx, cluster)).To(Succeed())
+
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, svc)).To(Succeed())
+			// GarageNode-managed pods carry labelCluster but NOT labelTier or
+			// instance=<cr>; a tier filter would silently match zero pods.
+			Expect(svc.Spec.Selector).To(Equal(map[string]string{labelCluster: name}))
+		})
+	})
+})
+
+func servicePortNames(svc *corev1.Service) []string {
+	names := make([]string, 0, len(svc.Spec.Ports))
+	for _, p := range svc.Spec.Ports {
+		names = append(names, p.Name)
+	}
+	return names
+}

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -148,9 +148,23 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.updateStatus(ctx, cluster, PhaseFailed, err)
 	}
 
-	// Create or update API Service
+	// Create or update API Service (primary <cr>, scoped to storage tier when
+	// present, else to the gateway tier for edge-gateway clusters)
 	if err := r.reconcileAPIService(ctx, cluster); err != nil {
 		return r.updateStatus(ctx, cluster, PhaseFailed, err)
+	}
+
+	// Per-tier gateway Service is created only for unified clusters (both
+	// storage + gateway). Without a storage tier the primary <cr> already
+	// targets the gateway pods, so a sibling Service would be redundant.
+	if cluster.HasStorageTier() && cluster.HasGatewayTier() {
+		if err := r.reconcileGatewayAPIService(ctx, cluster); err != nil {
+			return r.updateStatus(ctx, cluster, PhaseFailed, err)
+		}
+	} else {
+		if err := r.deleteGatewayAPIService(ctx, cluster); err != nil {
+			return r.updateStatus(ctx, cluster, PhaseFailed, err)
+		}
 	}
 
 	// Create, update, or delete the dedicated external RPC service for publicEndpoint
@@ -271,15 +285,17 @@ func (r *GarageClusterReconciler) finalize(ctx context.Context, cluster *garagev
 		return err
 	}
 
-	// Delete API Service
-	apiSvc := &corev1.Service{}
-	if err := r.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, apiSvc); err == nil {
-		log.Info("Deleting API Service", "name", apiSvc.Name)
-		if err := r.Delete(ctx, apiSvc); err != nil && !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete API Service: %w", err)
+	// Delete API Services (primary + per-tier gateway sibling)
+	for _, svcName := range []string{cluster.Name, cluster.Name + "-gateway"} {
+		apiSvc := &corev1.Service{}
+		if err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: cluster.Namespace}, apiSvc); err == nil {
+			log.Info("Deleting API Service", "name", apiSvc.Name)
+			if err := r.Delete(ctx, apiSvc); err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete API Service: %w", err)
+			}
+		} else if !errors.IsNotFound(err) {
+			return err
 		}
-	} else if !errors.IsNotFound(err) {
-		return err
 	}
 
 	// Delete Headless Service
@@ -1262,11 +1278,11 @@ func (r *GarageClusterReconciler) reconcileHeadlessService(ctx context.Context, 
 	return reconcileService(ctx, r.Client, svc, cluster, r.Scheme)
 }
 
-func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
-	log := logf.FromContext(ctx)
-	serviceName := cluster.Name
-
-	ports := []corev1.ServicePort{}
+// apiServicePorts returns the S3 / Admin / K2V / Web ServicePort set shared by
+// both the primary (<cr>) and gateway (<cr>-gateway) in-cluster API Services.
+// The port set is identical across tiers — only the selector differs.
+func apiServicePorts(cluster *garagev1beta2.GarageCluster) []corev1.ServicePort {
+	ports := make([]corev1.ServicePort, 0, 4)
 
 	// S3 API port (always enabled - Garage requires the [s3_api] section)
 	s3Port := int32(3900)
@@ -1281,20 +1297,18 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 	})
 
 	// Admin API port
-	{
-		adminPort := int32(3903)
-		if cluster.Spec.Admin != nil && cluster.Spec.Admin.BindPort != 0 {
-			adminPort = cluster.Spec.Admin.BindPort
-		}
-		ports = append(ports, corev1.ServicePort{
-			Name:       adminPortName,
-			Port:       adminPort,
-			TargetPort: intstr.FromInt32(adminPort),
-			Protocol:   corev1.ProtocolTCP,
-		})
+	adminPort := int32(3903)
+	if cluster.Spec.Admin != nil && cluster.Spec.Admin.BindPort != 0 {
+		adminPort = cluster.Spec.Admin.BindPort
 	}
+	ports = append(ports, corev1.ServicePort{
+		Name:       adminPortName,
+		Port:       adminPort,
+		TargetPort: intstr.FromInt32(adminPort),
+		Protocol:   corev1.ProtocolTCP,
+	})
 
-	// K2V API port
+	// K2V API port (only when enabled)
 	if cluster.Spec.K2VAPI != nil {
 		k2vPort := int32(3904)
 		if cluster.Spec.K2VAPI.BindPort != 0 {
@@ -1308,7 +1322,7 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 		})
 	}
 
-	// Web API port
+	// Web API port (when not explicitly disabled)
 	if w := effectiveWebAPI(cluster); w != nil {
 		webPort := int32(3902)
 		if w.BindPort != 0 {
@@ -1320,6 +1334,42 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 			TargetPort: intstr.FromInt32(webPort),
 			Protocol:   corev1.ProtocolTCP,
 		})
+	}
+
+	return ports
+}
+
+// apiServiceSelector returns the pod-selector used by the in-cluster API
+// Service for the given cluster shape.
+//
+//   - Manual layout: GarageNode pods don't carry the unified instance label, so
+//     the historical Manual selector ({labelCluster: cluster.Name}) is preserved
+//     — a tier filter would silently match zero pods.
+//   - Otherwise: scope to the requested tier (storage or gateway). The bare
+//     "instance" selector matches both StatefulSet and Deployment pods and
+//     would round-robin in-cluster admin/S3 traffic across mixed tiers; the
+//     tier label removes that ambiguity.
+func (r *GarageClusterReconciler) apiServiceSelector(cluster *garagev1beta2.GarageCluster, tier string) map[string]string {
+	if cluster.Spec.LayoutPolicy == LayoutPolicyManual {
+		return r.selectorLabelsForCluster(cluster)
+	}
+	return r.selectorLabelsForTier(cluster, tier)
+}
+
+// reconcileAPIService reconciles the primary in-cluster API Service (<cr>).
+//
+// Selector targets the storage tier when one is declared, otherwise the gateway
+// tier (edge-gateway clusters). The gateway-tier Deployment gets its own
+// dedicated Service via reconcileGatewayAPIService.
+func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	serviceName := cluster.Name
+
+	// Primary Service prefers the storage tier; falls back to gateway for
+	// edge-gateway clusters (no local storage).
+	primaryTier := tierStorage
+	if !cluster.HasStorageTier() {
+		primaryTier = tierGateway
 	}
 
 	serviceType := corev1.ServiceTypeClusterIP
@@ -1341,16 +1391,61 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     serviceType,
-			Selector: r.selectorLabelsForCluster(cluster),
-			Ports:    ports,
+			Selector: r.apiServiceSelector(cluster, primaryTier),
+			Ports:    apiServicePorts(cluster),
 			// Enable routing to pods even when not ready, essential for multi-cluster
 			// federation during bootstrap when pods are waiting for the cluster to be healthy
 			PublishNotReadyAddresses: true,
 		},
 	}
 
-	log.Info("Reconciling API Service", "name", serviceName)
+	log.Info("Reconciling API Service", "name", serviceName, "tier", primaryTier)
 	return reconcileService(ctx, r.Client, svc, cluster, r.Scheme)
+}
+
+// reconcileGatewayAPIService reconciles a tier-scoped <cr>-gateway Service so
+// in-cluster clients (operator's bucket/key controllers, WebUI, …) can target
+// either tier explicitly. Created only when the cluster has both a storage tier
+// AND a gateway tier — i.e. a unified cluster. For storage-only and
+// edge-gateway shapes the primary <cr> Service already points at the correct
+// (only) tier and a sibling gateway Service would be redundant.
+func (r *GarageClusterReconciler) reconcileGatewayAPIService(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	serviceName := cluster.Name + "-gateway"
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: cluster.Namespace,
+			Labels:    r.labelsForTier(cluster, tierGateway),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                     corev1.ServiceTypeClusterIP,
+			Selector:                 r.selectorLabelsForTier(cluster, tierGateway),
+			Ports:                    apiServicePorts(cluster),
+			PublishNotReadyAddresses: true,
+		},
+	}
+
+	log.Info("Reconciling gateway API Service", "name", serviceName)
+	return reconcileService(ctx, r.Client, svc, cluster, r.Scheme)
+}
+
+// deleteGatewayAPIService removes the <cr>-gateway Service when the gateway
+// tier is no longer declared (e.g. user removed spec.gateway from a unified
+// CR, or the cluster never had a gateway tier).
+func (r *GarageClusterReconciler) deleteGatewayAPIService(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	name := cluster.Name + "-gateway"
+	existing := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: cluster.Namespace}, existing); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	log.Info("Removing gateway API Service (gateway tier no longer declared)", "name", name)
+	return r.Delete(ctx, existing)
 }
 
 // reconcilePublicEndpointService manages a dedicated RPC service (<name>-rpc) used to expose

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -1420,10 +1420,16 @@ func (r *GarageClusterReconciler) reconcileGatewayAPIService(ctx context.Context
 			Labels:    r.labelsForTier(cluster, tierGateway),
 		},
 		Spec: corev1.ServiceSpec{
-			Type:                     corev1.ServiceTypeClusterIP,
-			Selector:                 r.selectorLabelsForTier(cluster, tierGateway),
-			Ports:                    apiServicePorts(cluster),
-			PublishNotReadyAddresses: true,
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: r.selectorLabelsForTier(cluster, tierGateway),
+			Ports:    apiServicePorts(cluster),
+			// Gateway pods carry a /health readiness probe (see
+			// buildGaragePodSpec). PublishNotReadyAddresses: false makes
+			// kube-proxy honor it — surge pods during a rollout don't
+			// receive S3 traffic until they've joined the cluster, and
+			// terminating pods drop out of the endpoint slice as soon as
+			// the readiness probe fails.
+			PublishNotReadyAddresses: false,
 		},
 	}
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -1290,7 +1290,7 @@ func apiServicePorts(cluster *garagev1beta2.GarageCluster) []corev1.ServicePort 
 		s3Port = cluster.Spec.S3API.BindPort
 	}
 	ports = append(ports, corev1.ServicePort{
-		Name:       "s3",
+		Name:       s3PortName,
 		Port:       s3Port,
 		TargetPort: intstr.FromInt32(s3Port),
 		Protocol:   corev1.ProtocolTCP,
@@ -1716,7 +1716,7 @@ func buildContainerPorts(cluster *garagev1beta2.GarageCluster) []corev1.Containe
 	if cluster.Spec.S3API != nil && cluster.Spec.S3API.BindPort != 0 {
 		s3Port = cluster.Spec.S3API.BindPort
 	}
-	ports = append(ports, corev1.ContainerPort{Name: "s3", ContainerPort: s3Port})
+	ports = append(ports, corev1.ContainerPort{Name: s3PortName, ContainerPort: s3Port})
 
 	{
 		adminPort := int32(3903)

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -194,15 +194,13 @@ var _ = Describe("GarageCluster Controller", func() {
 			// Gateway pods must carry a readiness probe — they're behind the
 			// tier-scoped <cr>-gateway Service whose PublishNotReadyAddresses
 			// is false, so the probe is what keeps surge pods out of the
-			// endpoint slice until Garage has bound :3900 and joined the
-			// cluster (preventing connection-refused on the first S3
-			// request after a rollout).
+			// endpoint slice until Garage has bound :3900 (preventing
+			// connection-refused on the first S3 request after a rollout).
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 			probe := deploy.Spec.Template.Spec.Containers[0].ReadinessProbe
 			Expect(probe).NotTo(BeNil(), "gateway pod must have a readiness probe")
-			Expect(probe.HTTPGet).NotTo(BeNil())
-			Expect(probe.HTTPGet.Path).To(Equal("/health"))
-			Expect(probe.HTTPGet.Port.StrVal).To(Equal(adminPortName))
+			Expect(probe.TCPSocket).NotTo(BeNil())
+			Expect(probe.TCPSocket.Port.StrVal).To(Equal(s3PortName))
 		})
 
 		It("should publish the GarageNode selector in Manual layout mode status", func() {

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -190,6 +190,19 @@ var _ = Describe("GarageCluster Controller", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName + "-gateway", Namespace: testNamespace}, deploy)).To(Succeed())
 			Expect(deploy.Spec.Replicas).NotTo(BeNil())
 			Expect(*deploy.Spec.Replicas).To(Equal(int32(0)))
+
+			// Gateway pods must carry a readiness probe — they're behind the
+			// tier-scoped <cr>-gateway Service whose PublishNotReadyAddresses
+			// is false, so the probe is what keeps surge pods out of the
+			// endpoint slice until Garage has bound :3900 and joined the
+			// cluster (preventing connection-refused on the first S3
+			// request after a rollout).
+			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+			probe := deploy.Spec.Template.Spec.Containers[0].ReadinessProbe
+			Expect(probe).NotTo(BeNil(), "gateway pod must have a readiness probe")
+			Expect(probe.HTTPGet).NotTo(BeNil())
+			Expect(probe.HTTPGet.Path).To(Equal("/health"))
+			Expect(probe.HTTPGet.Port.StrVal).To(Equal(adminPortName))
 		})
 
 		It("should publish the GarageNode selector in Manual layout mode status", func() {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -561,15 +561,13 @@ func buildGaragePodSpec(
 		container.SecurityContext = cfg.ContainerSecurityContext
 	}
 
-	// Readiness probe on the gateway tier only. Garage's /health endpoint is
-	// @special (no auth) and returns 200 when status is Healthy or Degraded
-	// (i.e. the pod has joined and at least one quorum-capable peer is
-	// reachable). Without this, gateway pods land in the tier-scoped API
-	// Service the moment the container is Running — before Garage has bound
-	// :3900 — and surge pods during a rollout serve connection-refused for
-	// the first ~1–3 seconds. Storage pods intentionally don't get a probe
-	// here: the headless RPC Service sets PublishNotReadyAddresses=true to
-	// keep federation bootstrap working before any peer is reachable.
+	// Readiness probe on the gateway tier only. The gateway Service should not
+	// receive S3 traffic until Garage has bound :3900, but readiness must not
+	// depend on cluster health: edge gateways need to be routable before
+	// bidirectional RPC connectivity can converge. Storage pods intentionally
+	// don't get a probe here: the headless RPC Service sets
+	// PublishNotReadyAddresses=true to keep federation bootstrap working before
+	// any peer is reachable.
 	//
 	// preStop is intentionally absent: the upstream `dxflrs/garage` image is
 	// distroless (no `sh`, no `sleep`), so an exec preStop can't delay
@@ -581,9 +579,8 @@ func buildGaragePodSpec(
 	if cfg.IsGateway {
 		container.ReadinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/health",
-					Port: intstr.FromString(adminPortName),
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromString(s3PortName),
 				},
 			},
 			InitialDelaySeconds: 2,

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -558,6 +559,38 @@ func buildGaragePodSpec(
 	}
 	if cfg.ContainerSecurityContext != nil {
 		container.SecurityContext = cfg.ContainerSecurityContext
+	}
+
+	// Readiness probe on the gateway tier only. Garage's /health endpoint is
+	// @special (no auth) and returns 200 when status is Healthy or Degraded
+	// (i.e. the pod has joined and at least one quorum-capable peer is
+	// reachable). Without this, gateway pods land in the tier-scoped API
+	// Service the moment the container is Running — before Garage has bound
+	// :3900 — and surge pods during a rollout serve connection-refused for
+	// the first ~1–3 seconds. Storage pods intentionally don't get a probe
+	// here: the headless RPC Service sets PublishNotReadyAddresses=true to
+	// keep federation bootstrap working before any peer is reachable.
+	//
+	// preStop is intentionally absent: the upstream `dxflrs/garage` image is
+	// distroless (no `sh`, no `sleep`), so an exec preStop can't delay
+	// SIGTERM. The default terminationGracePeriodSeconds of 30 is acceptable
+	// for typical rollouts; in-flight requests on a terminating gateway pod
+	// can still see RSTs if endpoint-slice propagation lags SIGTERM, but
+	// that's a documented edge case requiring a non-distroless base image
+	// to fix properly.
+	if cfg.IsGateway {
+		container.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/health",
+					Port: intstr.FromString(adminPortName),
+				},
+			},
+			InitialDelaySeconds: 2,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      3,
+			FailureThreshold:    6,
+		}
 	}
 
 	podSpec := corev1.PodSpec{

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	adminPortName   = "admin"
+	s3PortName      = "s3"
 	metricsPath     = "/metrics"
 	metricsTokenKey = "metrics-token"
 	labelCluster    = "garage.rajsingh.info/cluster"


### PR DESCRIPTION
## Summary

Two related fixes for in-cluster traffic to the unified storage + gateway CR.

### 1. Tier-scope the in-cluster API Service

The `<cr>` Service was selecting **both** storage and gateway pods (e.g. ottawa endpoints today: 1 storage + 2 gateway), so admin / S3 calls round-robin'd across tiers. WebUI hits `http://garage:3903` and lands on a gateway pod 2/3 of the time, which then proxies to storage — added latency and obscured "is admin authoritative" semantics.

New shape:

| Cluster | `<cr>` Service | `<cr>-gateway` Service |
|---|---|---|
| storage-only | `tier:storage` | — |
| unified (storage + gateway) | `tier:storage` | `tier:gateway` |
| edge gateway (no storage) | `tier:gateway` (fallback) | — |
| Manual layout | legacy `{cluster: name}` selector preserved (GarageNode pods lack the tier label) | — |

Mirrors the Tailscale-LB pattern fixed yesterday in `kubernetes-manifests`. WebUI / operator bucket+key controllers now always land on storage; apps wanting S3 fan-out via gateway can target `<cr>-gateway:3900` explicitly.

### 2. Gateway readiness probe + `PublishNotReadyAddresses: false` on the gateway Service

A rolling restart of the gateway tier produced a 1–3 second window of `connection refused` on the gateway-served S3 endpoint:

- `helpers.go:buildGaragePodSpec` set no `ReadinessProbe` at all — gateway pods became endpoints the moment the container was `Running`, before Garage bound `:3900` / `:3903`.
- The new `<cr>-gateway` Service from commit 1 initially inherited `PublishNotReadyAddresses: true`, which would defeat any readiness probe anyway.

Adds HTTP `GET /health` probe on the gateway container's admin port. Garage's `/health` is `@special` (no auth) and returns 200 once cluster status is Healthy or Degraded. Flips `PublishNotReadyAddresses: false` on the `<cr>-gateway` Service so kube-proxy honors the probe.

The primary `<cr>` (storage) Service keeps `PublishNotReadyAddresses: true` for federation bootstrap — storage pods continue not to carry a probe because the headless RPC Service deliberately publishes them while they're still joining peers.

`preStop` is intentionally not added: the upstream `dxflrs/garage` image is distroless (no `sh` / `sleep`). The default `terminationGracePeriodSeconds: 30` plus Garage's SIGTERM handling are acceptable for typical rollouts; closing the residual SIGTERM-vs-endpoint-removal race needs a non-distroless base image and is out of scope.

## Background

Both issues surfaced from yesterday's outage debugging — the in-cluster Service selector mixed tiers, and the gateway-tier rolling restart we did to fix `rpc_public_addr` produced visible client errors during the surge phase. Research is recorded in conversation memory; key findings:

- Quorum / storage data is **not** affected by gateway rolls (upstream confirms gateways have `capacity: None` and are excluded from `ring_assignment_data`, `garage/src/rpc/layout/version.rs:430-443`).
- The disruption surface is purely at the gateway-served edge — readiness gating fixes the surge half; the terminate half is bounded by grace period.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./api/... ./internal/controller/...` green (5 new specs + extended gateway-deployment test asserting the probe)
- [x] `make lint` 0 issues
- [x] `make manifests` does not touch CRDs (controller-only change)
- [ ] Deploy to ottawa/robbinsdale/stpetersburg, verify WebUI lands on storage tier consistently
- [ ] Roll the gateway tier in one region, verify no `connection refused` on `garage-gateway:3900`