### PR TITLE
refactor(controller): gateway pods no longer participate in cluster layout

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -199,6 +199,68 @@ layout entries change.
 
 ---
 
+## v0.5.x → v0.6.0: gateway tier no longer in cluster layout
+
+Starting with v0.6.0 the operator stops adding gateway-tier pods to the
+Garage cluster layout. Gateway nodes join the cluster purely via
+`ConnectClusterNodes`; the cluster's `node_id_vec` only ever contains
+storage-tier IDs.
+
+### Why
+
+Gateway pods run as a Deployment with EmptyDir metadata, so the Ed25519
+node identity (stored in `metadata_dir`) rotates on every pod restart.
+Every restart that the operator added to the layout produced one new
+layout version, accumulating Draining versions over time. Eliminating
+layout participation makes ephemeral identity safe at any restart
+cadence.
+
+### Automatic migration
+
+On the first reconcile after upgrade the operator runs a one-shot
+migration that detects existing role entries tagged `tier:gateway`
+belonging to this cluster and stages a `Remove` for each. The new layout
+version contains zero gateway entries. The migration is idempotent —
+subsequent reconciles find nothing to remove and do nothing.
+
+Look for the log line
+`Migrated gateway tier out of layout` and a transient
+`GatewayTombstones` condition on the GarageCluster status with the
+message `Migrated gateway tier out of layout (removed N entries)`.
+
+### Pre-existing Draining versions are NOT cleaned up
+
+The migration only stops the bleeding. Layout versions that were already
+stuck in `Draining` before the upgrade — particularly those whose
+`storage_sets` contain ghost UUIDs from earlier buggy capacity
+assignments — are unaffected. Quorum-impossible Draining versions need
+an upstream Garage fix to drain or be discarded.
+
+See upstream issue: TODO: upstream issue # (file before merging).
+
+### What changes for operators
+
+- `garage status` no longer lists gateway pods. Use
+  `kubectl get pod -l garage.rajsingh.info/tier=gateway` to enumerate
+  gateway pods instead.
+- `status.pendingGatewayTombstones` is no longer written. The field is
+  retained on the API for backwards-compat; existing values are cleared
+  on the next reconcile.
+- Edge gateway clusters (gateway-only + `connectTo`) follow the same
+  rule: the operator no longer registers gateway pod UUIDs in the
+  remote storage cluster's layout. `ConnectClusterNodes` in both
+  directions is unchanged.
+
+### Rollback
+
+Downgrade the operator image to v0.5.x. The gateway tier will start
+re-registering its pods in the layout again on the next reconcile.
+Existing storage-tier entries are untouched throughout — only gateway
+entries are removed by the migration, and they're recreated by the
+older operator on rollback.
+
+---
+
 ## v1alpha1 → v1beta1
 
 v1beta1 is the first stable API version. All resources are `garage.rajsingh.info/v1beta1`.

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -216,10 +216,11 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Connect to remote clusters for multi-cluster federation
 	r.reconcileFederation(ctx, cluster)
 
-	// Connect gateway tier pods to storage (local or remote) and clean up tombstones.
+	// Connect gateway tier pods to storage (local or remote). Gateway pods do not
+	// participate in the cluster layout — see migrateGatewayOutOfLayout (called
+	// from bootstrapCluster) for the one-shot removal of legacy entries.
 	if cluster.HasGatewayTier() {
 		r.reconcileGatewayConnection(ctx, cluster)
-		r.reconcileGatewayTombstones(ctx, cluster)
 	}
 
 	// Handle operational annotations — return error so controller-runtime requeues with backoff.
@@ -3042,9 +3043,34 @@ func countTotalNodesAfterApply(layout *garage.ClusterLayout) int {
 	return total
 }
 
