### PR TITLE
fix(finalize): pre-revoke bucket grants and surface stuck buckets

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -91,6 +91,14 @@ const (
 
 	// ConditionAliasesConfigured indicates bucket aliases have been configured
 	ConditionAliasesConfigured = "AliasesConfigured"
+
+	// ConditionBucketLookupStuck indicates the Garage admin API has timed out
+	// repeatedly when reading this bucket's info. Almost always caused by a
+	// stale entry in the bucket's authorized_keys whose RPC lookup never
+	// completes (upstream netapp::try_connect has no TCP timeout). Recover by
+	// triggering RepairType=Aliases on the parent GarageCluster via the
+	// garage.rajsingh.info/trigger-repair annotation.
+	ConditionBucketLookupStuck = "BucketLookupStuck"
 )
 
 // GarageKey condition types
@@ -199,6 +207,12 @@ const (
 	// ReasonGatewayTombstonesPending indicates stale gateway layout entries are
 	// queued but not auto-applied (layoutManagement.autoApply is false).
 	ReasonGatewayTombstonesPending = "PendingRemoval"
+
+	// ReasonBucketLookupStuck indicates GetBucketInfo has timed out N
+	// consecutive times for this bucket. Surfaced via the
+	// ConditionBucketLookupStuck condition; manual recovery is to trigger
+	// RepairType=Aliases on the parent GarageCluster.
+	ReasonBucketLookupStuck = "AdminAPITimeout"
 )
 
 // Annotation keys for operational tasks
@@ -239,6 +253,13 @@ const (
 
 	// AnnotationCleanupMPUOlderThan specifies the age threshold for MPU cleanup (e.g., "24h", "7d")
 	AnnotationCleanupMPUOlderThan = AnnotationPrefix + "cleanup-mpu-older-than"
+
+	// AnnotationBucketLookupTimeouts tracks consecutive GetBucketInfo timeouts
+	// on this bucket. Incremented on each timeout, cleared on first success.
+	// At BucketLookupStuckThreshold (3), the operator sets the
+	// ConditionBucketLookupStuck status condition. Internal use only — users
+	// should not set this directly.
+	AnnotationBucketLookupTimeouts = AnnotationPrefix + "bucket-lookup-timeouts"
 
 	// GarageCluster repair/maintenance annotations
 

--- a/api/v1beta2/garagecluster_unmarshal.go
+++ b/api/v1beta2/garagecluster_unmarshal.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1beta2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// UnmarshalJSON tolerates pre-#190 v1beta1 storage where `spec.gateway` is a
+// bool rather than the v1beta2 GatewaySpec struct. The API server is supposed
+// to convert this on read via the conversion webhook, but if the webhook
+// Service is misconfigured (cert mismatch, replica=0, endpoints stale) the
+// API server may return the raw v1beta1-encoded bytes and the controller
+// cache's strict decoder fails the entire LIST with `json: cannot unmarshal
+// bool into Go struct field GarageClusterSpec.items.spec.gateway` — fixes #195.
+//
+// Behavior:
+//
+//   - `gateway: true`   → `&GatewaySpec{}` (presence-only; the controller
+//     reads `cluster.Spec.Replicas` from the v1beta1 endpoint for legacy
+//     replica counts, but anything reading via v1beta2 won't have replicas
+//     because they're not on this type — that's by design, the proper fix
+//     is a storage-version migration sweep)
+//   - `gateway: false`  → nil
+//   - `gateway: {...}`  → standard struct decode
+//   - omitted           → nil
+func (s *GarageClusterSpec) UnmarshalJSON(data []byte) error {
+	type alias GarageClusterSpec
+	aux := struct {
+		Gateway json.RawMessage `json:"gateway,omitempty"`
+		*alias
+	}{alias: (*alias)(s)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	raw := bytes.TrimSpace(aux.Gateway)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		s.Gateway = nil
+		return nil
+	}
+	if bytes.Equal(raw, []byte("true")) {
+		s.Gateway = &GatewaySpec{}
+		return nil
+	}
+	if bytes.Equal(raw, []byte("false")) {
+		s.Gateway = nil
+		return nil
+	}
+	var g GatewaySpec
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return err
+	}
+	s.Gateway = &g
+	return nil
+}

