### PR TITLE
fix(controller): per-pod cross-region gateway peering

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -37,6 +37,57 @@ spec:
       storageClassName: fast-ssd
 ```
 
+### Federated clusters: per-pod gateway endpoints (v0.5.9+)
+
+Because gateways are in the layout, FullReplication tables (key_table,
+bucket_table, …) need write/read quorum across `layout.all_nodes()` — which
+includes gateway pods in every region. The storage-tier cross-region connect
+loop alone is not enough: it uses one shared admin hostname for every remote
+node, so a multi-pod gateway tier behind a single Tailscale/LB hostname only
+ever lands one of N pods.
+
+For each remote cluster in `spec.remoteClusters`, set
+`connection.gatewayRpcEndpointTemplate` to a per-ordinal hostname pattern.
+The operator iterates remote gateway nodes in the layout, parses each pod's
+ordinal from its tag (e.g. `garage-gateway-0`), substitutes `{ordinal}` into
+the template, and calls `ConnectClusterNodes` per pod.
+
+```yaml
+spec:
+  remoteClusters:
+    - name: ottawa
+      zone: ottawa
+      connection:
+        adminApiEndpoint: "http://ottawa-garage.keiretsu.ts.net:3903"
+        gatewayRpcEndpointTemplate: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+```
+
+Provision the per-pod hostnames at the same time — typically one
+`LoadBalancer` Service per gateway pod whose selector pins to
+`statefulset.kubernetes.io/pod-name: <cr>-gateway-<ordinal>`. With the
+Tailscale operator that looks like:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-gateway-0-ts
+  annotations:
+    tailscale.com/hostname: ottawa-garage-gw-0
+spec:
+  loadBalancerClass: tailscale
+  selector:
+    statefulset.kubernetes.io/pod-name: garage-gateway-0
+  ports:
+    - name: rpc
+      port: 3901
+```
+
+Without the template, federation works for storage but cross-region
+FullReplication operations involving the gateway tier (e.g. cluster-wide
+key creation, GetKeyInfo on `allBuckets: true` keys, DeleteKey) can hit
+quorum timeouts.
+
 ## TL;DR for existing v1beta1 users
 
 **You do not need to migrate anything.** Existing v1beta1 GarageCluster

--- a/api/v1beta1/garagecluster_types.go
+++ b/api/v1beta1/garagecluster_types.go
@@ -1062,6 +1062,13 @@ type RemoteClusterConnection struct {
 	// If not specified, uses the local cluster's admin token (for shared-token setups)
 	// +optional
 	AdminTokenSecretRef *corev1.SecretKeySelector `json:"adminTokenSecretRef,omitempty"`
+
+	// GatewayRPCEndpointTemplate is a hostname:port template used by federation
+	// to connect to remote gateway pods individually. The literal `{ordinal}`
+	// is replaced with each remote gateway pod's ordinal (0, 1, ...).
+	// Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+	// +optional
+	GatewayRPCEndpointTemplate string `json:"gatewayRpcEndpointTemplate,omitempty"`
 }
 
 // ConnectToConfig specifies how a gateway cluster connects to a storage cluster.

--- a/api/v1beta2/garagecluster_types.go
+++ b/api/v1beta2/garagecluster_types.go
@@ -966,6 +966,23 @@ type RemoteClusterConnection struct {
 	// AdminTokenSecretRef references the admin token for the remote cluster's API.
 	// +optional
 	AdminTokenSecretRef *corev1.SecretKeySelector `json:"adminTokenSecretRef,omitempty"`
+
+	// GatewayRPCEndpointTemplate is a hostname:port template used by federation
+	// to connect to remote gateway pods individually. The literal `{ordinal}`
+	// is replaced with each remote gateway pod's ordinal (0, 1, ...) parsed
+	// from the layout role's pod-name tag (e.g. `garage-gateway-0`).
+	//
+	// Required when the remote cluster runs gateway pods that participate in
+	// the cluster layout (default since v0.5.8). FullReplication tables
+	// (key_table, bucket_table, ...) need quorum across all_nodes, which
+	// includes remote gateways. Without this field the operator only peers
+	// storage↔storage cross-region; remote gateways appear in layout but
+	// remain unreachable, blocking GetKeyInfo / DeleteKey / FullReplication
+	// writes that need full quorum.
+	//
+	// Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+	// +optional
+	GatewayRPCEndpointTemplate string `json:"gatewayRpcEndpointTemplate,omitempty"`
 }
 
 // ConnectToConfig specifies how a gateway cluster connects to a remote storage cluster.

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -2085,6 +2085,13 @@ spec:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        gatewayRpcEndpointTemplate:
+                          description: |-
+                            GatewayRPCEndpointTemplate is a hostname:port template used by federation
+                            to connect to remote gateway pods individually. The literal `{ordinal}`
+                            is replaced with each remote gateway pod's ordinal (0, 1, ...).
+                            Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+                          type: string
                       required:
                       - adminApiEndpoint
                       type: object