-// assignNewNodesToLayout assigns undiscovered nodes to the cluster layout and fixes config drift
+// assignNewNodesToLayout assigns undiscovered nodes to the cluster layout and fixes config drift.
+//
+// Gateway-tier pods are filtered out: they never participate in the cluster
+// layout. Garage excludes them from ring_assignment_data regardless (capacity
+// is None for gateways), so adding them only produces churn — one new layout
+// version per pod restart given ephemeral gateway identity. Edge-gateway
+// clusters (gateway-only with connectTo) end up with an empty `nodes` slice
+// after this filter, so no role is staged in the remote cluster's layout.
 func assignNewNodesToLayout(ctx context.Context, garageClient *garage.Client, nodes []bootstrapNodeInfo, cfg layoutConfig) error {
 	log := logf.FromContext(ctx)
+
+	// Drop gateway-tier pods before touching the layout. Pods with an empty
+	// tier label fall through to legacy behavior (treated as storage when
+	// cfg.isGateway=false, gateway when cfg.isGateway=true) — preserving
+	// backward compat with any in-flight pod that hasn't been re-labelled yet.
+	filtered := make([]bootstrapNodeInfo, 0, len(nodes))
+	skippedGateway := 0
+	for _, n := range nodes {
+		if n.tier == tierGateway {
+			skippedGateway++
+			continue
+		}
+		filtered = append(filtered, n)
+	}
+	if skippedGateway > 0 {
+		log.V(1).Info("Skipped gateway-tier pods for layout assignment", "count", skippedGateway)
+	}
+	nodes = filtered
 
 	layout, err := garageClient.GetClusterLayout(ctx)
 	if err != nil {
@@ -3380,6 +3406,13 @@ func (r *GarageClusterReconciler) bootstrapCluster(ctx context.Context, cluster 
 			layoutClient = storageClusterClient
 			log.V(1).Info("Using storage cluster Admin API for layout operations")
 		}
+	}
+
+	// One-shot migration: strip any legacy gateway-tier role entries from the
+	// cluster layout (local for unified clusters, remote for edge gateways).
+	// Idempotent — after the first successful pass there's nothing to do.
+	if cluster.HasGatewayTier() {
+		r.migrateGatewayOutOfLayout(ctx, layoutClient, cluster)
 	}
 
 	return assignNewNodesToLayout(ctx, layoutClient, nodes, cfg)

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -31,6 +31,11 @@ import (
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
+// gatewayTierTag is the layout role tag identifying a node entry as belonging
+// to the gateway tier. Used by the one-shot migration that removes legacy
+// gateway-tier role entries from the cluster layout.
+const gatewayTierTag = "tier:" + tierGateway
+
 // gatewayDeploymentName is the canonical name for the gateway-tier Deployment.
 func gatewayDeploymentName(cluster *garagev1beta2.GarageCluster) string {
 	return cluster.Name + "-gateway"
@@ -39,8 +44,10 @@ func gatewayDeploymentName(cluster *garagev1beta2.GarageCluster) string {
 // reconcileGatewayDeployment creates/updates the gateway-tier Deployment.
 //
 // Gateway pods are ephemeral: EmptyDir for both metadata and data, RollingUpdate
-// strategy, no PVCs. Their node identity rotates per pod restart and the operator
-// garbage-collects stale layout entries via reconcileGatewayTombstones.
+// strategy, no PVCs. Their node identity rotates per pod restart. Gateway nodes
+// do NOT participate in the cluster layout — they join the cluster purely via
+// ConnectClusterNodes. See migrateGatewayOutOfLayout for the one-shot removal
+// of legacy gateway-tier role entries from upgraded clusters.
 func (r *GarageClusterReconciler) reconcileGatewayDeployment(ctx context.Context, cluster *garagev1beta2.GarageCluster, configHash string) error {
 	log := logf.FromContext(ctx)
 	gw := cluster.Spec.Gateway
@@ -274,163 +281,114 @@ func ptrIntOrStringPercent(p int) *intstr.IntOrString {
 	return &v
 }
 
-// reconcileGatewayTombstones removes stale gateway layout entries.
+// migrateGatewayOutOfLayout removes any pre-existing tier:gateway role entries
+// from the cluster layout. Gateway pods no longer participate in the layout —
+// they join the cluster purely via ConnectClusterNodes, which keeps the cluster
+// node_id_vec storage-tier-only and prevents the per-restart Draining-version
+// pileup that ephemeral gateway identity used to cause.
 //
-// Gateway pods generate a fresh node identity on every restart (no PVC), so the
-// Garage layout fills up with dead entries over time. On each reconcile we:
+// This is a one-shot migration: on a freshly upgraded cluster it finds legacy
+// gateway role entries tagged "tier:gateway" + the cluster ownership tag,
+// stages a Remove for each, applies the layout, and calls skip-dead-nodes on
+// the new version. Subsequent reconciles see nothing to remove and the call is
+// effectively a no-op. The migration does NOT touch already-accumulated
+// Draining versions whose storage_sets contain ghost UUIDs — that requires an
+// upstream Garage fix.
 //
-//  1. Query the layout via the appropriate admin API (local for unified clusters,
-//     remote for edge gateways).
-//  2. Filter entries to those carrying the `tier:gateway` ownership tag for this CR.
-//  3. Cross-reference with the live gateway pods' current node IDs (via the same
-//     admin API's GetClusterStatus).
-//  4. Stage removal of entries whose ID is not currently running.
-//
-// When `layoutManagement.autoApply` is true the removal is staged AND applied.
-// Otherwise we stage and surface pending removals via the GatewayTombstones
-// condition and PendingGatewayTombstones status field for human approval (via
-// the existing force-layout-apply annotation).
-func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context, cluster *garagev1beta2.GarageCluster) {
+// Errors are logged but never returned: failure here must not block the
+// primary reconciliation loop. On failure the migration retries on the next
+// reconcile.
+func (r *GarageClusterReconciler) migrateGatewayOutOfLayout(ctx context.Context, layoutClient *garage.Client, cluster *garagev1beta2.GarageCluster) {
 	log := logf.FromContext(ctx)
-	if !cluster.HasGatewayTier() {
-		return
-	}
-
-	// Determine which admin endpoint to query.
-	layoutClient, err := r.gatewayLayoutClient(ctx, cluster)
-	if err != nil {
-		log.V(1).Info("Skipping gateway tombstone cleanup (admin client not ready)", "error", err)
+	if layoutClient == nil {
 		return
 	}
 
 	layout, err := layoutClient.GetClusterLayout(ctx)
 	if err != nil {
-		log.V(1).Info("Skipping gateway tombstone cleanup (could not fetch layout)", "error", err)
+		log.V(1).Info("Skipping gateway-out-of-layout migration (could not fetch layout)", "error", err)
 		return
-	}
-
-	status, err := layoutClient.GetClusterStatus(ctx)
-	if err != nil {
-		log.V(1).Info("Skipping gateway tombstone cleanup (could not fetch status)", "error", err)
-		return
-	}
-
-	live := make(map[string]bool, len(status.Nodes))
-	for _, n := range status.Nodes {
-		if n.IsUp {
-			live[n.ID] = true
-		}
 	}
 
 	gatewayOwnershipTag := fmt.Sprintf("cluster:%s/%s", cluster.Name, cluster.Namespace)
-	var stale []string
+	// Skip roles already staged for removal so we don't double-stage on retries.
+	alreadyStagedForRemoval := make(map[string]bool, len(layout.StagedRoleChanges))
+	for _, change := range layout.StagedRoleChanges {
+		if change.Remove {
+			alreadyStagedForRemoval[change.ID] = true
+		}
+	}
+
+	var staleIDs []string
 	for _, role := range layout.Roles {
-		// Match by ownership tag AND tier:gateway tag.
 		ownsThis := false
 		isGatewayTier := false
 		for _, tag := range role.Tags {
 			if tag == gatewayOwnershipTag {
 				ownsThis = true
 			}
-			if tag == "tier:"+tierGateway {
+			if tag == gatewayTierTag {
 				isGatewayTier = true
 			}
 		}
 		if !ownsThis || !isGatewayTier {
 			continue
 		}
-		if live[role.ID] {
+		if alreadyStagedForRemoval[role.ID] {
 			continue
 		}
-		stale = append(stale, role.ID)
+		staleIDs = append(staleIDs, role.ID)
 	}
 
-	if len(stale) == 0 {
-		// Clear any pending-tombstones surfacing.
-		if len(cluster.Status.PendingGatewayTombstones) > 0 {
-			cluster.Status.PendingGatewayTombstones = nil
-		}
+	// Stop writing PendingGatewayTombstones (deprecated) and clear any leftover
+	// surfacing from a previous operator version.
+	//nolint:staticcheck // SA1019: intentional read+clear of the deprecated field
+	if len(cluster.Status.PendingGatewayTombstones) > 0 {
+		cluster.Status.PendingGatewayTombstones = nil //nolint:staticcheck // SA1019
+	}
+
+	if len(staleIDs) == 0 {
 		meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones)
 		return
 	}
-	sort.Strings(stale)
+	sort.Strings(staleIDs)
 
-	autoApply := cluster.Spec.LayoutManagement != nil && cluster.Spec.LayoutManagement.AutoApply
-	if !autoApply {
-		// Surface stale entries but don't apply.
-		cluster.Status.PendingGatewayTombstones = stale
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:    garagev1beta1.ConditionGatewayTombstones,
-			Status:  metav1.ConditionTrue,
-			Reason:  garagev1beta1.ReasonGatewayTombstonesPending,
-			Message: fmt.Sprintf("%d stale gateway entries pending; set spec.layoutManagement.autoApply: true or use the force-layout-apply annotation", len(stale)),
-		})
-		log.Info("Stale gateway entries pending (autoApply disabled)", "count", len(stale))
-		return
-	}
-
-	// AutoApply: stage and apply removal.
-	changes := make([]garage.NodeRoleChange, 0, len(stale))
-	for _, id := range stale {
+	changes := make([]garage.NodeRoleChange, 0, len(staleIDs))
+	for _, id := range staleIDs {
 		changes = append(changes, garage.NodeRoleChange{ID: id, Remove: true})
 	}
 	if err := layoutClient.UpdateClusterLayout(ctx, changes); err != nil {
-		log.Error(err, "Failed to stage stale gateway entry removal")
+		log.Error(err, "Failed to stage gateway-out-of-layout migration removal", "count", len(staleIDs))
 		return
 	}
 	layout, err = layoutClient.GetClusterLayout(ctx)
 	if err != nil {
-		log.Error(err, "Failed to refresh layout after staging tombstone removal")
+		log.Error(err, "Failed to refresh layout after staging gateway migration removal")
 		return
 	}
 	newVersion := layout.Version + 1
 	if err := layoutClient.ApplyClusterLayout(ctx, newVersion); err != nil {
 		if !garage.IsReplicationConstraint(err) {
-			log.Error(err, "Failed to apply gateway tombstone removal")
+			log.Error(err, "Failed to apply gateway-out-of-layout migration")
 		}
 		return
 	}
-	log.Info("Removed stale gateway entries from layout", "count", len(stale), "version", newVersion)
+	log.Info("Migrated gateway tier out of layout",
+		"removed", len(staleIDs), "version", newVersion)
 
-	// Skip-dead-nodes on the freshly applied layout — these gateway IDs are dead by
-	// definition (we removed them because no pod still owns them).
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               garagev1beta1.ConditionGatewayTombstones,
+		Status:             metav1.ConditionFalse,
+		Reason:             garagev1beta1.ReasonGatewayTombstonesPending,
+		Message:            fmt.Sprintf("Migrated gateway tier out of layout (removed %d entries)", len(staleIDs)),
+		ObservedGeneration: cluster.Generation,
+	})
+
+	// skip-dead-nodes on the freshly applied layout — gateway IDs we just
+	// removed are dead by definition. Single-version layouts return 400 which
+	// is expected on stable clusters; log at debug only.
 	skipReq := garage.SkipDeadNodesRequest{Version: newVersion, AllowMissingData: true}
 	if _, err := layoutClient.ClusterLayoutSkipDeadNodes(ctx, skipReq); err != nil && !garage.IsBadRequest(err) {
-		log.V(1).Info("skip-dead-nodes after tombstone removal failed", "error", err)
+		log.V(1).Info("skip-dead-nodes after gateway migration failed", "error", err)
 	}
-
-	cluster.Status.PendingGatewayTombstones = nil
-	meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones)
-}
-
-// gatewayLayoutClient returns the admin API client whose layout the gateway entries
-// live in. For unified clusters (gateway + storage in the same CR) that's the local
-// admin API. For edge gateways (gateway-only + connectTo) it's the remote storage
-// cluster.
-func (r *GarageClusterReconciler) gatewayLayoutClient(ctx context.Context, cluster *garagev1beta2.GarageCluster) (*garage.Client, error) {
-	if cluster.HasStorageTier() {
-		// Layout lives locally.
-		adminToken, err := r.getAdminToken(ctx, cluster)
-		if err != nil {
-			return nil, err
-		}
-		if adminToken == "" {
-			return nil, fmt.Errorf("admin token not configured")
-		}
-		adminPort := getAdminPort(cluster)
-		endpoint := "http://" + svcFQDN(cluster.Name, cluster.Namespace, adminPort, r.ClusterDomain)
-		return garage.NewClient(endpoint, adminToken), nil
-	}
-
-	// Edge gateway: layout lives on a remote storage cluster.
-	if cluster.Spec.ConnectTo == nil {
-		return nil, fmt.Errorf("gateway-only cluster missing connectTo")
-	}
-	if cluster.Spec.ConnectTo.ClusterRef != nil {
-		return r.getStorageClusterClient(ctx, cluster)
-	}
-	if cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
-		return r.getExternalStorageClient(ctx, cluster)
-	}
-	return nil, fmt.Errorf("connectTo missing clusterRef or adminApiEndpoint")
 }

--- a/internal/controller/gateway_out_of_layout_test.go
+++ b/internal/controller/gateway_out_of_layout_test.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
+)
+
+const (
+	testGatewayNodeID1 = "2222222222222222222222222222222222222222222222222222222222222222"
+	testGatewayNodeID2 = "3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+// layoutTestServer is a minimal mock Garage admin API used by the
+// gateway-out-of-layout tests. It serves a configurable initial layout and
+// records every UpdateClusterLayout/ApplyClusterLayout request.
+type layoutTestServer struct {
+	t              *testing.T
+	server         *httptest.Server
+	layout         garage.ClusterLayout
+	updateRequests []garage.UpdateClusterLayoutRequest
+	applyRequests  []garage.ApplyLayoutRequest
+	skipRequests   []garage.SkipDeadNodesRequest
+}
+
+func newLayoutTestServer(t *testing.T, initial garage.ClusterLayout) *layoutTestServer {
+	t.Helper()
+	s := &layoutTestServer{t: t, layout: initial}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/GetClusterLayout":
+			_ = json.NewEncoder(w).Encode(s.layout)
+		case "/v2/UpdateClusterLayout":
+			var req garage.UpdateClusterLayoutRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			s.updateRequests = append(s.updateRequests, req)
+			// Stage the requested changes on the layout the next GET returns.
+			s.layout.StagedRoleChanges = append(s.layout.StagedRoleChanges, req.Roles...)
+			w.WriteHeader(http.StatusOK)
+		case "/v2/ApplyClusterLayout":
+			var req garage.ApplyLayoutRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			s.applyRequests = append(s.applyRequests, req)
+			// Promote staged removals out of the role list, drop staged additions
+			// into roles. Simulate version bump and clear staged.
+			remaining := make([]garage.LayoutNodeRole, 0, len(s.layout.Roles))
+			toRemove := make(map[string]bool)
+			toAdd := make([]garage.NodeRoleChange, 0)
+			for _, c := range s.layout.StagedRoleChanges {
+				if c.Remove {
+					toRemove[c.ID] = true
+				} else {
+					toAdd = append(toAdd, c)
+				}
+			}
+			for _, role := range s.layout.Roles {
+				if !toRemove[role.ID] {
+					remaining = append(remaining, role)
+				}
+			}
+			for _, a := range toAdd {
+				remaining = append(remaining, garage.LayoutNodeRole{
+					ID: a.ID, Zone: a.Zone, Capacity: a.Capacity, Tags: a.Tags,
+				})
+			}
+			s.layout.Roles = remaining
+			s.layout.StagedRoleChanges = nil
+			s.layout.Version = req.Version
+			w.WriteHeader(http.StatusOK)
+		case "/v2/ClusterLayoutSkipDeadNodes":
+			var req garage.SkipDeadNodesRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			s.skipRequests = append(s.skipRequests, req)
+			// Single-version layout: return 400 like real Garage.
+			http.Error(w, `{"code":"InvalidRequest","message":"This command cannot be called when there is only one live cluster layout version"}`, http.StatusBadRequest)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *layoutTestServer) client() *garage.Client {
+	return garage.NewClient(s.server.URL, "test-admin-token")
+}
+
+// TestAssignNewNodesToLayout_SkipsGatewayTier verifies that gateway-tier pods
+// are never added to the cluster layout. Storage-tier pods continue to be
+// staged as before.
+func TestAssignNewNodesToLayout_SkipsGatewayTier(t *testing.T) {
+	srv := newLayoutTestServer(t, garage.ClusterLayout{Version: 1})
+
+	nodes := []bootstrapNodeInfo{
+		{
+			id:      "1111111111111111111111111111111111111111111111111111111111111111",
+			podIP:   "10.0.0.1",
+			podName: "test-0",
+			tier:    tierStorage,
+		},
+		{
+			id:      testGatewayNodeID1,
+			podIP:   "10.0.0.2",
+			podName: "test-gateway-abc",
+			tier:    tierGateway,
+		},
+		{
+			id:      testGatewayNodeID2,
+			podIP:   "10.0.0.3",
+			podName: "test-gateway-def",
+			tier:    tierGateway,
+		},
+	}
+
+	cfg := layoutConfig{
+		zone:               "zone-a",
+		capacity:           10 * 1024 * 1024 * 1024,
+		replicationFactor:  1,
+		clusterName:        "test",
+		namespace:          testNamespace,
+		skipStaleDetection: true, // we don't care about stale detection here
+	}
+
+	if err := assignNewNodesToLayout(context.Background(), srv.client(), nodes, cfg); err != nil {
+		t.Fatalf("assignNewNodesToLayout: %v", err)
+	}
+
+	// Exactly one UpdateClusterLayout request, staging only the storage node.
+	if len(srv.updateRequests) != 1 {
+		t.Fatalf("expected 1 UpdateClusterLayout call, got %d", len(srv.updateRequests))
+	}
+	staged := srv.updateRequests[0].Roles
+	if len(staged) != 1 {
+		t.Fatalf("expected 1 staged role, got %d: %+v", len(staged), staged)
+	}
+	if staged[0].ID != nodes[0].id {
+		t.Errorf("expected storage node %s staged, got %s", nodes[0].id, staged[0].ID)
+	}
+	for _, role := range staged {
+		for _, tag := range role.Tags {
+			if tag == gatewayTierTag {
+				t.Errorf("staged role carries tier:gateway tag: %+v", role)
+			}
+		}
+	}
+}
+
+// TestAssignNewNodesToLayout_GatewayOnlyEmptyLayout verifies edge-gateway
+// behavior: when the only pods discovered are gateway-tier, nothing is staged
+// in the (remote) layout. The remote cluster's node_id_vec stays storage-only.
+func TestAssignNewNodesToLayout_GatewayOnlyEmptyLayout(t *testing.T) {
+	srv := newLayoutTestServer(t, garage.ClusterLayout{
+		Version: 1,
+		// A remote storage cluster has its own roles already; the edge gateway
+		// must not touch them.
+		Roles: []garage.LayoutNodeRole{
+			{
+				ID:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Zone: "remote-zone",
+				Tags: []string{"cluster:storage/default", "tier:" + tierStorage},
+			},
+		},
+	})
+
+	nodes := []bootstrapNodeInfo{
+		{
+			id:      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			podIP:   "10.0.0.10",
+			podName: "edge-gateway-1",
+			tier:    tierGateway,
+		},
+	}
+
+	cfg := layoutConfig{
+		zone:               "edge-zone",
+		isGateway:          true,
+		replicationFactor:  1,
+		clusterName:        "edge",
+		namespace:          testNamespace,
+		skipStaleDetection: true,
+	}
+
+	if err := assignNewNodesToLayout(context.Background(), srv.client(), nodes, cfg); err != nil {
+		t.Fatalf("assignNewNodesToLayout: %v", err)
+	}
+
+	if len(srv.updateRequests) != 0 {
+		t.Errorf("expected 0 UpdateClusterLayout calls for edge gateway, got %d: %+v",
+			len(srv.updateRequests), srv.updateRequests)
+	}
+	if len(srv.applyRequests) != 0 {
+		t.Errorf("expected 0 ApplyClusterLayout calls for edge gateway, got %d", len(srv.applyRequests))
+	}
+}
+
+// TestMigrateGatewayOutOfLayout verifies the one-shot migration: existing
+// gateway-tier role entries are removed; subsequent calls are no-ops.
+func TestMigrateGatewayOutOfLayout(t *testing.T) {
+	ownership := "cluster:my-cluster/my-ns"
+	srv := newLayoutTestServer(t, garage.ClusterLayout{
+		Version: 5,
+		Roles: []garage.LayoutNodeRole{
+			{
+				ID:   "1111111111111111111111111111111111111111111111111111111111111111",
+				Zone: "z",
+				Tags: []string{ownership, "tier:" + tierStorage, "my-cluster-0"},
+			},
+			{
+				ID:   testGatewayNodeID1,
+				Zone: "z",
+				Tags: []string{ownership, gatewayTierTag, "my-cluster-gateway-xyz"},
+			},
+			{
+				ID:   testGatewayNodeID2,
+				Zone: "z",
+				Tags: []string{ownership, gatewayTierTag, "my-cluster-gateway-abc"},
+			},
+			// Belongs to another cluster — must be left alone even if gateway-tagged.
+			{
+				ID:   "4444444444444444444444444444444444444444444444444444444444444444",
+				Zone: "z",
+				Tags: []string{"cluster:other/elsewhere", gatewayTierTag},
+			},
+		},
+	})
+
+	s := runtime.NewScheme()
+	_ = garagev1beta1.AddToScheme(s)
+	_ = garagev1beta2.AddToScheme(s)
+	r := &GarageClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(s).Build(),
+		Scheme: s,
+	}
+	cluster := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cluster", Namespace: "my-ns", Generation: 7},
+		Status: garagev1beta2.GarageClusterStatus{
+			//nolint:staticcheck // SA1019: deprecated field intentionally seeded
+			PendingGatewayTombstones: []string{"left-over-from-old-operator"},
+		},
+	}
+
+	r.migrateGatewayOutOfLayout(context.Background(), srv.client(), cluster)
+
+	// First pass: exactly one UpdateClusterLayout call, removing both
+	// gateway-tier roles owned by this cluster.
+	if len(srv.updateRequests) != 1 {
+		t.Fatalf("expected 1 UpdateClusterLayout call, got %d", len(srv.updateRequests))
+	}
+	got := srv.updateRequests[0].Roles
+	if len(got) != 2 {
+		t.Fatalf("expected 2 staged removals, got %d: %+v", len(got), got)
+	}
+	want := map[string]bool{
+		testGatewayNodeID1: true,
+		testGatewayNodeID2: true,
+	}
+	for _, change := range got {
+		if !change.Remove {
+			t.Errorf("expected Remove=true on %s, got %+v", change.ID, change)
+		}
+		if !want[change.ID] {
+			t.Errorf("unexpected ID removed: %s", change.ID)
+		}
+		delete(want, change.ID)
+	}
+	if len(want) > 0 {
+		t.Errorf("missing removals: %v", want)
+	}
+
+	// Exactly one ApplyClusterLayout call.
+	if len(srv.applyRequests) != 1 {
+		t.Errorf("expected 1 ApplyClusterLayout, got %d", len(srv.applyRequests))
+	}
+
+	// Status: deprecated PendingGatewayTombstones cleared, migration condition set.
+	//nolint:staticcheck // SA1019: deprecated field intentionally inspected
+	if cluster.Status.PendingGatewayTombstones != nil {
+		//nolint:staticcheck // SA1019
+		t.Errorf("PendingGatewayTombstones should be cleared, got %v", cluster.Status.PendingGatewayTombstones)
+	}
+	cond := findCond(cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones)
+	if cond == nil {
+		t.Fatalf("expected GatewayTombstones condition to be set after migration")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("migration condition status = %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+	if cond.Message == "" || !contains(cond.Message, "Migrated gateway tier out of layout") {
+		t.Errorf("migration condition message = %q, want it to mention the migration", cond.Message)
+	}
+
+	// Second pass: layout no longer contains tier:gateway entries owned by us,
+	// so no further removals are staged.
+	prevUpdates := len(srv.updateRequests)
+	prevApplies := len(srv.applyRequests)
+	r.migrateGatewayOutOfLayout(context.Background(), srv.client(), cluster)
+	if len(srv.updateRequests) != prevUpdates {
+		t.Errorf("second migrate added UpdateClusterLayout call(s): %+v", srv.updateRequests[prevUpdates:])
+	}
+	if len(srv.applyRequests) != prevApplies {
+		t.Errorf("second migrate added ApplyClusterLayout call(s)")
+	}
+
+	// The other cluster's gateway entry must remain untouched.
+	foundOther := false
+	for _, role := range srv.layout.Roles {
+		if role.ID == "4444444444444444444444444444444444444444444444444444444444444444" {
+			foundOther = true
+		}
+	}
+	if !foundOther {
+		t.Errorf("migration removed a gateway entry belonging to another cluster")
+	}
+}
+
+func findCond(conds []metav1.Condition, t string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == t {
+			return &conds[i]
+		}
+	}
+	return nil
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Stop registering ephemeral gateway pods in the Garage cluster layout. Gateway pods join the cluster purely via `ConnectClusterNodes` (gossip layer) and are never added to `node_id_vec` / `ring_assignment_data`. Garage already excludes gateway-tagged entries from `nodes_of()` and quorum sets (`src/rpc/layout/version.rs:118-134`), so the layout participation was purely cosmetic — and it was causing real harm.

## Why

Gateway-tier pods use EmptyDir for their metadata dir, so they generate a fresh Ed25519 `node_key` on every restart (`src/rpc/system.rs:gen_node_key`). The operator's `assignNewNodesToLayout` then runs `UpdateClusterLayout` + `ApplyClusterLayout` for the new UUID — **one new layout version per pod restart**. Routine rollouts (and yesterday's outage debugging) accumulated 23+ Draining versions; some carried ghost UUIDs from prior buggy capacity assignments whose `storage_sets` are quorum-impossible and will not drain without an upstream fix. See related upstream issues: deuxfleurs/garage#1367 (sync_ack lag), #809 (stuck intermediate layout), #1277 (gateway/ghost-node persistence).

Filtering gateway pods out of layout participation eliminates the trigger entirely. Pod restart becomes a no-op for layout. Tombstone cleanup becomes unnecessary.

## What changes

- **`assignNewNodesToLayout`** filters `tier:gateway` pods at the top. Pods with empty tier label fall through to legacy behavior (in-flight pods without the label still work during upgrade).
- **`migrateGatewayOutOfLayout`** replaces `reconcileGatewayTombstones`. One-shot, idempotent: queries layout, finds entries tagged with the cluster ownership tag AND `tier:gateway`, stages a single `Remove` batch, applies, runs `skip-dead-nodes`. Surfaces success via the existing `GatewayTombstones` condition with `Migrated gateway tier out of layout (removed N entries)`.
- **Edge-gateway symmetry**: migration runs against `layoutClient` — local for unified clusters, remote for edge gateways via `spec.connectTo` — so any legacy gateway entries the operator added to the remote layout in older versions are also cleaned up. Storage-tier roles owned by the remote storage cluster are untouched (different ownership tag).
- **`PendingGatewayTombstones` status field** is retained for backward compat. Operator no longer writes to it; clears any leftover value during migration. Marked deprecated in code comments; CRD OpenAPI schema is unchanged (no API surface change in this PR).
- **MIGRATION.md** documents the design pivot and notes that pre-existing accumulated Draining versions are NOT auto-cleaned by this change — that needs an upstream fix.

## What this does NOT do

- Doesn't add a `PodDisruptionBudget` for the gateway Deployment (defer to follow-up).
- Doesn't clean up pre-existing Draining versions accumulated before the upgrade. The migration only removes gateway entries from the current layout; stuck historical state needs the upstream patch (issue being filed) or the maintainer-recommended `cluster_layout` file reset.
- Doesn't change the v1beta2 `PendingGatewayTombstones` API surface — formal API deprecation can be a separate API-versioning PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./api/... ./internal/controller/... ./internal/garage/...` green (3 new specs in `gateway_out_of_layout_test.go`)
- [x] `make lint` 0 issues
- [x] `make manifests` does not touch CRDs (controller-only change)
- [ ] Deploy to ottawa/robbinsdale/stpetersburg, verify migration condition fires once, gateway entries removed from current layout, subsequent reconciles are no-ops
- [ ] Roll the gateway tier, verify no new layout versions get generated

## Linked upstream issue

TODO: link `deuxfleurs/garage#NNNN` once filed — that issue proposes extending `SkipDeadNodes` so already-accumulated stuck Draining versions can be drained.