### PR TITLE
fix(helm): prevent servicemonitor from scraping webhook service

### DIFF
--- a/charts/garage-operator/templates/service.yaml
+++ b/charts/garage-operator/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "garage-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:

--- a/charts/garage-operator/templates/servicemonitor.yaml
+++ b/charts/garage-operator/templates/servicemonitor.yaml
@@ -31,4 +31,5 @@ spec:
   selector:
     matchLabels:
       {{- include "garage-operator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
 {{- end }}


### PR DESCRIPTION
After introduction of webhooks and new `Service` object, `ServiceMonitor` picks up both of them because they are using the same `include "garage-operator.labels"` helper.

This causes Prometheus to also try scraping the webhook port (which also has `http` port), causing `up` metric returning 0.

Added additional  `app.kubernetes.io/component: metrics` label to metrics service and `ServiceMonitor` selector to ensure that only metrics service is selected.

If its preferred to use different labels, or different separation method let me know.