@@ -7004,9 +7011,8 @@ spec:
                     default: 2
                     description: |-
                       Replicas is the number of gateway pods to deploy. Set to 0 to keep the
-                      gateway tier declared but stop all pods; the operator still tombstone-
-                      cleans any lingering gateway layout entries when the statefulset is
-                      scaled down.
+                      gateway tier declared but stop all pods; the operator scales the
+                      statefulset down and removes vacated entries from the layout.
                     format: int32
                     minimum: 0
                     type: integer
@@ -7857,6 +7863,23 @@ spec:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        gatewayRpcEndpointTemplate:
+                          description: |-
+                            GatewayRPCEndpointTemplate is a hostname:port template used by federation
+                            to connect to remote gateway pods individually. The literal `{ordinal}`
+                            is replaced with each remote gateway pod's ordinal (0, 1, ...) parsed
+                            from the layout role's pod-name tag (e.g. `garage-gateway-0`).
+
+                            Required when the remote cluster runs gateway pods that participate in
+                            the cluster layout (default since v0.5.8). FullReplication tables
+                            (key_table, bucket_table, ...) need quorum across all_nodes, which
+                            includes remote gateways. Without this field the operator only peers
+                            storage↔storage cross-region; remote gateways appear in layout but
+                            remain unreachable, blocking GetKeyInfo / DeleteKey / FullReplication
+                            writes that need full quorum.
+
+                            Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+                          type: string
                       required:
                       - adminApiEndpoint
                       type: object

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -2085,6 +2085,13 @@ spec:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        gatewayRpcEndpointTemplate:
+                          description: |-
+                            GatewayRPCEndpointTemplate is a hostname:port template used by federation
+                            to connect to remote gateway pods individually. The literal `{ordinal}`
+                            is replaced with each remote gateway pod's ordinal (0, 1, ...).
+                            Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+                          type: string
                       required:
                       - adminApiEndpoint
                       type: object
@@ -7004,9 +7011,8 @@ spec:
                     default: 2
                     description: |-
                       Replicas is the number of gateway pods to deploy. Set to 0 to keep the
-                      gateway tier declared but stop all pods; the operator still tombstone-
-                      cleans any lingering gateway layout entries when the statefulset is
-                      scaled down.
+                      gateway tier declared but stop all pods; the operator scales the
+                      statefulset down and removes vacated entries from the layout.
                     format: int32
                     minimum: 0
                     type: integer
@@ -7857,6 +7863,23 @@ spec:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        gatewayRpcEndpointTemplate:
+                          description: |-
+                            GatewayRPCEndpointTemplate is a hostname:port template used by federation
+                            to connect to remote gateway pods individually. The literal `{ordinal}`
+                            is replaced with each remote gateway pod's ordinal (0, 1, ...) parsed
+                            from the layout role's pod-name tag (e.g. `garage-gateway-0`).
+
+                            Required when the remote cluster runs gateway pods that participate in
+                            the cluster layout (default since v0.5.8). FullReplication tables
+                            (key_table, bucket_table, ...) need quorum across all_nodes, which
+                            includes remote gateways. Without this field the operator only peers
+                            storage↔storage cross-region; remote gateways appear in layout but
+                            remain unreachable, blocking GetKeyInfo / DeleteKey / FullReplication
+                            writes that need full quorum.
+
+                            Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+                          type: string
                       required:
                       - adminApiEndpoint
                       type: object