--- a/api/v1beta2/garagecluster_unmarshal_test.go
+++ b/api/v1beta2/garagecluster_unmarshal_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1beta2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestGarageClusterSpec_UnmarshalJSON_GatewayBool guards #195: when stored
+// bytes still carry the v1beta1 bool form (because a misconfigured conversion
+// webhook didn't rewrite them), the decoder must accept it instead of
+// blowing up the entire LIST.
+func TestGarageClusterSpec_UnmarshalJSON_GatewayBool(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		wantNN bool // wantNonNil — was *GatewaySpec populated
+	}{
+		{name: "bool true (legacy v1beta1 stored bytes)", input: `{"gateway":true}`, wantNN: true},
+		{name: "bool false (legacy v1beta1 stored bytes)", input: `{"gateway":false}`, wantNN: false},
+		{name: "null", input: `{"gateway":null}`, wantNN: false},
+		{name: "omitted", input: `{}`, wantNN: false},
+		{name: "empty struct (v1beta2)", input: `{"gateway":{}}`, wantNN: true},
+		{name: "populated struct (v1beta2)", input: `{"gateway":{"replicas":3}}`, wantNN: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s GarageClusterSpec
+			if err := json.Unmarshal([]byte(tc.input), &s); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := s.Gateway != nil; got != tc.wantNN {
+				t.Fatalf("gateway non-nil: got=%v want=%v (input=%q)", got, tc.wantNN, tc.input)
+			}
+		})
+	}
+}
+
+func TestGarageClusterSpec_UnmarshalJSON_PreservesOtherFields(t *testing.T) {
+	// Sanity: the custom UnmarshalJSON shadows the gateway field via the
+	// embedded alias trick; verify other fields still round-trip normally.
+	in := `{"zone":"us-east-1","gateway":true}`
+	var s GarageClusterSpec
+	if err := json.Unmarshal([]byte(in), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.Zone != "us-east-1" {
+		t.Fatalf("zone: got=%q want=us-east-1", s.Zone)
+	}
+	if s.Gateway == nil {
+		t.Fatal("gateway: nil, want non-nil for legacy bool true")
+	}
+}
+
+func TestGarageClusterSpec_UnmarshalJSON_GatewayStructPopulated(t *testing.T) {
+	// Replicas inside the struct must round-trip; this is the normal v1beta2
+	// case and must not regress.
+	in := `{"gateway":{"replicas":5,"rpcPublicAddr":"a:1"}}`
+	var s GarageClusterSpec
+	if err := json.Unmarshal([]byte(in), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.Gateway == nil || s.Gateway.Replicas != 5 || s.Gateway.RPCPublicAddr != "a:1" {
+		t.Fatalf("gateway: got=%+v", s.Gateway)
+	}
+}

--- a/hack/e2e-cluster.sh
+++ b/hack/e2e-cluster.sh
@@ -2567,7 +2567,7 @@ EOF
     fi
 
     # Wait for pod to be running
-    if wait_for_pods_ready "app.kubernetes.io/name=garagenode,app.kubernetes.io/instance=manual-node-1" 1 120; then
+    if wait_for_pods_ready "garage.rajsingh.info/node=manual-node-1" 1 120; then
         test_pass "GarageNode pod is running"
     else
         test_fail "GarageNode pod did not become ready"
@@ -2616,7 +2616,7 @@ EOF
     fi
 
     # Wait for pod to be running
-    if wait_for_pods_ready "app.kubernetes.io/name=garagenode,app.kubernetes.io/instance=manual-node-2" 1 120; then
+    if wait_for_pods_ready "garage.rajsingh.info/node=manual-node-2" 1 120; then
         test_pass "Second GarageNode pod is running"
     else
         test_fail "Second GarageNode pod did not become ready"

--- a/hack/e2e-multicluster.sh
+++ b/hack/e2e-multicluster.sh
@@ -1792,10 +1792,10 @@ test_manual_mode_garagenodes_creation() {
 
     # Verify StatefulSets are created for each node
     use_cluster "$CLUSTER1_NAME"
-    local c1_sts_count=$(kubectl get statefulset -n "$NAMESPACE" -l "app.kubernetes.io/name=garagenode" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    local c1_sts_count=$(kubectl get statefulset -n "$NAMESPACE" -l "garage.rajsingh.info/node" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 
     use_cluster "$CLUSTER2_NAME"
-    local c2_sts_count=$(kubectl get statefulset -n "$NAMESPACE" -l "app.kubernetes.io/name=garagenode" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    local c2_sts_count=$(kubectl get statefulset -n "$NAMESPACE" -l "garage.rajsingh.info/node" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 
     if [ "$c1_sts_count" -ge 2 ] && [ "$c2_sts_count" -ge 2 ]; then
         test_pass "GarageNodes created StatefulSets (c1: $c1_sts_count, c2: $c2_sts_count)"
@@ -1811,14 +1811,14 @@ test_manual_mode_pods_running() {
 
     # Wait for pods in cluster 1
     use_cluster "$CLUSTER1_NAME"
-    if ! wait_for_pods_ready "app.kubernetes.io/name=garagenode" 2 180; then
+    if ! wait_for_pods_ready "garage.rajsingh.info/node" 2 180; then
         test_fail "Cluster 1: GarageNode pods not ready"
         return 1
     fi
 
     # Wait for pods in cluster 2
     use_cluster "$CLUSTER2_NAME"
-    if ! wait_for_pods_ready "app.kubernetes.io/name=garagenode" 2 180; then
+    if ! wait_for_pods_ready "garage.rajsingh.info/node" 2 180; then
         test_fail "Cluster 2: GarageNode pods not ready"
         return 1
     fi
@@ -1887,10 +1887,10 @@ test_manual_mode_federation_multicluster() {
 
     # Configure remoteClusters for federation
     use_cluster "$CLUSTER1_NAME"
-    local c1_pod_ip=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=garagenode" -o jsonpath='{.items[0].status.podIP}' 2>/dev/null)
+    local c1_pod_ip=$(kubectl get pods -n "$NAMESPACE" -l "garage.rajsingh.info/node" -o jsonpath='{.items[0].status.podIP}' 2>/dev/null)
 
     use_cluster "$CLUSTER2_NAME"
-    local c2_pod_ip=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=garagenode" -o jsonpath='{.items[0].status.podIP}' 2>/dev/null)
+    local c2_pod_ip=$(kubectl get pods -n "$NAMESPACE" -l "garage.rajsingh.info/node" -o jsonpath='{.items[0].status.podIP}' 2>/dev/null)
 
     log_info "  Cluster 1 pod IP: $c1_pod_ip"
     log_info "  Cluster 2 pod IP: $c2_pod_ip"
@@ -1970,10 +1970,10 @@ test_manual_mode_cleanup_multicluster() {
 
     # Verify StatefulSets are cleaned up
     use_cluster "$CLUSTER1_NAME"
-    local c1_sts=$(kubectl get statefulset -n "$NAMESPACE" -l "app.kubernetes.io/name=garagenode" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    local c1_sts=$(kubectl get statefulset -n "$NAMESPACE" -l "garage.rajsingh.info/node" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 
     use_cluster "$CLUSTER2_NAME"
-    local c2_sts=$(kubectl get statefulset -n "$NAMESPACE" -l "app.kubernetes.io/name=garagenode" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    local c2_sts=$(kubectl get statefulset -n "$NAMESPACE" -l "garage.rajsingh.info/node" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 
     if [ "$c1_sts" -eq 0 ] && [ "$c2_sts" -eq 0 ]; then
         test_pass "Manual mode nodes and StatefulSets cleaned up"

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -18,8 +18,10 @@ package controller
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -40,7 +42,26 @@ import (
 
 const (
 	garageBucketFinalizer = "garagebucket.garage.rajsingh.info/finalizer"
+
+	// BucketLookupStuckThreshold is the number of consecutive GetBucketInfo
+	// timeouts after which we set the BucketLookupStuck status condition.
+	BucketLookupStuckThreshold = 3
 )
+
+// getBucketInfoTimeout caps each individual GetBucketInfo admin API call
+// from the bucket controller. Upstream Garage admin API can hang
+// indefinitely on a single bucket whose authorized_keys contains a stale
+// node entry (netapp::try_connect has no TCP timeout). Without a per-call
+// cap, one poisoned bucket wedges the bucket workqueue.
+//
+// Declared as a var (not const) so tests can shorten it without waiting 15s.
+var getBucketInfoTimeout = 15 * time.Second
+
+// errBucketInfoTimeout is the sentinel returned by getBucketWithTimeout when
+// the per-call deadline fires. Callers treat this distinctly from other
+// GetBucket errors so they can bail the reconcile gracefully and let the
+// stuck-bucket tracker increment its counter.
+var errBucketInfoTimeout = stderrors.New("GetBucketInfo timed out")
 
 // GarageBucketReconciler reconciles a GarageBucket object
 type GarageBucketReconciler struct {
@@ -219,6 +240,13 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Reconcile the bucket
 	if err := r.reconcileBucket(ctx, bucket, garageClient); err != nil {
+		// A wedged GetBucketInfo is informational, not a reconcile failure.
+		// Bail with a stuck-bucket signal instead of marking PhaseFailed; the
+		// rest of the reconcile (cluster ref, owner ref, finalizer) already
+		// ran above and persisted.
+		if isBucketLookupTimeout(err) {
+			return r.handleBucketLookupTimeout(ctx, bucket)
+		}
 		return r.updateStatus(ctx, bucket, PhaseFailed, err)
 	}
 
@@ -283,8 +311,11 @@ func (r *GarageBucketReconciler) getOrCreateBucket(ctx context.Context, bucket *
 
 	// spec.bucketId takes absolute priority — never create, never guess.
 	if bucket.Spec.BucketID != "" {
-		existing, err := garageClient.GetBucket(ctx, garage.GetBucketRequest{ID: bucket.Spec.BucketID})
+		existing, err := getBucketWithTimeout(ctx, garageClient, garage.GetBucketRequest{ID: bucket.Spec.BucketID})
 		if err != nil {
+			if isBucketLookupTimeout(err) {
+				return nil, err
+			}
 			return nil, fmt.Errorf("spec.bucketId %s not found or unreachable: %w", bucket.Spec.BucketID, err)
 		}
 		bucket.Status.BucketID = existing.ID
@@ -296,9 +327,12 @@ func (r *GarageBucketReconciler) getOrCreateBucket(ctx context.Context, bucket *
 	// Treating transient errors as "not found" is what caused duplicate
 	// buckets to be created during Garage cluster recovery.
 	if bucket.Status.BucketID != "" {
-		existing, err := garageClient.GetBucket(ctx, garage.GetBucketRequest{ID: bucket.Status.BucketID})
+		existing, err := getBucketWithTimeout(ctx, garageClient, garage.GetBucketRequest{ID: bucket.Status.BucketID})
 		if err == nil {
 			return existing, nil
+		}
+		if isBucketLookupTimeout(err) {
+			return nil, err
 		}
 		if !garage.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get bucket by ID %s: %w", bucket.Status.BucketID, err)
@@ -307,7 +341,7 @@ func (r *GarageBucketReconciler) getOrCreateBucket(ctx context.Context, bucket *
 		log.Info("Tracked bucket ID not found, falling back to alias lookup", "bucketID", bucket.Status.BucketID, "alias", alias)
 	}
 
-	existing, err := garageClient.GetBucket(ctx, garage.GetBucketRequest{GlobalAlias: alias})
+	existing, err := getBucketWithTimeout(ctx, garageClient, garage.GetBucketRequest{GlobalAlias: alias})
 	if err == nil {
 		if bucket.Status.BucketID != "" && existing.ID != bucket.Status.BucketID {
 			log.Info("Alias resolved to a different bucket than previously tracked; adopting it",
@@ -315,6 +349,9 @@ func (r *GarageBucketReconciler) getOrCreateBucket(ctx context.Context, bucket *
 		}
 		bucket.Status.BucketID = existing.ID
 		return existing, nil
+	}
+	if isBucketLookupTimeout(err) {
+		return nil, err
 	}
 	if !garage.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get bucket by alias %s: %w", alias, err)
@@ -690,9 +727,17 @@ func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, buc
 	}
 
 	// Get bucket info from Garage
-	garageBucket, err := garageClient.GetBucket(ctx, garage.GetBucketRequest{ID: bucket.Status.BucketID})
+	garageBucket, err := getBucketWithTimeout(ctx, garageClient, garage.GetBucketRequest{ID: bucket.Status.BucketID})
 	if err != nil {
+		if isBucketLookupTimeout(err) {
+			return r.handleBucketLookupTimeout(ctx, bucket)
+		}
 		return r.updateStatus(ctx, bucket, PhaseFailed, fmt.Errorf("failed to get bucket info: %w", err))
+	}
+	// First success after one or more timeouts → reset counter and clear
+	// the BucketLookupStuck condition so a transient stall self-heals.
+	if err := r.clearBucketLookupTimeouts(ctx, bucket); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to clear bucket-lookup-timeouts annotation")
 	}
 
 	// Capture old status before modifications to detect no-op updates
@@ -812,6 +857,132 @@ func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, buc
 
 	// Status updated — the informer watch event will re-enqueue for immediate verification.
 	return ctrl.Result{}, nil
+}
+
+// getBucketWithTimeout wraps garageClient.GetBucket with a per-call deadline.
+// Returns errBucketInfoTimeout when the call exceeds getBucketInfoTimeout —
+// callers use that sentinel to bump the stuck-bucket counter and bail
+// gracefully without surfacing a generic API error.
+func getBucketWithTimeout(ctx context.Context, garageClient *garage.Client, req garage.GetBucketRequest) (*garage.Bucket, error) {
+	callCtx, cancel := context.WithTimeout(ctx, getBucketInfoTimeout)
+	defer cancel()
+	b, err := garageClient.GetBucket(callCtx, req)
+	if err != nil && stderrors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+		// Distinguish per-call timeout from parent-ctx cancellation. We only
+		// want to count it as a "stuck" signal when our own deadline fired,
+		// not when the controller is shutting down.
+		return nil, errBucketInfoTimeout
+	}
+	return b, err
+}
+
+// isBucketLookupTimeout returns true if err originated from a per-call
+// GetBucketInfo deadline. Used by callers to decide whether to bail with a
+// stuck-bucket signal vs. propagate the error.
+func isBucketLookupTimeout(err error) bool {
+	return stderrors.Is(err, errBucketInfoTimeout)
+}
+
+// readTimeoutCounter parses the AnnotationBucketLookupTimeouts annotation
+// into an int. Returns 0 for missing, malformed, or negative values.
+func readTimeoutCounter(bucket *garagev1beta1.GarageBucket) int {
+	if bucket.Annotations == nil {
+		return 0
+	}
+	v, ok := bucket.Annotations[garagev1beta1.AnnotationBucketLookupTimeouts]
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// recordBucketLookupTimeout increments the consecutive-timeout counter
+// annotation via a Patch (avoids ResourceVersion conflicts with subsequent
+// status updates). Returns the new count.
+func (r *GarageBucketReconciler) recordBucketLookupTimeout(ctx context.Context, bucket *garagev1beta1.GarageBucket) (int, error) {
+	current := readTimeoutCounter(bucket) + 1
+	patch := client.MergeFrom(bucket.DeepCopy())
+	if bucket.Annotations == nil {
+		bucket.Annotations = map[string]string{}
+	}
+	bucket.Annotations[garagev1beta1.AnnotationBucketLookupTimeouts] = strconv.Itoa(current)
+	if err := r.Patch(ctx, bucket, patch); err != nil {
+		return current, err
+	}
+	return current, nil
+}
+
+// clearBucketLookupTimeouts removes the counter annotation and the
+// BucketLookupStuck condition if either is set. Idempotent. Called on the
+// first successful GetBucket so a transient stall self-heals.
+func (r *GarageBucketReconciler) clearBucketLookupTimeouts(ctx context.Context, bucket *garagev1beta1.GarageBucket) error {
+	hadAnno := false
+	if bucket.Annotations != nil {
+		_, hadAnno = bucket.Annotations[garagev1beta1.AnnotationBucketLookupTimeouts]
+	}
+	hadCond := meta.FindStatusCondition(bucket.Status.Conditions, garagev1beta1.ConditionBucketLookupStuck) != nil
+	if !hadAnno && !hadCond {
+		return nil
+	}
+	if hadAnno {
+		patch := client.MergeFrom(bucket.DeepCopy())
+		delete(bucket.Annotations, garagev1beta1.AnnotationBucketLookupTimeouts)
+		if err := r.Patch(ctx, bucket, patch); err != nil {
+			return err
+		}
+	}
+	if hadCond {
+		meta.RemoveStatusCondition(&bucket.Status.Conditions, garagev1beta1.ConditionBucketLookupStuck)
+	}
+	return nil
+}
+
+// handleBucketLookupTimeout is called when a GetBucketInfo call from this
+// reconcile timed out. Increments the counter and, on reaching
+// BucketLookupStuckThreshold consecutive timeouts, sets the
+// BucketLookupStuck status condition pointing operators at the
+// trigger-repair=Aliases workaround. Returns a Result that requeues on the
+// unhealthy interval — the timeout is informational, never a workqueue
+// error.
+func (r *GarageBucketReconciler) handleBucketLookupTimeout(ctx context.Context, bucket *garagev1beta1.GarageBucket) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	count, patchErr := r.recordBucketLookupTimeout(ctx, bucket)
+	if patchErr != nil {
+		log.Error(patchErr, "Failed to record bucket-lookup-timeouts annotation")
+		// Keep going — counter is best-effort; the condition is the durable signal.
+	}
+	log.Info("GetBucketInfo timed out; the bucket may be wedged on a stale authorized_keys entry",
+		"bucket", bucket.Name, "consecutiveTimeouts", count, "threshold", BucketLookupStuckThreshold)
+
+	if count >= BucketLookupStuckThreshold {
+		// TODO: auto-trigger Aliases repair on the parent cluster with a cooldown (see #190 follow-ups)
+		alias := bucket.Spec.GlobalAlias
+		if alias == "" {
+			alias = bucket.Name
+		}
+		meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+			Type:   garagev1beta1.ConditionBucketLookupStuck,
+			Status: metav1.ConditionTrue,
+			Reason: garagev1beta1.ReasonBucketLookupStuck,
+			Message: fmt.Sprintf(
+				"GetBucketInfo for bucket %q timed out %d consecutive times. "+
+					"Likely cause: stale entry in authorized_keys whose RPC lookup hangs. "+
+					"Manual recovery: set annotation %s=%s on the parent GarageCluster.",
+				alias, count,
+				garagev1beta1.AnnotationTriggerRepair,
+				garagev1beta1.RepairTypeAliases,
+			),
+			ObservedGeneration: bucket.Generation,
+		})
+		if err := UpdateStatusWithRetry(ctx, r.Client, bucket); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{RequeueAfter: RequeueAfterUnhealthy}, nil
 }
 
 func formatBytes(bytes int64) string {

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -18,7 +18,11 @@ package controller
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,12 +30,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 const testNamespace = "default"
@@ -357,6 +364,251 @@ var _ = Describe("GarageBucket Controller", func() {
 
 func int64Ptr(i int64) *int64 {
 	return &i
+}
+
+// TestGetBucketWithTimeout_HangServer asserts that getBucketWithTimeout
+// returns errBucketInfoTimeout (the sentinel) when the upstream admin API
+// hangs past the per-call deadline — same shape as a wedged GetBucketInfo
+// in production.
+func TestGetBucketWithTimeout_HangServer(t *testing.T) {
+	// Hang on every request — simulates a Garage admin API that's stuck on
+	// a stale authorized_keys entry whose RPC lookup never returns.
+	hangServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer hangServer.Close()
+
+	prev := getBucketInfoTimeout
+	getBucketInfoTimeout = 100 * time.Millisecond
+	defer func() { getBucketInfoTimeout = prev }()
+
+	client := garage.NewClient(hangServer.URL, "test-token")
+	start := time.Now()
+	_, err := getBucketWithTimeout(context.Background(), client, garage.GetBucketRequest{ID: "abc"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !isBucketLookupTimeout(err) {
+		t.Errorf("expected isBucketLookupTimeout(err)=true; got err=%v", err)
+	}
+	// Should return ~100ms after deadline, not hang for the full client timeout.
+	if elapsed > 2*time.Second {
+		t.Errorf("getBucketWithTimeout took %s, expected <2s", elapsed)
+	}
+}
+
+// TestGetBucketWithTimeout_ParentContextCancel ensures we DON'T mark a
+// caller-cancelled context as a stuck-bucket signal. Only our own deadline
+// firing should count.
+func TestGetBucketWithTimeout_ParentContextCancel(t *testing.T) {
+	hangServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer hangServer.Close()
+
+	prev := getBucketInfoTimeout
+	getBucketInfoTimeout = 10 * time.Second
+	defer func() { getBucketInfoTimeout = prev }()
+
+	client := garage.NewClient(hangServer.URL, "test-token")
+	parentCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := getBucketWithTimeout(parentCtx, client, garage.GetBucketRequest{ID: "abc"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if isBucketLookupTimeout(err) {
+		t.Errorf("parent-ctx cancel must not be reported as bucket lookup timeout; got %v", err)
+	}
+}
+
+// newBucketReconcilerWithFakeClient builds a GarageBucketReconciler backed
+// by a fake k8s client preloaded with the given bucket. Subresource status
+// is enabled so r.Status().Update works.
+func newBucketReconcilerWithFakeClient(t *testing.T, bucket *garagev1beta1.GarageBucket) (*GarageBucketReconciler, *garagev1beta1.GarageBucket) {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := garagev1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme v1beta1: %v", err)
+	}
+	if err := garagev1beta2.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme v1beta2: %v", err)
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(bucket).
+		WithStatusSubresource(&garagev1beta1.GarageBucket{}).
+		Build()
+	r := &GarageBucketReconciler{Client: fc, Scheme: s}
+
+	live := &garagev1beta1.GarageBucket{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, live); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	return r, live
+}
+
+// TestHandleBucketLookupTimeout_SetsConditionAtThreshold drives
+// handleBucketLookupTimeout N consecutive times (no successes in between)
+// and asserts: counter increments on each call; BucketLookupStuck condition
+// is True with Reason=AdminAPITimeout once count reaches the threshold; and
+// the result requeues on the unhealthy interval rather than surfacing an
+// error.
+func TestHandleBucketLookupTimeout_SetsConditionAtThreshold(t *testing.T) {
+	ctx := context.Background()
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "wedged-bucket", Namespace: testNamespace},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef:  garagev1beta1.ClusterReference{Name: testClusterName},
+			GlobalAlias: "wedged-alias",
+		},
+	}
+	r, live := newBucketReconcilerWithFakeClient(t, bucket)
+
+	for i := 1; i <= BucketLookupStuckThreshold; i++ {
+		res, err := r.handleBucketLookupTimeout(ctx, live)
+		if err != nil {
+			t.Fatalf("iter %d: unexpected error: %v", i, err)
+		}
+		if res.RequeueAfter != RequeueAfterUnhealthy {
+			t.Errorf("iter %d: RequeueAfter=%s, want %s", i, res.RequeueAfter, RequeueAfterUnhealthy)
+		}
+
+		// Re-fetch to verify persisted annotation count.
+		fresh := &garagev1beta1.GarageBucket{}
+		if err := r.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, fresh); err != nil {
+			t.Fatalf("iter %d: get bucket: %v", i, err)
+		}
+		gotCount := readTimeoutCounter(fresh)
+		if gotCount != i {
+			t.Errorf("iter %d: counter=%d, want %d", i, gotCount, i)
+		}
+		live = fresh
+
+		cond := meta.FindStatusCondition(fresh.Status.Conditions, garagev1beta1.ConditionBucketLookupStuck)
+		if i < BucketLookupStuckThreshold {
+			if cond != nil {
+				t.Errorf("iter %d (below threshold): expected no BucketLookupStuck condition, got %+v", i, cond)
+			}
+		} else {
+			if cond == nil {
+				t.Fatalf("iter %d (threshold reached): expected BucketLookupStuck condition, got nil", i)
+			}
+			if cond.Status != metav1.ConditionTrue {
+				t.Errorf("condition.Status=%v, want True", cond.Status)
+			}
+			if cond.Reason != garagev1beta1.ReasonBucketLookupStuck {
+				t.Errorf("condition.Reason=%q, want %q", cond.Reason, garagev1beta1.ReasonBucketLookupStuck)
+			}
+			// Message should name the bucket alias and point at the manual fix.
+			if !strings.Contains(cond.Message, "wedged-alias") {
+				t.Errorf("condition.Message does not name the bucket alias: %q", cond.Message)
+			}
+			if !strings.Contains(cond.Message, garagev1beta1.RepairTypeAliases) {
+				t.Errorf("condition.Message does not mention RepairType=Aliases: %q", cond.Message)
+			}
+		}
+	}
+}
+
+// TestClearBucketLookupTimeouts_ResetsCounterAndCondition verifies that a
+// successful GetBucketInfo (simulated by directly calling
+// clearBucketLookupTimeouts) wipes both the counter annotation and the
+// BucketLookupStuck condition.
+func TestClearBucketLookupTimeouts_ResetsCounterAndCondition(t *testing.T) {
+	ctx := context.Background()
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "recovered-bucket",
+			Namespace:   testNamespace,
+			Annotations: map[string]string{garagev1beta1.AnnotationBucketLookupTimeouts: "3"},
+		},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: testClusterName},
+		},
+		Status: garagev1beta1.GarageBucketStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               garagev1beta1.ConditionBucketLookupStuck,
+					Status:             metav1.ConditionTrue,
+					Reason:             garagev1beta1.ReasonBucketLookupStuck,
+					Message:            "stuck",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+	r, live := newBucketReconcilerWithFakeClient(t, bucket)
+
+	// Seed: pull current state so we have a non-zero count and live condition.
+	if got := readTimeoutCounter(live); got != 3 {
+		t.Fatalf("precondition: counter=%d, want 3", got)
+	}
+
+	if err := r.clearBucketLookupTimeouts(ctx, live); err != nil {
+		t.Fatalf("clearBucketLookupTimeouts: %v", err)
+	}
+
+	fresh := &garagev1beta1.GarageBucket{}
+	if err := r.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, fresh); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got := readTimeoutCounter(fresh); got != 0 {
+		t.Errorf("counter after clear=%d, want 0", got)
+	}
+	if _, ok := fresh.Annotations[garagev1beta1.AnnotationBucketLookupTimeouts]; ok {
+		t.Errorf("annotation should be removed")
+	}
+	// Conditions on the live object are cleared in-memory by RemoveStatusCondition.
+	// clearBucketLookupTimeouts does not flush status (callers do as part of
+	// their own status update). We assert the in-memory clear here.
+	if cond := meta.FindStatusCondition(live.Status.Conditions, garagev1beta1.ConditionBucketLookupStuck); cond != nil {
+		t.Errorf("BucketLookupStuck condition still set in-memory: %+v", cond)
+	}
+}
+
+// TestHandleThenClear_FullCycle simulates the production sequence: three
+// reconciles time out (condition gets set), then the next reconcile sees a
+// success (clear is invoked) — final state has no counter and no condition.
+func TestHandleThenClear_FullCycle(t *testing.T) {
+	ctx := context.Background()
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "cycle-bucket", Namespace: testNamespace},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: testClusterName},
+		},
+	}
+	r, live := newBucketReconcilerWithFakeClient(t, bucket)
+
+	for i := 0; i < BucketLookupStuckThreshold; i++ {
+		if _, err := r.handleBucketLookupTimeout(ctx, live); err != nil {
+			t.Fatalf("handleBucketLookupTimeout iter %d: %v", i, err)
+		}
+		if err := r.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, live); err != nil {
+			t.Fatalf("get bucket iter %d: %v", i, err)
+		}
+	}
+	if cond := meta.FindStatusCondition(live.Status.Conditions, garagev1beta1.ConditionBucketLookupStuck); cond == nil {
+		t.Fatal("expected BucketLookupStuck condition after threshold reached")
+	}
+
+	// First successful GetBucketInfo on the next reconcile.
+	if err := r.clearBucketLookupTimeouts(ctx, live); err != nil {
+		t.Fatalf("clearBucketLookupTimeouts: %v", err)
+	}
+	fresh := &garagev1beta1.GarageBucket{}
+	if err := r.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, fresh); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got := readTimeoutCounter(fresh); got != 0 {
+		t.Errorf("counter after recovery=%d, want 0", got)
+	}
+	if cond := meta.FindStatusCondition(live.Status.Conditions, garagev1beta1.ConditionBucketLookupStuck); cond != nil {
+		t.Errorf("BucketLookupStuck condition should be cleared in-memory: %+v", cond)
+	}
 }
 
 func TestParseMPUOlderThan(t *testing.T) {

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -876,9 +876,39 @@ func (r *GarageKeyReconciler) finalize(ctx context.Context, key *garagev1beta1.G
 		return nil
 	}
 
+	// Pre-revoke every per-bucket grant the operator believes this key has before
+	// calling DeleteKey. Upstream DeleteKey iterates state.authorized_buckets
+	// sequentially and calls set_bucket_key_permissions per bucket — if a single
+	// bucket is wedged (e.g. its RPC lookup never returns), DeleteKey hangs
+	// forever and our client's request-level timeout is the only escape. By
+	// clearing the grants first, with a fresh short timeout per call, one stuck
+	// bucket can't poison the whole finalize. Each iteration has its own
+	// context so we keep making progress even when some calls time out.
+	for _, b := range key.Status.Buckets {
+		if b.BucketID == "" {
+			continue
+		}
+		denyCtx, cancel := context.WithTimeout(ctx, finalizeRPCTimeout)
+		_, err := garageClient.DenyBucketKey(denyCtx, garage.DenyBucketKeyRequest{
+			BucketID:    b.BucketID,
+			AccessKeyID: key.Status.AccessKeyID,
+			Permissions: garage.BucketKeyPerms{Read: true, Write: true, Owner: true},
+		})
+		cancel()
+		if err != nil {
+			if garage.IsNotFound(err) {
+				continue
+			}
+			log.Info("Pre-revoke of bucket grant failed; continuing",
+				"bucketID", b.BucketID, "accessKeyID", key.Status.AccessKeyID, "error", err)
+		}
+	}
+
 	log.Info("Deleting key", "accessKeyID", key.Status.AccessKeyID)
 
-	if err := garageClient.DeleteKey(ctx, key.Status.AccessKeyID); err != nil {
+	delCtx, cancel := context.WithTimeout(ctx, finalizeRPCTimeout)
+	defer cancel()
+	if err := garageClient.DeleteKey(delCtx, key.Status.AccessKeyID); err != nil {
 		// Check if key doesn't exist (404) - that's okay, we can proceed
 		if garage.IsNotFound(err) {
 			log.Info("Key already deleted or not found", "accessKeyID", key.Status.AccessKeyID)

--- a/internal/controller/garagekey_controller_test.go
+++ b/internal/controller/garagekey_controller_test.go
@@ -19,6 +19,12 @@ package controller
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 var _ = Describe("GarageKey Controller", func() {
@@ -454,6 +461,144 @@ var _ = Describe("GarageKey Controller", func() {
 			// All chars after GK prefix must be hex (0-9a-f)
 			for _, c := range akID[2:] {
 				Expect("0123456789abcdef").To(ContainSubstring(string(c)))
+			}
+		})
+	})
+
+	Describe("finalize pre-revokes bucket grants before DeleteKey", func() {
+		// Spins up a mock Garage admin server that lets each test override
+		// per-bucket DenyBucketKey behavior (status code + optional sleep).
+		type denyResp struct {
+			delay  time.Duration
+			status int
+		}
+
+		const (
+			testAccessKeyID = "GKtestkey1234567890abcdef"
+			bucketIDGood1   = "11111111111111111111111111111111"
+			bucketIDStuck   = "22222222222222222222222222222222"
+			bucketIDGood2   = "33333333333333333333333333333333"
+		)
+
+		buildKey := func() *garagev1beta1.GarageKey {
+			return &garagev1beta1.GarageKey{
+				ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: testNamespace},
+				Status: garagev1beta1.GarageKeyStatus{
+					AccessKeyID: testAccessKeyID,
+					Buckets: []garagev1beta1.KeyBucketAccess{
+						{BucketID: bucketIDGood1, Read: true},
+						{BucketID: bucketIDStuck, Read: true, Write: true},
+						{BucketID: bucketIDGood2, Owner: true},
+					},
+				},
+			}
+		}
+
+		newServer := func(denyBehavior map[string]denyResp, deleteKeyStatus int, denyCalls *[]string, deleteCalls *int32) *httptest.Server {
+			var mu sync.Mutex
+			return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/v2/DenyBucketKey"):
+					var req garage.DenyBucketKeyRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					mu.Lock()
+					*denyCalls = append(*denyCalls, req.BucketID)
+					mu.Unlock()
+					beh, ok := denyBehavior[req.BucketID]
+					if !ok {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{}`))
+						return
+					}
+					if beh.delay > 0 {
+						select {
+						case <-time.After(beh.delay):
+						case <-r.Context().Done():
+							return
+						}
+					}
+					status := beh.status
+					if status == 0 {
+						status = http.StatusOK
+					}
+					w.WriteHeader(status)
+					if status == http.StatusOK {
+						_, _ = w.Write([]byte(`{}`))
+					}
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/v2/DeleteKey"):
+					atomic.AddInt32(deleteCalls, 1)
+					status := deleteKeyStatus
+					if status == 0 {
+						status = http.StatusOK
+					}
+					w.WriteHeader(status)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+		}
+
+		It("revokes the surviving buckets and still calls DeleteKey when one DenyBucketKey errors", func() {
+			var denyCalls []string
+			var deleteCalls int32
+			srv := newServer(map[string]denyResp{
+				bucketIDStuck: {status: http.StatusInternalServerError},
+			}, http.StatusOK, &denyCalls, &deleteCalls)
+			defer srv.Close()
+
+			r := &GarageKeyReconciler{}
+			err := r.finalize(context.Background(), buildKey(), garage.NewClient(srv.URL, "tok"))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(denyCalls).To(ConsistOf(bucketIDGood1, bucketIDStuck, bucketIDGood2))
+			Expect(atomic.LoadInt32(&deleteCalls)).To(Equal(int32(1)))
+		})
+
+		It("treats a NotFound from DeleteKey after pre-revoke as success", func() {
+			var denyCalls []string
+			var deleteCalls int32
+			srv := newServer(nil, http.StatusNotFound, &denyCalls, &deleteCalls)
+			defer srv.Close()
+
+			r := &GarageKeyReconciler{}
+			err := r.finalize(context.Background(), buildKey(), garage.NewClient(srv.URL, "tok"))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(denyCalls).To(HaveLen(3))
+			Expect(atomic.LoadInt32(&deleteCalls)).To(Equal(int32(1)))
+		})
+
+		It("does not let a slow DenyBucketKey block subsequent buckets or DeleteKey", func() {
+			var denyCalls []string
+			var deleteCalls int32
+			// Hang the stuck bucket past the per-call timeout but well under the
+			// total test budget. The other two must still be called and DeleteKey
+			// must still fire.
+			srv := newServer(map[string]denyResp{
+				bucketIDStuck: {delay: 20 * time.Second},
+			}, http.StatusOK, &denyCalls, &deleteCalls)
+			defer srv.Close()
+
+			r := &GarageKeyReconciler{}
+
+			done := make(chan error, 1)
+			start := time.Now()
+			go func() {
+				done <- r.finalize(context.Background(), buildKey(), garage.NewClient(srv.URL, "tok"))
+			}()
+
+			select {
+			case err := <-done:
+				elapsed := time.Since(start)
+				Expect(err).NotTo(HaveOccurred())
+				// Should finish at roughly one per-call timeout (15s) for the stuck
+				// bucket plus negligible time for the others — well under 30s.
+				Expect(elapsed).To(BeNumerically("<", 25*time.Second),
+					"finalize should not be blocked by the full upstream delay")
+				Expect(denyCalls).To(ConsistOf(bucketIDGood1, bucketIDStuck, bucketIDGood2))
+				Expect(atomic.LoadInt32(&deleteCalls)).To(Equal(int32(1)))
+			case <-time.After(45 * time.Second):
+				Fail("finalize blocked past the per-call timeout budget")
 			}
 		})
 	})

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -83,6 +83,21 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		Name:      node.Spec.ClusterRef.Name,
 		Namespace: clusterNamespace,
 	}, cluster); err != nil {
+		// Cluster gone (the cluster-level finalizer ran ahead of GC catching up to
+		// this GarageNode) → no admin API to talk to; the layout entries were
+		// already drained by the cluster finalizer's removeNodesFromLayout call.
+		// Drop the per-node finalizer so the GarageNode + its owned STS get GC'd
+		// instead of wedging this namespace forever.
+		if errors.IsNotFound(err) && !node.DeletionTimestamp.IsZero() {
+			if controllerutil.ContainsFinalizer(node, garageNodeFinalizer) {
+				log.Info("Parent cluster already deleted; releasing GarageNode finalizer", "node", node.Name)
+				controllerutil.RemoveFinalizer(node, garageNodeFinalizer)
+				if updateErr := r.Update(ctx, node); updateErr != nil {
+					return ctrl.Result{}, updateErr
+				}
+			}
+			return ctrl.Result{}, nil
+		}
 		return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("cluster not found: %w", err))
 	}
 	// User-created GarageNodes still require Manual layout — operator-managed CRs

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -265,6 +265,11 @@ const (
 	FinalizationRetryAnnotation = "garage.rajsingh.info/finalization-retries"
 	// FinalizationMaxRetries before giving up and removing finalizer
 	FinalizationMaxRetries = 5
+	// finalizeRPCTimeout caps a single admin API call on the finalize hot path.
+	// Generous compared to a healthy call, short enough that one wedged peer
+	// (e.g. a bucket whose authorized_keys lookup never returns) cannot
+	// monopolize the whole reconcile.
+	finalizeRPCTimeout = 15 * time.Second
 )
 
 // GetGarageClient creates a Garage Admin API client for the given cluster.

--- a/test/e2e/dual_version_test.go
+++ b/test/e2e/dual_version_test.go
@@ -184,7 +184,7 @@ spec:
 		By("expecting PVCs to be provisioned for metadata+data on the per-node STS")
 		Eventually(func(g Gomega) {
 			get := exec.Command("kubectl", "get", "pvc", "-n", testNS,
-				"-l", "app.kubernetes.io/instance="+v1Storage+"-storage-0", "-o", "jsonpath={.items[*].metadata.name}")
+				"-l", "garage.rajsingh.info/node="+v1Storage+"-storage-0", "-o", "jsonpath={.items[*].metadata.name}")
 			o, err := utils.Run(get)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(o).NotTo(BeEmpty(), "expected at least one PVC for v1beta1 storage cluster's per-node STS")


### PR DESCRIPTION
## Summary

Three operator hardening fixes landing together.

### #1 — Pre-revoke per-bucket grants before `DeleteKey` (fixes the 5-day-stuck-finalizer)

`GarageKey.finalize` now iterates `key.status.buckets` and calls `DenyBucketKey` per bucket under its own 15s `context.WithTimeout`, tolerating individual failures. After the loop, `DeleteKey` is called (also under a 15s timeout). With `authorized_buckets` already drained, upstream Garage's internal loop in `src/model/helper/locked.rs:456` has nothing to iterate and can't hang on a bad bucket.

### #2 — `BucketLookupStuck` status condition

`GarageBucket` reconcile wraps `GetBucketInfo` with a 15s timeout and tracks consecutive timeouts via the new `garage.rajsingh.info/bucket-lookup-timeouts` annotation. At 3 strikes the operator sets a `BucketLookupStuck` status condition pointing operators at the existing `trigger-repair=Aliases` annotation (upstream `repair_aliases` in `src/model/helper/locked.rs:486` fixes orphan `authorized_keys` references). The condition doesn't block other reconciliation; the counter resets on the first successful read.

### #3 — Defensive `UnmarshalJSON` for `spec.gateway` bool (fixes #195)

Reporters hit `json: cannot unmarshal bool into Go struct field GarageClusterSpec.items.spec.gateway` from the operator cache reflector. The reason: their cluster has at least one `GarageCluster` whose stored etcd bytes are still in the v1beta1 schema (where `spec.gateway` was a bool). On LIST through v1beta2 the API server is supposed to call the conversion webhook, but if `webhooks.enabled: false` (chart strips the conversion stanza) or cert-manager is misconfigured, the per-object conversion call fails and the API server returns the raw v1beta1 bytes — the strict decoder then gives up on the entire LIST.

Add `UnmarshalJSON` on `GarageClusterSpec` that accepts `gateway: {true, false, null, {struct}}`. Other fields pass through the standard decoder via the embedded-alias trick. Independent of whether the conversion webhook is healthy, the operator can now LIST and reconcile.

### #4 — e2e selector refresh

`hack/e2e-cluster.sh` and `hack/e2e-multicluster.sh` were matching per-node STS pods via the old `app.kubernetes.io/name=garagenode` selector. v0.6.1 restored the cluster-shared `instance` label, so these selectors broke `main`. Switched to `garage.rajsingh.info/node[=<node-name>]` (unique-per-STS, stable across the label refactor).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green; new unit tests for pre-revoke, stuck-bucket detection, gateway bool unmarshal)
- [x] `bin/golangci-lint run` clean
- [ ] CI green on this PR (rerun after the e2e + #195 commits)