### PR TITLE
refactor(controller): Set GARAGE_CONFIG_FILE

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -65,6 +65,13 @@ const (
 	// learn its own externally-routable host (set from the pod IP via downward API).
 	envGarageNodeHost = "GARAGE_NODE_HOST"
 
+	// Garage, by default looks for a config file at /etc/garage.toml
+	// Exposing the config map there is not possible without a subPath mount, meaning
+	// changes to the configmap would not be propagated to existing pods.
+	// So we use a different path and set the appropriate env var instead
+	envGarageConfigFile      = "GARAGE_CONFIG_FILE"
+	garageConfigFileLocation = configMountPath + "/" + configFileName
+
 	// Health status constants
 	healthStatusHealthy  = "healthy"
 	healthStatusDegraded = "degraded"
@@ -673,7 +680,7 @@ func (r *GarageClusterReconciler) writeConfigMap(ctx context.Context, cluster *g
 			Namespace: cluster.Namespace,
 			Labels:    r.labelsForCluster(cluster),
 		},
-		Data: map[string]string{"garage.toml": body},
+		Data: map[string]string{configFileName: body},
 	}
 	if err := controllerutil.SetControllerReference(cluster, cm, r.Scheme); err != nil {
 		return "", err

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -1309,7 +1309,7 @@ func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node 
 			Name:      node.Name + "-config",
 			Namespace: cluster.Namespace,
 		},
-		Data: map[string]string{"garage.toml": nodeConfig},
+		Data: map[string]string{configFileName: nodeConfig},
 	}
 	if err := controllerutil.SetControllerReference(node, cm, r.Scheme); err != nil {
 		return err

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -120,6 +120,7 @@ const (
 	dataPath             = "/data/data"
 	metadataPath         = "/data/metadata"
 	configMountPath      = "/etc/garage"
+	configFileName       = "garage.toml"
 	rpcSecretMountPath   = "/secrets/rpc"
 	adminSecretMountPath = "/secrets/admin"
 	adminTokenVolume     = "admin-token"
@@ -542,6 +543,9 @@ func buildGaragePodSpec(
 	env := []corev1.EnvVar{{
 		Name:      envGarageNodeHost,
 		ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}},
+	}, {
+		Name:  envGarageConfigFile,
+		Value: garageConfigFileLocation,
 	}}
 	if l := cfg.Logging; l != nil {
 		if l.Level != "" {
@@ -564,7 +568,7 @@ func buildGaragePodSpec(
 		Name:            defaultAppName,
 		Image:           cfg.Image,
 		ImagePullPolicy: cfg.ImagePullPolicy,
-		Command:         []string{"/garage", "-c", "/etc/garage/garage.toml", "server"},
+		Command:         []string{"/garage", "server"},
 		Ports:           containerPorts,
 		VolumeMounts:    volumeMounts,
 		Env:             env,


### PR DESCRIPTION
After a day of playing around, I found it a bit tedious to have to specify the config file location for `garage` commands. 

I discovered that Garage also offers an env-override for the config file location. So with this change, one can kubectl exec sts/my-garage-node -- /garage <command> without having to specify -c /etc/garage/garage.toml. 

There is no more need to include -c /etc/garage/garage.toml in the container command either. 

Cheers!