--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -48,6 +48,8 @@ const (
 	testZoneRemote          = "zone-remote"
 	testTagLocal            = "local"
 	testTagRemoteCluster    = "remote-cluster"
+	testGatewayOwnershipTag = "cluster:garage/garage"
+	testTierGatewayTag      = "tier:gateway"
 )
 
 // newMockGarageServer creates a mock Garage Admin API server with configurable
@@ -747,5 +749,151 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 			ids := []string{updatedRoles[0].ID, updatedRoles[1].ID}
 			Expect(ids).To(ContainElements("fedcba9876543210fedcba98fromapi1", "fedcba9876543210fedcba98fromapi2"))
 		})
+	})
+})
+
+var _ = Describe("Federation - connectRemoteGatewayPods", func() {
+	const adminToken = "test-admin-token-value"
+	var reconciler *GarageClusterReconciler
+
+	BeforeEach(func() {
+		reconciler = &GarageClusterReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	})
+
+	It("dials each remote gateway pod via the per-ordinal template", func() {
+		type connectCall struct {
+			id, addr string
+		}
+		var calls []connectCall
+
+		handler := &garageHandler{
+			statusResp: func() (int, any) {
+				return http.StatusOK, garage.ClusterStatus{}
+			},
+			healthResp: func() (int, any) {
+				return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
+			},
+		}
+		// Custom handler captures the body to inspect per-call addresses.
+		mux := http.NewServeMux()
+		mux.HandleFunc(pathConnectNodes, func(w http.ResponseWriter, r *http.Request) {
+			var body []string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, peer := range body {
+				at := -1
+				for i := 0; i < len(peer); i++ {
+					if peer[i] == '@' {
+						at = i
+						break
+					}
+				}
+				if at > 0 {
+					calls = append(calls, connectCall{id: peer[:at], addr: peer[at+1:]})
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]garage.ConnectNodeResult{{Success: true}})
+		})
+		mux.HandleFunc(pathGetClusterStatus, func(w http.ResponseWriter, r *http.Request) {
+			code, body := handler.statusResp()
+			w.WriteHeader(code)
+			_ = json.NewEncoder(w).Encode(body)
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		localClient := garage.NewClient(server.URL, adminToken)
+
+		// localStatus describes 2 remote gateway pods in zone-remote — one up
+		// (should be skipped), one down (should be connected).
+		localStatus := &garage.ClusterStatus{
+			Nodes: []garage.NodeInfo{
+				{
+					ID:   "1111111111111111aaaaaaaaaaaaaaaa1111111111111111aaaaaaaaaaaaaaab",
+					IsUp: true,
+					Role: &garage.NodeAssignedRole{
+						Zone: testZoneRemote,
+						Tags: []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-0"},
+					},
+				},
+				{
+					ID:   "2222222222222222bbbbbbbbbbbbbbbb2222222222222222bbbbbbbbbbbbbbbb",
+					IsUp: false,
+					Role: &garage.NodeAssignedRole{
+						Zone: testZoneRemote,
+						Tags: []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-1"},
+					},
+				},
+				// Storage node in same zone — must be ignored by gateway loop
+				{
+					ID:   "3333333333333333cccccccccccccccc3333333333333333cccccccccccccccc",
+					IsUp: false,
+					Role: &garage.NodeAssignedRole{
+						Zone: testZoneRemote,
+						Tags: []string{testGatewayOwnershipTag, "tier:storage", "garage-0"},
+					},
+				},
+			},
+		}
+
+		remote := garagev1beta2.RemoteClusterConfig{
+			Name: testTagRemoteCluster,
+			Zone: testZoneRemote,
+			Connection: garagev1beta2.RemoteClusterConnection{
+				AdminAPIEndpoint:           server.URL,
+				GatewayRPCEndpointTemplate: "remote-gw-{ordinal}.example.com:3901",
+			},
+		}
+
+		reconciler.connectRemoteGatewayPods(ctx, localClient, localStatus, remote, remote.Connection.GatewayRPCEndpointTemplate)
+
+		// Only the down gateway pod (ordinal 1) should have triggered a ConnectNode.
+		Expect(calls).To(HaveLen(1))
+		Expect(calls[0].id).To(Equal("2222222222222222bbbbbbbbbbbbbbbb2222222222222222bbbbbbbbbbbbbbbb"))
+		Expect(calls[0].addr).To(Equal("remote-gw-1.example.com:3901"))
+	})
+
+	It("is a no-op when GatewayRPCEndpointTemplate is empty", func() {
+		var connectCalls atomic.Int32
+		handler := &garageHandler{
+			statusResp: func() (int, any) {
+				return http.StatusOK, garage.ClusterStatus{}
+			},
+			healthResp: func() (int, any) {
+				return http.StatusOK, garage.ClusterHealth{Status: healthStatusHealthy}
+			},
+			connectResp: func() (int, any) {
+				connectCalls.Add(1)
+				return http.StatusOK, []garage.ConnectNodeResult{{Success: true}}
+			},
+		}
+		server := newMockGarageServer(handler)
+		defer server.Close()
+
+		localClient := garage.NewClient(server.URL, adminToken)
+		localStatus := &garage.ClusterStatus{
+			Nodes: []garage.NodeInfo{
+				{
+					ID:   "4444444444444444dddddddddddddddd4444444444444444dddddddddddddddd",
+					IsUp: false,
+					Role: &garage.NodeAssignedRole{
+						Zone: testZoneRemote,
+						Tags: []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-0"},
+					},
+				},
+			},
+		}
+		remote := garagev1beta2.RemoteClusterConfig{
+			Name:       testTagRemoteCluster,
+			Zone:       testZoneRemote,
+			Connection: garagev1beta2.RemoteClusterConnection{AdminAPIEndpoint: server.URL},
+		}
+
+		reconciler.connectRemoteGatewayPods(ctx, localClient, localStatus, remote, remote.Connection.GatewayRPCEndpointTemplate)
+
+		Expect(connectCalls.Load()).To(Equal(int32(0)))
 	})
 })

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -64,6 +64,10 @@ const (
 	// Health status constants
 	healthStatusHealthy  = "healthy"
 	healthStatusDegraded = "degraded"
+
+	// connectErrUnknown is the fallback message when ConnectClusterNodes
+	// returns Success=false without an explicit error string.
+	connectErrUnknown = "unknown"
 )
 
 // GarageClusterReconciler reconciles a GarageCluster object
@@ -4136,7 +4140,7 @@ func (r *GarageClusterReconciler) connectToRemoteCluster(
 				connectedCount++
 				log.V(1).Info("Connected to remote node", "nodeID", node.ID[:16]+"...", "addr", addr)
 			} else {
-				errMsg := "unknown"
+				errMsg := connectErrUnknown
 				if result.Error != nil {
 					errMsg = *result.Error
 				}
@@ -4148,6 +4152,21 @@ func (r *GarageClusterReconciler) connectToRemoteCluster(
 		}
 	} else {
 		log.V(1).Info("All remote nodes already up, skipping connect", "cluster", remote.Name)
+	}
+
+	// Per-pod cross-region gateway peering. The storage-tier connect loop above
+	// uses ONE shared remote hostname (admin endpoint host) for every node,
+	// which means a Tailscale-fronted multi-pod gateway tier only ever lands
+	// one of N pods. Without all gateway pods being reachable, FullReplication
+	// quorum reads/writes for key_table / bucket_table / admin_token_table
+	// time out and operations like GetKeyInfo, DeleteKey, and cluster-wide
+	// key resync fail.
+	//
+	// Requires remote.Connection.GatewayRPCEndpointTemplate to be set; the
+	// template substitutes {ordinal} with each remote gateway pod's ordinal
+	// parsed from its pod-name layout tag (e.g. "garage-gateway-0").
+	if tmpl := remote.Connection.GatewayRPCEndpointTemplate; tmpl != "" {
+		r.connectRemoteGatewayPods(ctx, localClient, localStatus, remote, tmpl)
 	}
 
 	// Add remote nodes to local layout for data replication (best-effort with timeout)
@@ -4163,6 +4182,80 @@ func (r *GarageClusterReconciler) connectToRemoteCluster(
 	}
 
 	return nil
+}
+
+// connectRemoteGatewayPods peers the local cluster with each gateway pod in a
+// remote region. The storage-tier connect loop only reaches one pod per
+// Tailscale-fronted remote (because they share an admin hostname); this loop
+// uses GatewayRPCEndpointTemplate to dial each remote gateway pod by its
+// ordinal-stable external address.
+//
+// Iterates layout roles tagged tier:gateway in the remote zone, parses the
+// ordinal from the pod-name tag, substitutes it into the template, and
+// calls ConnectClusterNodes. Best-effort; errors are logged and skipped.
+func (r *GarageClusterReconciler) connectRemoteGatewayPods(
+	ctx context.Context,
+	localClient *garage.Client,
+	localStatus *garage.ClusterStatus,
+	remote garagev1beta2.RemoteClusterConfig,
+	template string,
+) {
+	if template == "" {
+		return
+	}
+	log := logf.FromContext(ctx)
+	if !strings.Contains(template, "{ordinal}") {
+		log.Info("gatewayRpcEndpointTemplate missing {ordinal} placeholder — all remote gateway pods will share the same address",
+			"remote", remote.Name, "template", template)
+	}
+
+	for _, node := range localStatus.Nodes {
+		if node.Role == nil || node.Role.Zone != remote.Zone {
+			continue
+		}
+		isGateway := false
+		var podName string
+		for _, tag := range node.Role.Tags {
+			if tag == "tier:"+tierGateway {
+				isGateway = true
+			}
+			if strings.HasPrefix(tag, "garage-gateway-") {
+				podName = tag
+			}
+		}
+		if !isGateway || podName == "" {
+			continue
+		}
+		if node.IsUp {
+			continue
+		}
+		ordinalStr := strings.TrimPrefix(podName, "garage-gateway-")
+		if _, err := strconv.Atoi(ordinalStr); err != nil {
+			log.V(1).Info("Skipping remote gateway with non-numeric ordinal", "podName", podName)
+			continue
+		}
+		addr := strings.ReplaceAll(template, "{ordinal}", ordinalStr)
+
+		connectCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		result, err := localClient.ConnectNode(connectCtx, node.ID, addr)
+		cancel()
+		if err != nil {
+			log.V(1).Info("Failed to connect remote gateway pod",
+				"nodeID", node.ID[:16]+"...", "addr", addr, "error", err)
+			continue
+		}
+		if !result.Success {
+			errMsg := connectErrUnknown
+			if result.Error != nil {
+				errMsg = *result.Error
+			}
+			log.V(1).Info("ConnectNode returned failure for remote gateway pod",
+				"nodeID", node.ID[:16]+"...", "addr", addr, "error", errMsg)
+			continue
+		}
+		log.Info("Connected to remote gateway pod",
+			"nodeID", node.ID[:16]+"...", "addr", addr, "podName", podName)
+	}
 }
 
 // addRemoteNodesToLayout adds remote cluster nodes to the local cluster's layout.
@@ -4794,7 +4887,7 @@ func (r *GarageClusterReconciler) handleConnectNodes(ctx context.Context, cluste
 		if result.Success {
 			log.Info("Successfully connected to external node", "nodeID", nodeID[:16]+"...", "addr", addr)
 		} else {
-			errMsg := "unknown"
+			errMsg := connectErrUnknown
 			if result.Error != nil {
 				errMsg = *result.Error
 			}

--- a/schemas/garagecluster_v1beta1.json
+++ b/schemas/garagecluster_v1beta1.json
@@ -1870,6 +1870,10 @@
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
+                  },
+                  "gatewayRpcEndpointTemplate": {
+                    "description": "GatewayRPCEndpointTemplate is a hostname:port template used by federation\nto connect to remote gateway pods individually. The literal `{ordinal}`\nis replaced with each remote gateway pod's ordinal (0, 1, ...).\nExample: \"ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901\"",
+                    "type": "string"
                   }
                 },
                 "required": [

--- a/schemas/garagecluster_v1beta2.json
+++ b/schemas/garagecluster_v1beta2.json
@@ -2023,7 +2023,7 @@
             },
             "replicas": {
               "default": 2,
-              "description": "Replicas is the number of gateway pods to deploy. Set to 0 to keep the\ngateway tier declared but stop all pods; the operator still tombstone-\ncleans any lingering gateway layout entries when the statefulset is\nscaled down.",
+              "description": "Replicas is the number of gateway pods to deploy. Set to 0 to keep the\ngateway tier declared but stop all pods; the operator scales the\nstatefulset down and removes vacated entries from the layout.",
               "format": "int32",
               "minimum": 0,
               "type": "integer"
@@ -2765,6 +2765,10 @@
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
+                  },
+                  "gatewayRpcEndpointTemplate": {
+                    "description": "GatewayRPCEndpointTemplate is a hostname:port template used by federation\nto connect to remote gateway pods individually. The literal `{ordinal}`\nis replaced with each remote gateway pod's ordinal (0, 1, ...) parsed\nfrom the layout role's pod-name tag (e.g. `garage-gateway-0`).\n\nRequired when the remote cluster runs gateway pods that participate in\nthe cluster layout (default since v0.5.8). FullReplication tables\n(key_table, bucket_table, ...) need quorum across all_nodes, which\nincludes remote gateways. Without this field the operator only peers\nstorage\u2194storage cross-region; remote gateways appear in layout but\nremain unreachable, blocking GetKeyInfo / DeleteKey / FullReplication\nwrites that need full quorum.\n\nExample: \"ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901\"",
+                    "type": "string"
                   }
                 },
                 "required": [


### PR DESCRIPTION
## Summary

Two coupled fixes:

1. **Federation now peers remote gateway pods individually.** Adds `RemoteClusterConnection.gatewayRpcEndpointTemplate`. The operator iterates remote-zone layout roles tagged `tier:gateway`, parses the ordinal from each pod's name tag (`garage-gateway-0`, `garage-gateway-1`, …), substitutes `{ordinal}` into the template, and ConnectsClusterNodes per pod.

2. **Remove `v1alpha1` from GarageCluster CRD `spec.versions`** — fixes #181.

## Why (1)

The existing `connectToRemoteCluster` uses one shared admin hostname for every remote node. With a gateway tier of N≥2 pods behind a single Tailscale-fronted hostname, only one of N gateway pods is ever reached. The others sit in `layout.all_nodes()` as "Not connected", which:

- Breaks `GetKeyInfo` / `DeleteKey` on clusterwide keys (the operator hits a 90s client timeout because Garage waits for quorum from unreachable gateways).
- Surfaces as `Could not reach quorum of 6 (sets=Some(3)). 1 of 10 request succeeded` 503s when the operator's `GarageKey` finalizer calls `DeleteKey`.
- Pins block resync persistent errors high (cross-region writes failing the FullReplication ack).

S3 sig-auth (the `key_table.get_local()` path fixed in v0.5.8) is unaffected — only operations requiring FullReplication quorum across `all_nodes` break.

Empty template ⇒ no-op (back-compat for clusters that haven't set the field yet).

## Why (2) — fixes #181

`v0.5.8` shipped a `served=false, storage=false` stub for v1alpha1 in the GarageCluster CRD, but the operator's runtime scheme no longer registers v1alpha1. With the conversion webhook configured, the API server endlessly calls the webhook for v1alpha1 conversion and logs ~3 errors/sec.

GarageCluster never had v1alpha1 as a stored version, so removing the stub is safe. The other CRDs (garagebucket, garagekey, garagenode, garageadmintoken) keep their v1alpha1 stub — they don't have conversion webhooks and the stub is inert.

## Test plan

- [x] `go test ./...`
- [x] `golangci-lint run` — 0 issues
- [x] New ginkgo cases: dials each remote gateway pod via the template, no-op when template empty
- [ ] Deploy v0.5.9; verify no v1alpha1 conversion webhook errors in operator log
- [ ] Set `gatewayRpcEndpointTemplate` in `kubernetes-manifests` GarageCluster CR + add per-pod Tailscale LB Services
- [ ] Verify all 6 gateway pods (2/region × 3) show `isUp=true` in every region's `GetClusterStatus`
- [ ] Verify `kubectl delete garagekey ...` no longer 503s; cluster-wide GarageKey operations no longer time out
- [ ] Watch block resync `persistentErrors` trend toward 0