### PR TITLE
refactor(controller): gateway pods no longer participate in cluster layout

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,10 +50,70 @@ All other `VolumeConfig` fields (`accessModes`, `selector`, `labels`,
 
 ### Tombstone cleanup
 
-The operator's `reconcileGatewayTombstones` reconciler still runs, but it now
-only has work to do on genuine scale-down events (when a gateway replica is
-permanently removed and its PVC is reclaimed). Rolling restarts no longer
-produce stale layout entries.
+Superseded by the v0.5.6 → v0.5.7 migration below — gateway pods are removed
+from the cluster layout entirely.
+
+## v0.5.6 → v0.5.7 — gateway tier removed from cluster layout participation
+
+The v0.5.6 gateway StatefulSet design preserved Ed25519 node identity across
+restarts, eliminating per-restart layout churn. v0.5.7 extends that: gateway
+pods no longer get added to the Garage cluster layout at all. Garage's
+`nodes_of()` excludes gateway-tagged entries from `ring_assignment_data`
+regardless (capacity is `None` for gateways, see
+`src/rpc/layout/version.rs:118-134`), so layout participation was purely
+cosmetic — and harmful at federation scale.
+
+### Why
+
+FullCopy tables (`key`, `bucket_v2`, `bucket_alias`, `admin_token`) replicate
+to every node in `layout.all_nodes()` and require quorum on reads. When the
+layout includes gateway pods from regions other than the requesting region,
+those remote gateway pods are unreachable (the operator only calls
+`ConnectClusterNodes` across regions for storage, not gateways). FullCopy
+reads sit at the quorum boundary and produce 5-30 second timeouts on
+`GetBucketInfo` / `GetKeyInfo` from regions other than the canonical one.
+
+### One-time effect on first reconcile after upgrade
+
+The operator runs a one-shot migration (`migrateGatewayOutOfLayout`) that
+removes any `tier:gateway` role entries from the current layout (local for
+unified clusters, remote for edge gateways via `spec.connectTo`). Subsequent
+reconciles find nothing to remove and are no-ops.
+
+Look for the log line `Migrated gateway tier out of layout` and a
+`GatewayTombstones` condition on the GarageCluster status with the message
+`Migrated gateway tier out of layout (removed N entries)`.
+
+The deprecated `status.pendingGatewayTombstones` field is no longer written;
+any leftover value from a previous operator version is cleared on the next
+reconcile.
+
+### Trade-off
+
+Gateways no longer hold a local FullCopy cache. S3 GET / PUT against a
+gateway pod adds 1-2 admin RPCs to a storage pod for key and bucket lookup.
+Cross-region availability is the higher-value property here; the extra RPC
+is small overhead for stable cross-region clusters. There is no opt-out for
+this release.
+
+### What changes for operators
+
+- `garage status` (and `/v2/GetClusterLayout`) no longer lists gateway pods.
+  Use `kubectl get pod -l garage.rajsingh.info/tier=gateway` to enumerate
+  gateway pods, or `/v2/GetClusterStatus` (which still shows the gateway as
+  a connected peer with no role assigned).
+- The previously-staged "tombstone cleanup" reconciler has been removed.
+- Edge-gateway clusters (gateway-only + `connectTo`) follow the same rule:
+  the operator no longer registers gateway pod UUIDs in the remote storage
+  cluster's layout. `ConnectClusterNodes` in both directions is unchanged.
+
+### Rollback
+
+Downgrade the operator image to v0.5.6. The gateway tier will start
+re-registering its pods in the layout again on the next reconcile. Existing
+storage-tier entries are untouched throughout — only gateway entries were
+removed by the migration, and they're recreated by the older operator on
+rollback.
 
 ## TL;DR for existing v1beta1 users
 

--- a/api/v1beta2/garagecluster_types.go
+++ b/api/v1beta2/garagecluster_types.go
@@ -237,15 +237,15 @@ type StorageSpec struct {
 // Workload: StatefulSet with a small metadata PVC and EmptyDir for the data
 // directory. The metadata PVC persists the Ed25519 node_key Garage stores
 // under metadata_dir, so each gateway pod re-joins the cluster with the
-// same node identity across restarts. Stable identity is what prevents
-// rolling restarts from generating new layout versions (the root cause of
-// the 2026-05-19 layout-churn incident).
+// same node identity across restarts.
 //
 // Data blocks are not stored on gateways, so the data dir remains EmptyDir
 // — no PVC, no storage cost beyond the metadata claim.
 //
-// The operator still runs `reconcileGatewayTombstones` to clean up genuine
-// scale-down events (when a gateway replica is permanently removed).
+// Gateway pods do NOT participate in the Garage cluster layout — they join
+// the cluster purely via ConnectClusterNodes. A one-shot migration
+// (`migrateGatewayOutOfLayout`) removes any legacy gateway-tier role entries
+// left by pre-v0.5.7 operators.
 type GatewaySpec struct {
 	// Replicas is the number of gateway pods to deploy. Set to 0 to keep the
 	// gateway tier declared but stop all pods; the operator still tombstone-

--- a/hack/e2e-multicluster.sh
+++ b/hack/e2e-multicluster.sh
@@ -1231,7 +1231,7 @@ test_gateway_cluster_creation() {
 }
 
 test_gateway_in_layout() {
-    log_test "Testing gateway node is in storage cluster layout with nil capacity..."
+    log_test "Testing gateway node is NOT in storage cluster layout (v0.5.7+ design) and IS a connected peer..."
 
     use_cluster "$CLUSTER1_NAME"
 
@@ -1250,6 +1250,7 @@ test_gateway_in_layout() {
 
     # Port forward to storage cluster with retry
     local layout_info=""
+    local status_info=""
     local pf_port=33903  # Use unique port to avoid conflicts
 
     # Kill any existing port-forward on this port
@@ -1268,9 +1269,11 @@ test_gateway_in_layout() {
             sleep 1
         done
 
-        # Get layout from storage cluster
+        # Get layout AND cluster status from storage cluster
         layout_info=$(curl -s --connect-timeout 10 -H "Authorization: Bearer ${admin_token}" \
             "http://localhost:${pf_port}/v2/GetClusterLayout" 2>/dev/null)
+        status_info=$(curl -s --connect-timeout 10 -H "Authorization: Bearer ${admin_token}" \
+            "http://localhost:${pf_port}/v2/GetClusterStatus" 2>/dev/null)
 
         kill $pf_pid 2>/dev/null || true
         wait $pf_pid 2>/dev/null || true
@@ -1282,21 +1285,26 @@ test_gateway_in_layout() {
         sleep 3
     done
 
-    # Count nodes with nil capacity (gateway nodes)
-    local gateway_nodes=$(echo "$layout_info" | jq '[.roles[] | select(.capacity == null)] | length' 2>/dev/null || echo "0")
-    local storage_nodes=$(echo "$layout_info" | jq '[.roles[] | select(.capacity != null)] | length' 2>/dev/null || echo "0")
+    # v0.5.7+: gateway pods are NOT in the layout. Count layout entries.
+    local gateway_in_layout=$(echo "$layout_info" | jq '[.roles[] | select(.capacity == null)] | length' 2>/dev/null || echo "0")
+    local storage_in_layout=$(echo "$layout_info" | jq '[.roles[] | select(.capacity != null)] | length' 2>/dev/null || echo "0")
 
-    log_info "  Gateway nodes (nil capacity): $gateway_nodes"
-    log_info "  Storage nodes (with capacity): $storage_nodes"
+    # Count gateway peers from cluster status (live nodes with no assigned role).
+    local gateway_peers=$(echo "$status_info" | jq '[.nodes[] | select(.isUp == true and .role == null)] | length' 2>/dev/null || echo "0")
 
-    if [ "$gateway_nodes" -ge 1 ] && [ "$storage_nodes" -ge 1 ]; then
-        test_pass "Gateway node registered in layout with nil capacity (gateway: $gateway_nodes, storage: $storage_nodes)"
+    log_info "  Gateway nodes in layout (expect 0): $gateway_in_layout"
+    log_info "  Storage nodes in layout: $storage_in_layout"
+    log_info "  Gateway peers connected (no role): $gateway_peers"
+
+    if [ "$gateway_in_layout" = "0" ] && [ "$storage_in_layout" -ge 1 ] && [ "$gateway_peers" -ge 1 ]; then
+        test_pass "Gateway is not in layout but IS a connected peer (layout: $storage_in_layout storage / 0 gateway; peers: $gateway_peers gateway)"
         return 0
     fi
 
-    test_fail "Gateway node not properly registered in layout (gateway: $gateway_nodes, storage: $storage_nodes)"
+    test_fail "Gateway layout/peer state unexpected (gw-in-layout: $gateway_in_layout, storage-in-layout: $storage_in_layout, gw-peers: $gateway_peers)"
     echo "Layout response: $layout_info" | head -20
     echo "$layout_info" | jq '.roles' 2>/dev/null || true
+    echo "Status response: $status_info" | head -20
     return 1
 }
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -216,10 +216,11 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Connect to remote clusters for multi-cluster federation
 	r.reconcileFederation(ctx, cluster)
 
-	// Connect gateway tier pods to storage (local or remote) and clean up tombstones.
+	// Connect gateway tier pods to storage (local or remote). Gateway pods do not
+	// participate in the cluster layout — see migrateGatewayOutOfLayout (called
+	// from bootstrapCluster) for the one-shot removal of legacy entries.
 	if cluster.HasGatewayTier() {
 		r.reconcileGatewayConnection(ctx, cluster)
-		r.reconcileGatewayTombstones(ctx, cluster)
 	}
 
 	// Handle operational annotations — return error so controller-runtime requeues with backoff.
@@ -2791,9 +2792,10 @@ type bootstrapNodeInfo struct {
 	podName string
 	// tier is the cluster tier the pod belongs to (tierStorage or tierGateway),
 	// derived from the pod's labelTier label. Empty when neither label is set.
-	// Layout entries get a "tier:<tier>" tag so reconcileGatewayTombstones can
-	// distinguish gateway-tier entries (which rotate identity per restart) from
-	// storage-tier entries (which persist identity across restarts).
+	// Layout entries get a "tier:<tier>" tag so migrateGatewayOutOfLayout can
+	// identify any legacy gateway-tier entries (created by pre-v0.5.7 operators)
+	// and strip them from the layout — gateway pods are no longer added to the
+	// layout going forward.
 	tier string
 }
 
@@ -3042,9 +3044,37 @@ func countTotalNodesAfterApply(layout *garage.ClusterLayout) int {
 	return total
 }
 
-// assignNewNodesToLayout assigns undiscovered nodes to the cluster layout and fixes config drift
+// assignNewNodesToLayout assigns undiscovered nodes to the cluster layout and fixes config drift.
+//
+// Gateway-tier pods are filtered out: they never participate in the cluster
+// layout. Garage excludes them from ring_assignment_data regardless (capacity
+// is None for gateways), so adding them only produces churn — one new layout
+// version per pod restart in the pre-v0.5.6 ephemeral-identity era, and at
+// federation scale they break FullCopy quorum because cross-region gateway
+// peering doesn't exist (operator only calls ConnectClusterNodes across
+// regions for the storage tier). Edge-gateway clusters (gateway-only with
+// connectTo) end up with an empty `nodes` slice after this filter, so no
+// gateway role is staged in the remote cluster's layout either.
 func assignNewNodesToLayout(ctx context.Context, garageClient *garage.Client, nodes []bootstrapNodeInfo, cfg layoutConfig) error {
 	log := logf.FromContext(ctx)
+
+	// Drop gateway-tier pods before touching the layout. Pods with an empty
+	// tier label fall through to legacy behavior (treated as storage when
+	// cfg.isGateway=false, gateway when cfg.isGateway=true) — preserving
+	// backward compat with any in-flight pod that hasn't been re-labelled yet.
+	filtered := make([]bootstrapNodeInfo, 0, len(nodes))
+	skippedGateway := 0
+	for _, n := range nodes {
+		if n.tier == tierGateway {
+			skippedGateway++
+			continue
+		}
+		filtered = append(filtered, n)
+	}
+	if skippedGateway > 0 {
+		log.V(1).Info("Skipped gateway-tier pods for layout assignment", "count", skippedGateway)
+	}
+	nodes = filtered
 
 	layout, err := garageClient.GetClusterLayout(ctx)
 	if err != nil {
@@ -3380,6 +3410,14 @@ func (r *GarageClusterReconciler) bootstrapCluster(ctx context.Context, cluster 
 			layoutClient = storageClusterClient
 			log.V(1).Info("Using storage cluster Admin API for layout operations")
 		}
+	}
+
+	// One-shot migration: strip any legacy gateway-tier role entries from the
+	// cluster layout (local for unified clusters, remote for edge gateways).
+	// Idempotent — after the first successful pass the migration finds nothing
+	// to remove and is effectively a no-op.
+	if cluster.HasGatewayTier() {
+		r.migrateGatewayOutOfLayout(ctx, layoutClient, cluster)
 	}
 
 	return assignNewNodesToLayout(ctx, layoutClient, nodes, cfg)
@@ -4951,9 +4989,9 @@ func nodeBelongsToCluster(tags []string, clusterName, namespace string) bool {
 
 // buildNodeTags creates the tags list for a node including the cluster ownership tag.
 // Format: ["cluster:<name>/<namespace>", "tier:<tier>" (if tier non-empty), <cluster.Spec.DefaultNodeTags...>, <podName>]
-// The "tier:<tier>" tag lets reconcileGatewayTombstones identify gateway-tier
-// entries whose Ed25519 identity rotates per pod restart (vs storage-tier entries
-// whose identity is pinned by the metadata PVC).
+// The "tier:<tier>" tag lets migrateGatewayOutOfLayout identify any legacy
+// gateway-tier entries (created by pre-v0.5.7 operators) and strip them from
+// the layout. Storage entries continue to carry tier:storage for diagnostics.
 func buildNodeTags(clusterName, namespace, tier string, defaultTags []string, podName string) []string {
 	tags := make([]string, 0, 3+len(defaultTags))
 	// Ownership tag for unique cluster identification

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -53,6 +53,11 @@ func gatewayWorkloadName(cluster *garagev1beta2.GarageCluster) string {
 //
 // As a one-shot upgrade aid, any pre-existing Deployment with the same name
 // (from v0.5.5 and earlier) is removed before the StatefulSet is created.
+//
+// Gateway pods do NOT participate in the cluster layout — they join the
+// cluster purely via ConnectClusterNodes. See migrateGatewayOutOfLayout for
+// the one-shot removal of legacy gateway-tier role entries from upgraded
+// clusters.
 func (r *GarageClusterReconciler) reconcileGatewayStatefulSet(ctx context.Context, cluster *garagev1beta2.GarageCluster, configHash string) error {
 	log := logf.FromContext(ctx)
 	gw := cluster.Spec.Gateway
@@ -363,167 +368,124 @@ func buildGatewayVolumeClaimTemplates(cluster *garagev1beta2.GarageCluster) []co
 	return []corev1.PersistentVolumeClaim{pvc}
 }
 
-// reconcileGatewayTombstones removes stale gateway layout entries.
-//
-// With persistent gateway identity (v0.5.6+) a routine rollout no longer
-// generates a new layout entry per restart, so this reconciler only has work
-// to do on genuine scale-down events — when a gateway replica is permanently
-// removed and its PVC (and therefore its node_key) is deleted via the
-// StatefulSet's WhenScaled=Delete retention policy.
-//
-//  1. Query the layout via the appropriate admin API (local for unified
-//     clusters, remote for edge gateways).
-//  2. Filter entries to those carrying the `tier:gateway` ownership tag for
-//     this CR.
-//  3. Cross-reference with the live gateway pods' current node IDs (via the
-//     same admin API's GetClusterStatus).
-//  4. Stage removal of entries whose ID is not currently running.
-//
-// When `layoutManagement.autoApply` is true the removal is staged AND applied.
-// Otherwise we stage and surface pending removals via the GatewayTombstones
-// condition and PendingGatewayTombstones status field for human approval (via
-// the existing force-layout-apply annotation).
-func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context, cluster *garagev1beta2.GarageCluster) {
-	log := logf.FromContext(ctx)
-	if !cluster.HasGatewayTier() {
-		return
-	}
+// gatewayTierTag is the layout role tag identifying a node entry as belonging
+// to the gateway tier. Used by the one-shot migration that removes legacy
+// gateway-tier role entries from the cluster layout.
+const gatewayTierTag = "tier:" + tierGateway
 
-	// Determine which admin endpoint to query.
-	layoutClient, err := r.gatewayLayoutClient(ctx, cluster)
-	if err != nil {
-		log.V(1).Info("Skipping gateway tombstone cleanup (admin client not ready)", "error", err)
+// migrateGatewayOutOfLayout removes any pre-existing tier:gateway role entries
+// from the cluster layout. Gateway pods no longer participate in the layout —
+// they join the cluster purely via ConnectClusterNodes, which keeps the cluster
+// node_id_vec storage-tier-only.
+//
+// Why: FullCopy tables (key, bucket_v2, bucket_alias, admin_token) replicate
+// to every node in `layout.all_nodes()` and require quorum on reads. Gateway
+// pods in remote regions are unreachable from a region's storage tier
+// (operator only calls ConnectClusterNodes across regions for storage), so
+// including them in layout pushes FullCopy reads to the quorum boundary and
+// causes 5-30s timeouts on GetBucketInfo / GetKeyInfo from non-canonical
+// regions.
+//
+// This is a one-shot migration: on a freshly upgraded cluster it finds legacy
+// gateway role entries tagged "tier:gateway" + the cluster ownership tag,
+// stages a Remove for each, applies the layout, and calls skip-dead-nodes on
+// the new version. Subsequent reconciles see nothing to remove and the call
+// is effectively a no-op (idempotent via the absence of matching roles).
+//
+// Errors are logged but never returned: failure here must not block the
+// primary reconciliation loop. On failure the migration retries on the next
+// reconcile.
+func (r *GarageClusterReconciler) migrateGatewayOutOfLayout(ctx context.Context, layoutClient *garage.Client, cluster *garagev1beta2.GarageCluster) {
+	log := logf.FromContext(ctx)
+	if layoutClient == nil {
 		return
 	}
 
 	layout, err := layoutClient.GetClusterLayout(ctx)
 	if err != nil {
-		log.V(1).Info("Skipping gateway tombstone cleanup (could not fetch layout)", "error", err)
+		log.V(1).Info("Skipping gateway-out-of-layout migration (could not fetch layout)", "error", err)
 		return
-	}
-
-	status, err := layoutClient.GetClusterStatus(ctx)
-	if err != nil {
-		log.V(1).Info("Skipping gateway tombstone cleanup (could not fetch status)", "error", err)
-		return
-	}
-
-	live := make(map[string]bool, len(status.Nodes))
-	for _, n := range status.Nodes {
-		if n.IsUp {
-			live[n.ID] = true
-		}
 	}
 
 	gatewayOwnershipTag := fmt.Sprintf("cluster:%s/%s", cluster.Name, cluster.Namespace)
-	var stale []string
+	// Skip roles already staged for removal so we don't double-stage on retries.
+	alreadyStagedForRemoval := make(map[string]bool, len(layout.StagedRoleChanges))
+	for _, change := range layout.StagedRoleChanges {
+		if change.Remove {
+			alreadyStagedForRemoval[change.ID] = true
+		}
+	}
+
+	var staleIDs []string
 	for _, role := range layout.Roles {
-		// Match by ownership tag AND tier:gateway tag.
 		ownsThis := false
 		isGatewayTier := false
 		for _, tag := range role.Tags {
 			if tag == gatewayOwnershipTag {
 				ownsThis = true
 			}
-			if tag == "tier:"+tierGateway {
+			if tag == gatewayTierTag {
 				isGatewayTier = true
 			}
 		}
 		if !ownsThis || !isGatewayTier {
 			continue
 		}
-		if live[role.ID] {
+		if alreadyStagedForRemoval[role.ID] {
 			continue
 		}
-		stale = append(stale, role.ID)
+		staleIDs = append(staleIDs, role.ID)
 	}
 
-	if len(stale) == 0 {
-		// Clear any pending-tombstones surfacing.
-		if len(cluster.Status.PendingGatewayTombstones) > 0 {
-			cluster.Status.PendingGatewayTombstones = nil
-		}
+	// Stop writing PendingGatewayTombstones (deprecated) and clear any leftover
+	// surfacing from a previous operator version.
+	//nolint:staticcheck // SA1019: intentional read+clear of the deprecated field
+	if len(cluster.Status.PendingGatewayTombstones) > 0 {
+		cluster.Status.PendingGatewayTombstones = nil //nolint:staticcheck // SA1019
+	}
+
+	if len(staleIDs) == 0 {
 		meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones)
 		return
 	}
-	sort.Strings(stale)
+	sort.Strings(staleIDs)
 
-	autoApply := cluster.Spec.LayoutManagement != nil && cluster.Spec.LayoutManagement.AutoApply
-	if !autoApply {
-		// Surface stale entries but don't apply.
-		cluster.Status.PendingGatewayTombstones = stale
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:    garagev1beta1.ConditionGatewayTombstones,
-			Status:  metav1.ConditionTrue,
-			Reason:  garagev1beta1.ReasonGatewayTombstonesPending,
-			Message: fmt.Sprintf("%d stale gateway entries pending; set spec.layoutManagement.autoApply: true or use the force-layout-apply annotation", len(stale)),
-		})
-		log.Info("Stale gateway entries pending (autoApply disabled)", "count", len(stale))
-		return
-	}
-
-	// AutoApply: stage and apply removal.
-	changes := make([]garage.NodeRoleChange, 0, len(stale))
-	for _, id := range stale {
+	changes := make([]garage.NodeRoleChange, 0, len(staleIDs))
+	for _, id := range staleIDs {
 		changes = append(changes, garage.NodeRoleChange{ID: id, Remove: true})
 	}
 	if err := layoutClient.UpdateClusterLayout(ctx, changes); err != nil {
-		log.Error(err, "Failed to stage stale gateway entry removal")
+		log.Error(err, "Failed to stage gateway-out-of-layout migration removal", "count", len(staleIDs))
 		return
 	}
 	layout, err = layoutClient.GetClusterLayout(ctx)
 	if err != nil {
-		log.Error(err, "Failed to refresh layout after staging tombstone removal")
+		log.Error(err, "Failed to refresh layout after staging gateway migration removal")
 		return
 	}
 	newVersion := layout.Version + 1
 	if err := layoutClient.ApplyClusterLayout(ctx, newVersion); err != nil {
 		if !garage.IsReplicationConstraint(err) {
-			log.Error(err, "Failed to apply gateway tombstone removal")
+			log.Error(err, "Failed to apply gateway-out-of-layout migration")
 		}
 		return
 	}
-	log.Info("Removed stale gateway entries from layout", "count", len(stale), "version", newVersion)
+	log.Info("Migrated gateway tier out of layout",
+		"removed", len(staleIDs), "version", newVersion)
 
-	// Skip-dead-nodes on the freshly applied layout — these gateway IDs are dead by
-	// definition (we removed them because no pod still owns them).
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               garagev1beta1.ConditionGatewayTombstones,
+		Status:             metav1.ConditionFalse,
+		Reason:             garagev1beta1.ReasonGatewayTombstonesPending,
+		Message:            fmt.Sprintf("Migrated gateway tier out of layout (removed %d entries)", len(staleIDs)),
+		ObservedGeneration: cluster.Generation,
+	})
+
+	// skip-dead-nodes on the freshly applied layout — gateway IDs we just
+	// removed are dead by definition. Single-version layouts return 400 which
+	// is expected on stable clusters; log at debug only.
 	skipReq := garage.SkipDeadNodesRequest{Version: newVersion, AllowMissingData: true}
 	if _, err := layoutClient.ClusterLayoutSkipDeadNodes(ctx, skipReq); err != nil && !garage.IsBadRequest(err) {
-		log.V(1).Info("skip-dead-nodes after tombstone removal failed", "error", err)
+		log.V(1).Info("skip-dead-nodes after gateway migration failed", "error", err)
 	}
-
-	cluster.Status.PendingGatewayTombstones = nil
-	meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones)
-}
-
-// gatewayLayoutClient returns the admin API client whose layout the gateway entries
-// live in. For unified clusters (gateway + storage in the same CR) that's the local
-// admin API. For edge gateways (gateway-only + connectTo) it's the remote storage
-// cluster.
-func (r *GarageClusterReconciler) gatewayLayoutClient(ctx context.Context, cluster *garagev1beta2.GarageCluster) (*garage.Client, error) {
-	if cluster.HasStorageTier() {
-		// Layout lives locally.
-		adminToken, err := r.getAdminToken(ctx, cluster)
-		if err != nil {
-			return nil, err
-		}
-		if adminToken == "" {
-			return nil, fmt.Errorf("admin token not configured")
-		}
-		adminPort := getAdminPort(cluster)
-		endpoint := "http://" + svcFQDN(cluster.Name, cluster.Namespace, adminPort, r.ClusterDomain)
-		return garage.NewClient(endpoint, adminToken), nil
-	}
-
-	// Edge gateway: layout lives on a remote storage cluster.
-	if cluster.Spec.ConnectTo == nil {
-		return nil, fmt.Errorf("gateway-only cluster missing connectTo")
-	}
-	if cluster.Spec.ConnectTo.ClusterRef != nil {
-		return r.getStorageClusterClient(ctx, cluster)
-	}
-	if cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
-		return r.getExternalStorageClient(ctx, cluster)
-	}
-	return nil, fmt.Errorf("connectTo missing clusterRef or adminApiEndpoint")
 }

--- a/internal/controller/gateway_out_of_layout_test.go
+++ b/internal/controller/gateway_out_of_layout_test.go
@@ -1,0 +1,384 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
+)
+
+const (
+	testStorageNodeID  = "1111111111111111111111111111111111111111111111111111111111111111"
+	testGatewayNodeID1 = "2222222222222222222222222222222222222222222222222222222222222222"
+	testGatewayNodeID2 = "3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+// layoutTestServer is a minimal mock Garage admin API used by the
+// gateway-out-of-layout tests. It serves a configurable initial layout and
+// records every UpdateClusterLayout/ApplyClusterLayout request.
+type layoutTestServer struct {
+	t              *testing.T
+	server         *httptest.Server
+	layout         garage.ClusterLayout
+	updateRequests []garage.UpdateClusterLayoutRequest
+	applyRequests  []garage.ApplyLayoutRequest
+	skipRequests   []garage.SkipDeadNodesRequest
+}
+
+func newLayoutTestServer(t *testing.T, initial garage.ClusterLayout) *layoutTestServer {
+	t.Helper()
+	s := &layoutTestServer{t: t, layout: initial}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/GetClusterLayout":
+			_ = json.NewEncoder(w).Encode(s.layout)
+		case "/v2/UpdateClusterLayout":
+			var req garage.UpdateClusterLayoutRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			s.updateRequests = append(s.updateRequests, req)
+			// Stage the requested changes on the layout the next GET returns.
+			s.layout.StagedRoleChanges = append(s.layout.StagedRoleChanges, req.Roles...)
+			w.WriteHeader(http.StatusOK)
+		case "/v2/ApplyClusterLayout":
+			var req garage.ApplyLayoutRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			s.applyRequests = append(s.applyRequests, req)
+			// Promote staged removals out of the role list, drop staged additions
+			// into roles. Simulate version bump and clear staged.
+			remaining := make([]garage.LayoutNodeRole, 0, len(s.layout.Roles))
+			toRemove := make(map[string]bool)
+			toAdd := make([]garage.NodeRoleChange, 0)
+			for _, c := range s.layout.StagedRoleChanges {
+				if c.Remove {
+					toRemove[c.ID] = true
+				} else {
+					toAdd = append(toAdd, c)
+				}
+			}
+			for _, role := range s.layout.Roles {
+				if !toRemove[role.ID] {
+					remaining = append(remaining, role)
+				}
+			}
+			for _, a := range toAdd {
+				remaining = append(remaining, garage.LayoutNodeRole{
+					ID: a.ID, Zone: a.Zone, Capacity: a.Capacity, Tags: a.Tags,
+				})
+			}
+			s.layout.Roles = remaining
+			s.layout.StagedRoleChanges = nil
+			s.layout.Version = req.Version
+			w.WriteHeader(http.StatusOK)
+		case "/v2/ClusterLayoutSkipDeadNodes":
+			var req garage.SkipDeadNodesRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			s.skipRequests = append(s.skipRequests, req)
+			// Single-version layout: return 400 like real Garage.
+			http.Error(w, `{"code":"InvalidRequest","message":"This command cannot be called when there is only one live cluster layout version"}`, http.StatusBadRequest)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *layoutTestServer) client() *garage.Client {
+	return garage.NewClient(s.server.URL, "test-admin-token")
+}
+
+// TestAssignNewNodesToLayout_SkipsGatewayTier verifies that gateway-tier pods
+// are never added to the cluster layout. Storage-tier pods continue to be
+// staged as before.
+func TestAssignNewNodesToLayout_SkipsGatewayTier(t *testing.T) {
+	srv := newLayoutTestServer(t, garage.ClusterLayout{Version: 1})
+
+	nodes := []bootstrapNodeInfo{
+		{
+			id:      testStorageNodeID,
+			podIP:   "10.0.0.1",
+			podName: "test-0",
+			tier:    tierStorage,
+		},
+		{
+			id:      testGatewayNodeID1,
+			podIP:   "10.0.0.2",
+			podName: "test-gateway-abc",
+			tier:    tierGateway,
+		},
+		{
+			id:      testGatewayNodeID2,
+			podIP:   "10.0.0.3",
+			podName: "test-gateway-def",
+			tier:    tierGateway,
+		},
+	}
+
+	cfg := layoutConfig{
+		zone:               "zone-a",
+		capacity:           10 * 1024 * 1024 * 1024,
+		replicationFactor:  1,
+		clusterName:        "test",
+		namespace:          testNamespace,
+		skipStaleDetection: true, // we don't care about stale detection here
+	}
+
+	if err := assignNewNodesToLayout(context.Background(), srv.client(), nodes, cfg); err != nil {
+		t.Fatalf("assignNewNodesToLayout: %v", err)
+	}
+
+	// Exactly one UpdateClusterLayout request, staging only the storage node.
+	if len(srv.updateRequests) != 1 {
+		t.Fatalf("expected 1 UpdateClusterLayout call, got %d", len(srv.updateRequests))
+	}
+	staged := srv.updateRequests[0].Roles
+	if len(staged) != 1 {
+		t.Fatalf("expected 1 staged role, got %d: %+v", len(staged), staged)
+	}
+	if staged[0].ID != nodes[0].id {
+		t.Errorf("expected storage node %s staged, got %s", nodes[0].id, staged[0].ID)
+	}
+	for _, role := range staged {
+		for _, tag := range role.Tags {
+			if tag == gatewayTierTag {
+				t.Errorf("staged role carries tier:gateway tag: %+v", role)
+			}
+		}
+	}
+}
+
+// TestAssignNewNodesToLayout_GatewayOnlyEmptyLayout verifies edge-gateway
+// behavior: when the only pods discovered are gateway-tier, nothing is staged
+// in the (remote) layout. The remote cluster's node_id_vec stays storage-only.
+func TestAssignNewNodesToLayout_GatewayOnlyEmptyLayout(t *testing.T) {
+	srv := newLayoutTestServer(t, garage.ClusterLayout{
+		Version: 1,
+		// A remote storage cluster has its own roles already; the edge gateway
+		// must not touch them.
+		Roles: []garage.LayoutNodeRole{
+			{
+				ID:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Zone: "remote-zone",
+				Tags: []string{"cluster:storage/default", "tier:" + tierStorage},
+			},
+		},
+	})
+
+	nodes := []bootstrapNodeInfo{
+		{
+			id:      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			podIP:   "10.0.0.10",
+			podName: "edge-gateway-1",
+			tier:    tierGateway,
+		},
+	}
+
+	cfg := layoutConfig{
+		zone:               "edge-zone",
+		isGateway:          true,
+		replicationFactor:  1,
+		clusterName:        "edge",
+		namespace:          testNamespace,
+		skipStaleDetection: true,
+	}
+
+	if err := assignNewNodesToLayout(context.Background(), srv.client(), nodes, cfg); err != nil {
+		t.Fatalf("assignNewNodesToLayout: %v", err)
+	}
+
+	if len(srv.updateRequests) != 0 {
+		t.Errorf("expected 0 UpdateClusterLayout calls for edge gateway, got %d: %+v",
+			len(srv.updateRequests), srv.updateRequests)
+	}
+	if len(srv.applyRequests) != 0 {
+		t.Errorf("expected 0 ApplyClusterLayout calls for edge gateway, got %d", len(srv.applyRequests))
+	}
+}
+
+// TestMigrateGatewayOutOfLayout verifies the one-shot migration: existing
+// gateway-tier role entries are removed; subsequent calls are no-ops.
+func TestMigrateGatewayOutOfLayout(t *testing.T) {
+	ownership := "cluster:my-cluster/my-ns"
+	srv := newLayoutTestServer(t, garage.ClusterLayout{
+		Version: 5,
+		Roles: []garage.LayoutNodeRole{
+			{
+				ID:   testStorageNodeID,
+				Zone: "z",
+				Tags: []string{ownership, "tier:" + tierStorage, "my-cluster-0"},
+			},
+			{
+				ID:   testGatewayNodeID1,
+				Zone: "z",
+				Tags: []string{ownership, gatewayTierTag, "my-cluster-gateway-xyz"},
+			},
+			{
+				ID:   testGatewayNodeID2,
+				Zone: "z",
+				Tags: []string{ownership, gatewayTierTag, "my-cluster-gateway-abc"},
+			},
+			// Belongs to another cluster — must be left alone even if gateway-tagged.
+			{
+				ID:   "4444444444444444444444444444444444444444444444444444444444444444",
+				Zone: "z",
+				Tags: []string{"cluster:other/elsewhere", gatewayTierTag},
+			},
+		},
+	})
+
+	s := runtime.NewScheme()
+	_ = garagev1beta1.AddToScheme(s)
+	_ = garagev1beta2.AddToScheme(s)
+	r := &GarageClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(s).Build(),
+		Scheme: s,
+	}
+	cluster := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cluster", Namespace: "my-ns", Generation: 7},
+		Status: garagev1beta2.GarageClusterStatus{
+			//nolint:staticcheck // SA1019: deprecated field intentionally seeded
+			PendingGatewayTombstones: []string{"left-over-from-old-operator"},
+		},
+	}
+
+	r.migrateGatewayOutOfLayout(context.Background(), srv.client(), cluster)
+
+	// First pass: exactly one UpdateClusterLayout call, removing both
+	// gateway-tier roles owned by this cluster.
+	if len(srv.updateRequests) != 1 {
+		t.Fatalf("expected 1 UpdateClusterLayout call, got %d", len(srv.updateRequests))
+	}
+	got := srv.updateRequests[0].Roles
+	if len(got) != 2 {
+		t.Fatalf("expected 2 staged removals, got %d: %+v", len(got), got)
+	}
+	want := map[string]bool{
+		testGatewayNodeID1: true,
+		testGatewayNodeID2: true,
+	}
+	for _, change := range got {
+		if !change.Remove {
+			t.Errorf("expected Remove=true on %s, got %+v", change.ID, change)
+		}
+		if !want[change.ID] {
+			t.Errorf("unexpected ID removed: %s", change.ID)
+		}
+		delete(want, change.ID)
+	}
+	if len(want) > 0 {
+		t.Errorf("missing removals: %v", want)
+	}
+
+	// Exactly one ApplyClusterLayout call.
+	if len(srv.applyRequests) != 1 {
+		t.Errorf("expected 1 ApplyClusterLayout, got %d", len(srv.applyRequests))
+	}
+
+	// Status: deprecated PendingGatewayTombstones cleared, migration condition set.
+	//nolint:staticcheck // SA1019: deprecated field intentionally inspected
+	if cluster.Status.PendingGatewayTombstones != nil {
+		//nolint:staticcheck // SA1019
+		t.Errorf("PendingGatewayTombstones should be cleared, got %v", cluster.Status.PendingGatewayTombstones)
+	}
+	cond := findCond(cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones)
+	if cond == nil {
+		t.Fatalf("expected GatewayTombstones condition to be set after migration")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("migration condition status = %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+	if cond.Message == "" || !strings.Contains(cond.Message, "Migrated gateway tier out of layout") {
+		t.Errorf("migration condition message = %q, want it to mention the migration", cond.Message)
+	}
+
+	// Second pass: layout no longer contains tier:gateway entries owned by us,
+	// so no further removals are staged.
+	prevUpdates := len(srv.updateRequests)
+	prevApplies := len(srv.applyRequests)
+	r.migrateGatewayOutOfLayout(context.Background(), srv.client(), cluster)
+	if len(srv.updateRequests) != prevUpdates {
+		t.Errorf("second migrate added UpdateClusterLayout call(s): %+v", srv.updateRequests[prevUpdates:])
+	}
+	if len(srv.applyRequests) != prevApplies {
+		t.Errorf("second migrate added ApplyClusterLayout call(s)")
+	}
+
+	// The other cluster's gateway entry must remain untouched.
+	foundOther := false
+	for _, role := range srv.layout.Roles {
+		if role.ID == "4444444444444444444444444444444444444444444444444444444444444444" {
+			foundOther = true
+		}
+	}
+	if !foundOther {
+		t.Errorf("migration removed a gateway entry belonging to another cluster")
+	}
+}
+
+// TestMigrateGatewayOutOfLayout_NoLegacyEntries verifies the migration is a
+// pure no-op when the layout has never contained gateway entries.
+func TestMigrateGatewayOutOfLayout_NoLegacyEntries(t *testing.T) {
+	srv := newLayoutTestServer(t, garage.ClusterLayout{
+		Version: 3,
+		Roles: []garage.LayoutNodeRole{
+			{
+				ID:   testStorageNodeID,
+				Zone: "z",
+				Tags: []string{"cluster:fresh/ns", "tier:" + tierStorage, "fresh-0"},
+			},
+		},
+	})
+
+	s := runtime.NewScheme()
+	_ = garagev1beta1.AddToScheme(s)
+	_ = garagev1beta2.AddToScheme(s)
+	r := &GarageClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(s).Build(),
+		Scheme: s,
+	}
+	cluster := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "fresh", Namespace: "ns"},
+	}
+
+	r.migrateGatewayOutOfLayout(context.Background(), srv.client(), cluster)
+
+	if len(srv.updateRequests) != 0 {
+		t.Errorf("expected 0 UpdateClusterLayout calls on a clean layout, got %d", len(srv.updateRequests))
+	}
+	if len(srv.applyRequests) != 0 {
+		t.Errorf("expected 0 ApplyClusterLayout calls on a clean layout, got %d", len(srv.applyRequests))
+	}
+	if cond := findCond(cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones); cond != nil {
+		t.Errorf("did not expect GatewayTombstones condition on a clean layout, got %+v", cond)
+	}
+}
+
+func findCond(conds []metav1.Condition, t string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == t {
+			return &conds[i]
+		}
+	}
+	return nil
+}

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -1167,10 +1167,9 @@ func TestMergeLabels(t *testing.T) {
 }
 
 // TestBuildNodeTags_TierTag verifies the tier:<tier> tag is emitted when a
-// non-empty tier is provided. reconcileGatewayTombstones depends on this tag
-// to distinguish gateway-tier layout entries (whose Ed25519 identity rotates
-// per pod restart) from storage-tier entries (whose identity is pinned to a
-// metadata PVC).
+// non-empty tier is provided. migrateGatewayOutOfLayout depends on the
+// tier:gateway tag to identify legacy gateway-tier entries from pre-v0.5.7
+// operators and strip them from the layout.
 func TestBuildNodeTags_TierTag(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1382,11 +1382,15 @@ spec:
 			_, _ = utils.Run(cmd)
 		})
 
-		It("should have gateway nodes with null capacity in layout", func() {
+		It("should NOT register gateway nodes in the cluster layout", func() {
+			// Post-v0.5.7 design: gateway pods join the cluster purely via
+			// ConnectClusterNodes; they do not get added to the layout. The
+			// layout should contain only storage-tier entries (one per
+			// storage pod), and the gateway cluster's CR ownership tag must
+			// not appear in any role.
 			By("querying the cluster layout via Admin API")
 			adminToken := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-			verifyGatewayCapacity := func(g Gomega) {
-				// Use --overrides to set security context for restricted namespace
+			verifyGatewayAbsent := func(g Gomega) {
 				curlCmd := fmt.Sprintf("curl -s -H 'Authorization: Bearer %s' http://%s.%s.svc.cluster.local:3903/v2/GetClusterLayout",
 					adminToken, storageClusterName, testNamespace)
 				cmd := exec.Command("kubectl", "run", "curl-layout-check", "--rm", "-i", "--restart=Never",
@@ -1414,9 +1418,6 @@ spec:
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "Failed to query layout: %s", output)
 
-				// Parse the layout JSON to find gateway nodes
-				// Gateway nodes should have capacity: null, not a numeric value
-				// Handle both compact JSON ("capacity":null) and pretty-printed ("capacity": null)
 				var layout struct {
 					Roles []struct {
 						ID       string   `json:"id"`
@@ -1424,7 +1425,6 @@ spec:
 						Capacity *uint64  `json:"capacity"`
 					} `json:"roles"`
 				}
-				// Extract JSON from output (kubectl adds "pod deleted" message)
 				jsonStart := strings.Index(output, "{")
 				jsonEnd := strings.LastIndex(output, "}")
 				g.Expect(jsonStart).To(BeNumerically(">=", 0), "No JSON found in output: %s", output)
@@ -1432,28 +1432,26 @@ spec:
 				jsonStr := output[jsonStart : jsonEnd+1]
 				g.Expect(json.Unmarshal([]byte(jsonStr), &layout)).To(Succeed(), "Failed to parse layout JSON: %s", jsonStr)
 
-				// Find the gateway node by its tag prefix
-				var foundGatewayNode bool
 				for _, role := range layout.Roles {
 					for _, tag := range role.Tags {
-						if strings.HasPrefix(tag, gatewayClusterName) {
-							g.Expect(role.Capacity).To(BeNil(),
-								"Gateway node %s should have null capacity, got: %v", tag, role.Capacity)
-							foundGatewayNode = true
-						}
+						g.Expect(strings.HasPrefix(tag, gatewayClusterName)).To(BeFalse(),
+							"Gateway-tagged role found in layout — gateways must not participate in the layout. Role: %+v", role)
+						g.Expect(tag).NotTo(Equal("tier:gateway"),
+							"tier:gateway tag found in layout. Role: %+v", role)
 					}
 				}
-				g.Expect(foundGatewayNode).To(BeTrue(),
-					"Gateway node not found in layout. Roles: %+v", layout.Roles)
 			}
-			Eventually(verifyGatewayCapacity, 2*time.Minute, 10*time.Second).Should(Succeed())
+			Eventually(verifyGatewayAbsent, 2*time.Minute, 10*time.Second).Should(Succeed())
 		})
 
 		It("should preserve node identity when gateway pods restart (persistent identity)", func() {
 			// Gateway tier (v0.5.6+) is a StatefulSet with a metadata PVC, so
 			// the Ed25519 node_key Garage stores under metadata_dir persists
-			// across pod restarts. The cluster layout MUST NOT gain a new
-			// entry when a gateway pod is recreated.
+			// across pod restarts. Although gateway pods do NOT participate
+			// in the cluster layout (v0.5.7+), they still report a stable
+			// node ID via the local admin API, and the storage cluster's
+			// view of connected nodes must show the same ID before and
+			// after a gateway pod restart.
 			By("getting the current gateway pod name")
 			cmd := exec.Command("kubectl", "get", "pods",
 				"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", gatewayClusterName),
@@ -1463,11 +1461,11 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oldPodName).NotTo(BeEmpty(), "No gateway pod found")
 
-			By("getting the gateway node ID before restart")
+			By("getting the gateway node ID before restart (from the storage cluster's GetClusterStatus)")
 			adminToken := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 			var oldNodeID string
 			getGatewayNodeID := func(g Gomega) {
-				curlCmd := fmt.Sprintf("curl -s -H 'Authorization: Bearer %s' http://%s.%s.svc.cluster.local:3903/v2/GetClusterLayout",
+				curlCmd := fmt.Sprintf("curl -s -H 'Authorization: Bearer %s' http://%s.%s.svc.cluster.local:3903/v2/GetClusterStatus",
 					adminToken, storageClusterName, testNamespace)
 				cmd := exec.Command("kubectl", "run", "curl-get-node-id", "--rm", "-i", "--restart=Never",
 					"-n", testNamespace,
@@ -1492,29 +1490,32 @@ spec:
 						}
 					}`, curlCmd))
 				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to query layout: %s", output)
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to query cluster status: %s", output)
 
-				var layout struct {
-					Roles []struct {
-						ID   string   `json:"id"`
-						Tags []string `json:"tags"`
-					} `json:"roles"`
+				var status struct {
+					Nodes []struct {
+						ID   string `json:"id"`
+						Addr string `json:"addr"`
+						IsUp bool   `json:"isUp"`
+						Role *struct {
+							Capacity *uint64 `json:"capacity"`
+						} `json:"role"`
+					} `json:"nodes"`
 				}
 				jsonStart := strings.Index(output, "{")
 				jsonEnd := strings.LastIndex(output, "}")
 				g.Expect(jsonStart).To(BeNumerically(">=", 0))
 				jsonStr := output[jsonStart : jsonEnd+1]
-				g.Expect(json.Unmarshal([]byte(jsonStr), &layout)).To(Succeed())
+				g.Expect(json.Unmarshal([]byte(jsonStr), &status)).To(Succeed())
 
-				for _, role := range layout.Roles {
-					for _, tag := range role.Tags {
-						if strings.HasPrefix(tag, gatewayClusterName) {
-							oldNodeID = role.ID
-							return
-						}
+				// Gateway shows up as a connected peer with no role assigned.
+				for _, n := range status.Nodes {
+					if n.IsUp && n.Role == nil {
+						oldNodeID = n.ID
+						return
 					}
 				}
-				g.Expect(oldNodeID).NotTo(BeEmpty(), "Gateway node not found in layout")
+				g.Expect(oldNodeID).NotTo(BeEmpty(), "Gateway node not found in cluster status: %+v", status.Nodes)
 			}
 			Eventually(getGatewayNodeID, 30*time.Second, 5*time.Second).Should(Succeed())
 
@@ -1547,7 +1548,7 @@ spec:
 
 			By("verifying the same node ID is reused after restart (identity preserved)")
 			verifyNodeIDPreserved := func(g Gomega) {
-				curlCmd := fmt.Sprintf("curl -s -H 'Authorization: Bearer %s' http://%s.%s.svc.cluster.local:3903/v2/GetClusterLayout",
+				curlCmd := fmt.Sprintf("curl -s -H 'Authorization: Bearer %s' http://%s.%s.svc.cluster.local:3903/v2/GetClusterStatus",
 					adminToken, storageClusterName, testNamespace)
 				cmd := exec.Command("kubectl", "run", "curl-check-node-id", "--rm", "-i", "--restart=Never",
 					"-n", testNamespace,
@@ -1572,45 +1573,43 @@ spec:
 						}
 					}`, curlCmd))
 				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to query layout: %s", output)
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to query cluster status: %s", output)
 
-				var layout struct {
-					Roles []struct {
-						ID   string   `json:"id"`
-						Tags []string `json:"tags"`
-					} `json:"roles"`
+				var status struct {
+					Nodes []struct {
+						ID   string `json:"id"`
+						IsUp bool   `json:"isUp"`
+						Role *struct {
+							Capacity *uint64 `json:"capacity"`
+						} `json:"role"`
+					} `json:"nodes"`
 				}
 				jsonStart := strings.Index(output, "{")
 				jsonEnd := strings.LastIndex(output, "}")
 				g.Expect(jsonStart).To(BeNumerically(">=", 0))
 				jsonStr := output[jsonStart : jsonEnd+1]
-				g.Expect(json.Unmarshal([]byte(jsonStr), &layout)).To(Succeed())
+				g.Expect(json.Unmarshal([]byte(jsonStr), &status)).To(Succeed())
 
 				var newNodeID string
-				for _, role := range layout.Roles {
-					for _, tag := range role.Tags {
-						if strings.HasPrefix(tag, gatewayClusterName) {
-							newNodeID = role.ID
-							break
-						}
+				for _, n := range status.Nodes {
+					if n.IsUp && n.Role == nil {
+						newNodeID = n.ID
+						break
 					}
 				}
 				// The node ID MUST be the same as before because the gateway
 				// StatefulSet remounts the metadata PVC and Garage reads the
-				// existing node_key from it. No tombstone, no new layout
-				// version on rolling restart.
-				g.Expect(newNodeID).NotTo(BeEmpty(), "expected the gateway node to still be in the layout after restart")
+				// existing node_key from it.
+				g.Expect(newNodeID).NotTo(BeEmpty(), "expected the gateway to be connected after restart")
 				g.Expect(newNodeID).To(Equal(oldNodeID),
 					"Node ID must be preserved across restart. Old: %s, New: %s", oldNodeID[:16], newNodeID[:16])
 			}
 			Eventually(verifyNodeIDPreserved, 3*time.Minute, 10*time.Second).Should(Succeed())
 
-			By("verifying layout contains exactly one gateway entry with the SAME ID as before")
-			// With persistent identity (v0.5.6+) the gateway re-joins under
-			// the same node_key after restart, so the layout should still
-			// contain exactly one entry for this gateway cluster — and it
-			// must be the same ID we saw before the pod was deleted. No new
-			// version, no tombstone.
+			By("verifying layout still contains zero gateway entries (gateways are not in the layout)")
+			// With v0.5.7+ gateways do not participate in the layout at all.
+			// A restart must not introduce a layout entry, and no removal
+			// should be staged either.
 			verifyLayoutClean := func(g Gomega) {
 				curlCmd := fmt.Sprintf("curl -s -H 'Authorization: Bearer %s' http://%s.%s.svc.cluster.local:3903/v2/GetClusterLayout",
 					adminToken, storageClusterName, testNamespace)
@@ -1655,25 +1654,20 @@ spec:
 				jsonStr := output[jsonStart : jsonEnd+1]
 				g.Expect(json.Unmarshal([]byte(jsonStr), &layout)).To(Succeed())
 
-				// Collect every layout entry tagged for this gateway cluster.
-				var gatewayRoles []string
+				// No layout entry should be tagged for this gateway cluster.
 				for _, role := range layout.Roles {
 					for _, tag := range role.Tags {
-						if strings.HasPrefix(tag, gatewayClusterName) {
-							gatewayRoles = append(gatewayRoles, role.ID)
-							break
-						}
+						g.Expect(strings.HasPrefix(tag, gatewayClusterName)).To(BeFalse(),
+							"Gateway-tagged role found in layout after restart. Role: %+v", role)
+						g.Expect(tag).NotTo(Equal("tier:gateway"),
+							"tier:gateway tag found in layout. Role: %+v", role)
 					}
 				}
-				g.Expect(gatewayRoles).To(HaveLen(1),
-					"Layout should have exactly one gateway entry, got %d: %v", len(gatewayRoles), gatewayRoles)
-				g.Expect(gatewayRoles[0]).To(Equal(oldNodeID),
-					"Gateway node ID must be preserved across restart (persistent identity). Old: %s, Now: %s", oldNodeID[:16], gatewayRoles[0][:16])
 
-				// No removal should be staged — there is nothing to tombstone.
+				// No staged removal either — once migrated, the layout is stable.
 				for _, change := range layout.StagedRoleChanges {
 					g.Expect(change.Remove).To(BeFalse(),
-						"Unexpected pending gateway tombstone for %s", change.ID)
+						"Unexpected pending gateway removal for %s", change.ID)
 				}
 			}
 			Eventually(verifyLayoutClean, 4*time.Minute, 10*time.Second).Should(Succeed())
@@ -1724,10 +1718,10 @@ spec:
 				jsonStr := output[jsonStart : jsonEnd+1]
 				g.Expect(json.Unmarshal([]byte(jsonStr), &layout)).To(Succeed(), "Failed to parse layout JSON: %s", jsonStr)
 
-				// We have 1 storage node + 1 gateway node = 2 roles total
-				// If there are stale nodes, there would be more
-				g.Expect(layout.Roles).To(HaveLen(2),
-					"Layout should have exactly 2 roles (1 storage + 1 gateway), got %d. Layout: %s", len(layout.Roles), output)
+				// v0.5.7+: gateway pods do not participate in the layout, so we
+				// have only the 1 storage node here.
+				g.Expect(layout.Roles).To(HaveLen(1),
+					"Layout should have exactly 1 role (storage only, gateway is not in layout), got %d. Layout: %s", len(layout.Roles), output)
 
 				// Also verify no staged changes are pending
 				g.Expect(layout.StagedRoleChanges).To(BeEmpty(),

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -812,20 +812,20 @@ spec:
 			Eventually(verifyGatewayConnected, 3*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
-		It("should register gateway as gateway node in layout", func() {
-			By("checking storage cluster layout version increased after gateway joined")
-			verifyLayoutUpdated := func(g Gomega) {
-				// The layout version should be > 1 if gateway node was added
-				// (version 1 is initial storage cluster, version 2+ means gateway was added)
+		It("should not bump storage cluster layout version when gateway joins (v0.5.7+: gateway not in layout)", func() {
+			By("checking storage cluster layout version stays at 1 (gateway joins via ConnectClusterNodes, not the layout)")
+			verifyLayoutStable := func(g Gomega) {
+				// v0.5.7+: gateway pods do not participate in the layout, so
+				// the storage cluster's layout version should remain at 1
+				// (initial storage assignment) even after the gateway joins.
 				cmd := exec.Command("kubectl", "get", "garagecluster", storageClusterName,
 					"-n", testNamespace, "-o", "jsonpath={.status.layoutVersion}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				// Layout version should be 2 or higher (gateway node added)
-				g.Expect(output).To(SatisfyAny(Equal("2"), Equal("3"), Equal("4"), Equal("5")),
-					"Layout version should be >= 2 after gateway joins, got %s", output)
+				g.Expect(output).To(Equal("1"),
+					"Storage layout version must not be bumped by gateway joining (got %s)", output)
 			}
-			Eventually(verifyLayoutUpdated, 2*time.Minute, 5*time.Second).Should(Succeed())
+			Eventually(verifyLayoutStable, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("verifying gateway cluster component label")
 			cmd := exec.Command("kubectl", "get", "statefulset", gatewayClusterName+"-gateway",


### PR DESCRIPTION
## Summary

Completes the design pivot started in #178 (v0.5.6 — persistent gateway identity via StatefulSet+PVC). Gateway pods now skip the cluster layout entirely. Garage already excluded gateway-tagged entries from `ring_assignment_data` (`src/rpc/layout/version.rs:118-134`), so layout participation was cosmetic in the single-region case — and harmful at federation scale, which is what motivated this change.

## Background — the production discovery

After #178 reset the `cluster_layout` storage on each cluster to a fresh single-version layout, FullCopy reads against a gateway pod in non-canonical regions started timing out 5-30s on `GetBucketInfo` / `GetKeyInfo`. Tracing:

1. FullCopy tables (`key`, `bucket_v2`, `bucket_alias`, `admin_token`) replicate to every node in `layout.all_nodes()` and require quorum on reads.
2. The operator only calls `ConnectClusterNodes` across regions for the storage tier (see `reconcileFederation`). Gateways in different regions never peer with each other.
3. From any one region's view, the local 4 storage pods + 2 local gateways = 6 reachable, but the 4 remote gateways in `layout.all_nodes()` are unreachable.
4. FullCopy quorum reads include those unreachable remote gateways, pushing the read to the quorum boundary and triggering the long timeout.

## Design pivot — accepted trade-off

Closed PR #177 originally proposed this same removal but was held because gateways then lose their local FullCopy cache, costing 1-2 extra admin RPCs to a storage pod per S3 GET/PUT for key+bucket lookup. Post-v0.5.6 testing made it clear the cross-region failure mode is much worse than the small per-op RPC cost. Reopening that design now, on top of #178's persistent-identity foundation.

Because identity is now persistent, this migration is genuinely one-shot: successful migration sets a condition and never re-runs.

## What's in this PR

- `assignNewNodesToLayout`: filters `tier:gateway` pods at the top — they are never added to the layout. Edge-gateway clusters (gateway-only + `connectTo`) end up with an empty `nodes` slice and stage no role in the remote cluster's layout.
- `garagecluster_gateway.go`: replaces `reconcileGatewayTombstones` with `migrateGatewayOutOfLayout` — a one-shot, idempotent removal of any pre-existing `tier:gateway` role entries. Surfaces success via the existing `GatewayTombstones` condition with status `False` and message `Migrated gateway tier out of layout (removed N entries)`.
- Migration runs against the appropriate `layoutClient` — local for unified clusters, remote for edge gateways via `connectTo` — so legacy gateway entries on the remote storage cluster's layout are also cleaned.
- `PendingGatewayTombstones` status field retained for backward compat; operator no longer writes it and clears any leftover value during migration.
- `gatewayLayoutClient` helper removed (its only caller was the deleted tombstone reconciler; `bootstrapCluster` already computes the right client).
- MIGRATION.md: new `v0.5.6 → v0.5.7` section documenting the trade-off and the one-time effect.
- `GatewaySpec` docstring updated to reflect the new design.

## Tests

New `internal/controller/gateway_out_of_layout_test.go`:
- `TestAssignNewNodesToLayout_SkipsGatewayTier` — gateway-tier pods never reach the layout; storage continues to be staged normally.
- `TestAssignNewNodesToLayout_GatewayOnlyEmptyLayout` — edge-gateway clusters stage zero `UpdateClusterLayout` against the remote storage cluster's layout.
- `TestMigrateGatewayOutOfLayout` — seeds a fake layout with mixed storage + gateway roles, runs the migration twice, asserts exactly one `UpdateClusterLayout` with Remove entries, one `ApplyClusterLayout`, condition set, deprecated field cleared, other cluster's entries untouched, second pass is a no-op.
- `TestMigrateGatewayOutOfLayout_NoLegacyEntries` — pure no-op on a clean layout.

E2E test updates in `test/e2e/e2e_test.go`:
- The previously named "should have gateway nodes with null capacity in layout" test is now "should NOT register gateway nodes in the cluster layout" — verifies absence.
- The persistent-identity restart test now queries `GetClusterStatus` (gateway shows up as a connected peer with no role) instead of the layout, and asserts gateway pods remain absent from the layout pre and post restart.
- "should have layout with only expected roles" expects 1 role (storage only) instead of 2.
- The gateway-deletion test continues to work unchanged (it already asserts 0 gateway entries post-deletion).

## Trade-off summary

| Property | Before | After |
|---|---|---|
| Cross-region FullCopy read latency | 5-30s timeouts in non-canonical regions | normal |
| Per-S3-op cost on gateway | 0 extra RPC (local FullCopy cache hit) | 1-2 admin RPCs to a storage pod |
| Layout entries per gateway pod | 1 | 0 |
| Layout drift on gateway restart | none (since #178) | none (no entry to drift) |

## Related

- #175 — tier-scoped API services + gateway readiness probe
- #177 — original gateway-out-of-layout PR (closed, reopened here on the v0.5.6 foundation)
- #178 — persistent gateway identity (StatefulSet + metadata PVC)

## Test plan

- [x] `go build ./...` clean
- [x] `make test` green (unit + envtest)
- [x] `make lint` 0 issues
- [x] `make manifests` produces no CRD / schema / chart drift
- [x] New unit tests pass: `TestAssignNewNodesToLayout_*`, `TestMigrateGatewayOutOfLayout*`
- [ ] CI e2e green