### PR TITLE
fix: PDB regression + v0.6.x review fixes (#196)

### DIFF
--- a/api/v1beta1/garagenode_types.go
+++ b/api/v1beta1/garagenode_types.go
@@ -418,6 +418,22 @@ type GarageNodeStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// ClusterAdminEndpoint is the resolved Garage Admin API endpoint last used
+	// to manage this node's layout entry. Captured on each successful reconcile
+	// so that a delete-time finalizer can still attempt to drop the layout
+	// entry when the parent GarageCluster CR has already been deleted (edge
+	// gateway pattern via spec.connectTo.adminApiEndpoint).
+	// +optional
+	ClusterAdminEndpoint string `json:"clusterAdminEndpoint,omitempty"`
+
+	// ClusterAdminTokenSecretRef references the Admin API token secret last
+	// used to manage this node's layout entry. The secret lives in the same
+	// namespace as the GarageNode. Paired with ClusterAdminEndpoint to enable
+	// best-effort finalize against an external admin API after the parent
+	// GarageCluster CR is gone.
+	// +optional
+	ClusterAdminTokenSecretRef *corev1.SecretKeySelector `json:"clusterAdminTokenSecretRef,omitempty"`
+
 	// Conditions represent the current state
 	// +listType=map
 	// +listMapKey=type

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1756,6 +1756,11 @@ func (in *GarageNodeStatus) DeepCopyInto(out *GarageNodeStatus) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.ClusterAdminTokenSecretRef != nil {
+		in, out := &in.ClusterAdminTokenSecretRef, &out.ClusterAdminTokenSecretRef
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/api/v1beta2/garagecluster_unmarshal.go
+++ b/api/v1beta2/garagecluster_unmarshal.go
@@ -33,14 +33,30 @@ import (
 //   - `gateway: false`  → nil
 //   - `gateway: {...}`  → standard struct decode
 //   - omitted           → nil
+//
+// It also salvages the matching v1beta1 storage shape: in v1beta1 `replicas`
+// is a top-level field and `spec.storage` is the legacy StorageConfig with no
+// Replicas field. When those bytes leak through the v1beta2 endpoint (same
+// webhook-hiccup scenario as the gateway bool), the strict decoder would
+// otherwise yield `Storage != nil, Storage.Replicas == 0`. `HasStorageTier()`
+// returns true on that, and the Auto-mode reconciler computes a desired set
+// of zero GarageNodes — deleting every operator-owned storage node. We
+// detect a top-level `replicas` in the raw JSON and, when storage is also
+// present with replicas zero, copy it across.
 func (s *GarageClusterSpec) UnmarshalJSON(data []byte) error {
 	type alias GarageClusterSpec
 	aux := struct {
-		Gateway json.RawMessage `json:"gateway,omitempty"`
+		Gateway  json.RawMessage `json:"gateway,omitempty"`
+		Replicas *int32          `json:"replicas,omitempty"`
 		*alias
 	}{alias: (*alias)(s)}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
+	}
+	// Salvage v1beta1 leak: top-level replicas + storage block where
+	// storage.replicas was not present (decoded to zero).
+	if aux.Replicas != nil && s.Storage != nil && s.Storage.Replicas == 0 {
+		s.Storage.Replicas = *aux.Replicas
 	}
 	raw := bytes.TrimSpace(aux.Gateway)
 	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {

--- a/api/v1beta2/garagecluster_unmarshal_test.go
+++ b/api/v1beta2/garagecluster_unmarshal_test.go
@@ -61,6 +61,59 @@ func TestGarageClusterSpec_UnmarshalJSON_PreservesOtherFields(t *testing.T) {
 	}
 }
 
+// TestGarageClusterSpec_UnmarshalJSON_LegacyStorageReplicas guards the matching
+// storage-side leak of #195: a v1beta1 CR puts `replicas` at the top level
+// and `spec.storage` is the legacy StorageConfig (no Replicas field). When
+// those bytes reach v1beta2's strict decoder via a webhook hiccup, the
+// decoder produces `Storage != nil, Storage.Replicas == 0`, which the
+// Auto-mode reconciler then interprets as "delete every storage GarageNode."
+// Salvage by copying the top-level replicas into Storage.Replicas.
+func TestGarageClusterSpec_UnmarshalJSON_LegacyStorageReplicas(t *testing.T) {
+	in := `{"replicas":3,"storage":{"metadata":{"size":"10Gi"},"data":{"size":"100Gi"}}}`
+	var s GarageClusterSpec
+	if err := json.Unmarshal([]byte(in), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.Storage == nil {
+		t.Fatal("storage: nil, want non-nil")
+	}
+	if s.Storage.Replicas != 3 {
+		t.Fatalf("storage.replicas: got=%d want=3 (v1beta1 leak not salvaged)", s.Storage.Replicas)
+	}
+}
+
+// TestGarageClusterSpec_UnmarshalJSON_V1beta2StorageReplicas confirms the
+// normal v1beta2 path still works — top-level `replicas` absent, replicas
+// only inside spec.storage.
+func TestGarageClusterSpec_UnmarshalJSON_V1beta2StorageReplicas(t *testing.T) {
+	in := `{"storage":{"replicas":3,"metadata":{"size":"10Gi"}}}`
+	var s GarageClusterSpec
+	if err := json.Unmarshal([]byte(in), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.Storage == nil || s.Storage.Replicas != 3 {
+		t.Fatalf("storage: got=%+v want replicas=3", s.Storage)
+	}
+}
+
+// TestGarageClusterSpec_UnmarshalJSON_StorageReplicasZeroPreserved confirms
+// the explicit-pause case — `spec.storage.replicas: 0` is a valid v1beta2
+// state (Minimum=0) used to keep the tier declared without running pods.
+// Without a top-level `replicas` field the salvage path must NOT fire.
+func TestGarageClusterSpec_UnmarshalJSON_StorageReplicasZeroPreserved(t *testing.T) {
+	in := `{"storage":{"replicas":0,"metadata":{"size":"10Gi"}}}`
+	var s GarageClusterSpec
+	if err := json.Unmarshal([]byte(in), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.Storage == nil {
+		t.Fatal("storage: nil, want non-nil")
+	}
+	if s.Storage.Replicas != 0 {
+		t.Fatalf("storage.replicas: got=%d want=0 (explicit pause was clobbered)", s.Storage.Replicas)
+	}
+}
+
 func TestGarageClusterSpec_UnmarshalJSON_GatewayStructPopulated(t *testing.T) {
 	// Replicas inside the struct must round-trip; this is the normal v1beta2
 	// case and must not regress.

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
@@ -2438,6 +2438,42 @@ spec:
                   this node
                 format: int32
                 type: integer
+              clusterAdminEndpoint:
+                description: |-
+                  ClusterAdminEndpoint is the resolved Garage Admin API endpoint last used
+                  to manage this node's layout entry. Captured on each successful reconcile
+                  so that a delete-time finalizer can still attempt to drop the layout
+                  entry when the parent GarageCluster CR has already been deleted (edge
+                  gateway pattern via spec.connectTo.adminApiEndpoint).
+                type: string
+              clusterAdminTokenSecretRef:
+                description: |-
+                  ClusterAdminTokenSecretRef references the Admin API token secret last
+                  used to manage this node's layout entry. The secret lives in the same
+                  namespace as the GarageNode. Paired with ClusterAdminEndpoint to enable
+                  best-effort finalize against an external admin API after the parent
+                  GarageCluster CR is gone.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
               conditions:
                 description: Conditions represent the current state
                 items:

--- a/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
@@ -2438,6 +2438,42 @@ spec:
                   this node
                 format: int32
                 type: integer
+              clusterAdminEndpoint:
+                description: |-
+                  ClusterAdminEndpoint is the resolved Garage Admin API endpoint last used
+                  to manage this node's layout entry. Captured on each successful reconcile
+                  so that a delete-time finalizer can still attempt to drop the layout
+                  entry when the parent GarageCluster CR has already been deleted (edge
+                  gateway pattern via spec.connectTo.adminApiEndpoint).
+                type: string
+              clusterAdminTokenSecretRef:
+                description: |-
+                  ClusterAdminTokenSecretRef references the Admin API token secret last
+                  used to manage this node's layout entry. The secret lives in the same
+                  namespace as the GarageNode. Paired with ClusterAdminEndpoint to enable
+                  best-effort finalize against an external admin API after the parent
+                  GarageCluster CR is gone.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
               conditions:
                 description: Conditions represent the current state
                 items:

--- a/hack/e2e-cluster.sh
+++ b/hack/e2e-cluster.sh
@@ -1974,9 +1974,12 @@ test_pdb_creation() {
     log_test "Testing PodDisruptionBudget creation..."
 
     # Enable PDB — pass minAvailable as integer (not quoted string; "2" would be
-    # treated as a non-percentage string and rejected by the PDB API)
+    # treated as a non-percentage string and rejected by the PDB API).
+    # v1beta2 field path is spec.storage.podDisruptionBudget; the v0.5.x
+    # spec.podDisruptionBudget path is a v1beta1-only artifact that the
+    # conversion webhook lifts into spec.storage.
     kubectl patch garagecluster garage -n "$NAMESPACE" --type=merge \
-        -p '{"spec":{"podDisruptionBudget":{"enabled":true,"minAvailable":2}}}'
+        -p '{"spec":{"storage":{"podDisruptionBudget":{"enabled":true,"minAvailable":2}}}}'
 
     # Wait for PDB to be created (controller needs time to reconcile)
     local timeout=30

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -867,13 +869,43 @@ func getBucketWithTimeout(ctx context.Context, garageClient *garage.Client, req 
 	callCtx, cancel := context.WithTimeout(ctx, getBucketInfoTimeout)
 	defer cancel()
 	b, err := garageClient.GetBucket(callCtx, req)
-	if err != nil && stderrors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+	if err != nil && isTimeoutErr(err) && ctx.Err() == nil {
 		// Distinguish per-call timeout from parent-ctx cancellation. We only
 		// want to count it as a "stuck" signal when our own deadline fired,
-		// not when the controller is shutting down.
+		// not when the controller is shutting down. We classify both our
+		// own context.DeadlineExceeded and net/http transport timeouts
+		// (http.Client.Timeout) as stuck signals — the latter surface as a
+		// *url.Error wrapping a net.Error with Timeout()==true and do NOT
+		// match errors.Is(err, context.DeadlineExceeded).
 		return nil, errBucketInfoTimeout
 	}
 	return b, err
+}
+
+// isTimeoutErr returns true for any error that indicates a timeout —
+// either our per-call ctx deadline or a transport-level timeout from
+// net/http (when http.Client.Timeout fires before the ctx deadline).
+//
+// We check:
+//  1. errors.Is(err, context.DeadlineExceeded) — our own per-call ctx fired
+//  2. net.Error.Timeout() — *url.Error / *net.OpError expose this
+//  3. string fallback — wrapped errors that don't expose net.Error but
+//     still carry timeout substrings in their message (defence in depth).
+func isTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if stderrors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if stderrors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "timeout awaiting response headers") ||
+		strings.Contains(msg, "context deadline exceeded")
 }
 
 // isBucketLookupTimeout returns true if err originated from a per-call
@@ -964,7 +996,7 @@ func (r *GarageBucketReconciler) handleBucketLookupTimeout(ctx context.Context, 
 		if alias == "" {
 			alias = bucket.Name
 		}
-		meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+		cond := metav1.Condition{
 			Type:   garagev1beta1.ConditionBucketLookupStuck,
 			Status: metav1.ConditionTrue,
 			Reason: garagev1beta1.ReasonBucketLookupStuck,
@@ -977,8 +1009,17 @@ func (r *GarageBucketReconciler) handleBucketLookupTimeout(ctx context.Context, 
 				garagev1beta1.RepairTypeAliases,
 			),
 			ObservedGeneration: bucket.Generation,
-		})
-		if err := UpdateStatusWithRetry(ctx, r.Client, bucket); err != nil {
+		}
+		// Apply the condition. The mutate closure re-applies it after a
+		// conflict-driven re-fetch — without it, the helper would re-read the
+		// stored object and silently overwrite this in-memory condition before
+		// the next Update attempt, so the admin-recovery hint from #194 would
+		// never surface on a Conflict.
+		apply := func() {
+			meta.SetStatusCondition(&bucket.Status.Conditions, cond)
+		}
+		apply()
+		if err := UpdateStatusWithRetry(ctx, r.Client, bucket, apply); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -18,9 +18,13 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,9 +35,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
@@ -42,6 +49,10 @@ import (
 )
 
 const testNamespace = "default"
+
+// testBucketID is a throwaway bucket id used by the timeout tests where the
+// upstream admin API call never returns or is mocked out before responding.
+const testBucketID = "abc"
 
 var _ = Describe("GarageBucket Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -384,7 +395,7 @@ func TestGetBucketWithTimeout_HangServer(t *testing.T) {
 
 	client := garage.NewClient(hangServer.URL, "test-token")
 	start := time.Now()
-	_, err := getBucketWithTimeout(context.Background(), client, garage.GetBucketRequest{ID: "abc"})
+	_, err := getBucketWithTimeout(context.Background(), client, garage.GetBucketRequest{ID: testBucketID})
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -416,7 +427,7 @@ func TestGetBucketWithTimeout_ParentContextCancel(t *testing.T) {
 	parentCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	_, err := getBucketWithTimeout(parentCtx, client, garage.GetBucketRequest{ID: "abc"})
+	_, err := getBucketWithTimeout(parentCtx, client, garage.GetBucketRequest{ID: testBucketID})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -631,5 +642,198 @@ func TestParseMPUOlderThan(t *testing.T) {
 				t.Errorf("parseMPUOlderThan(%q) = %d, want %d", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIsTimeoutErr_ClassifiesNetHTTPTimeouts verifies that isTimeoutErr
+// classifies the timeout shapes net/http actually returns — not just
+// context.DeadlineExceeded. http.Client.Timeout firing surfaces as a
+// *url.Error wrapping a net.Error with Timeout()==true, and
+// errors.Is(err, context.DeadlineExceeded) is FALSE for those.
+//
+// Regression for the case where getBucketWithTimeout previously only
+// matched context.DeadlineExceeded; transport-level timeouts slipped
+// through as generic errors and the stuck-bucket counter never moved.
+func TestIsTimeoutErr_ClassifiesNetHTTPTimeouts(t *testing.T) {
+	// A timeout-shaped *net.OpError, as returned by net/http when the
+	// transport timeout fires.
+	netTimeout := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: timeoutError{},
+	}
+	// What http.Client.Do wraps the transport error in.
+	urlTimeout := &url.Error{
+		Op:  "Get",
+		URL: "http://garage.example/v2/GetBucketInfo",
+		Err: fmt.Errorf("net/http: timeout awaiting response headers"),
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context.DeadlineExceeded direct", context.DeadlineExceeded, true},
+		{"wrapped context.DeadlineExceeded", fmt.Errorf("calling admin: %w", context.DeadlineExceeded), true},
+		{"net.OpError with Timeout()==true", netTimeout, true},
+		{"url.Error with timeout substring", urlTimeout, true},
+		{"plain io timeout string", fmt.Errorf("read tcp: i/o timeout"), true},
+		{"unrelated error", fmt.Errorf("HTTP 500 layout not ready"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isTimeoutErr(tc.err)
+			if got != tc.want {
+				t.Errorf("isTimeoutErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// timeoutError is a minimal net.Error that reports Timeout()==true.
+// Mirrors the shape of internal/poll.DeadlineExceededError.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+// TestGetBucketWithTimeout_TransportTimeoutClassified verifies that a
+// net/http transport-level timeout (http.Client.Timeout firing before our
+// context's deadline) is reported as errBucketInfoTimeout — not as a
+// generic error. Regression for the case where the per-call deadline was
+// longer than the transport's own timeout (or vice-versa under load).
+//
+// Strategy: stand up a slow server, dial the *garage client* (which has its
+// own 90s http.Client.Timeout — too long for unit tests) via a custom
+// http.Client whose transport returns a *url.Error timeout to simulate the
+// underlying behaviour without waiting on real socket timeouts.
+//
+// Simpler: build a Garage client whose http.Client.Timeout is the limiting
+// factor, with the per-call ctx deadline well beyond it.
+func TestGetBucketWithTimeout_TransportTimeoutClassified(t *testing.T) {
+	// Server hangs — neither it nor the per-call ctx will respond before the
+	// http.Client.Timeout fires.
+	hangServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer hangServer.Close()
+
+	// Per-call ctx deadline well in excess of the transport timeout below
+	// — so the *url.Error path is the one that wins.
+	prev := getBucketInfoTimeout
+	getBucketInfoTimeout = 5 * time.Second
+	defer func() { getBucketInfoTimeout = prev }()
+
+	// Build a garage client with a short transport-level Timeout so the
+	// http.Client.Timeout fires first, producing a *url.Error{Timeout=true}.
+	gc := garage.NewClient(hangServer.URL, "test-token")
+	gc.SetHTTPTimeout(100 * time.Millisecond)
+
+	start := time.Now()
+	_, err := getBucketWithTimeout(context.Background(), gc, garage.GetBucketRequest{ID: testBucketID})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !isBucketLookupTimeout(err) {
+		t.Errorf("expected transport-level timeout to be classified as bucket lookup timeout; got err=%v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("call took %s, expected <2s (transport timeout should have fired first)", elapsed)
+	}
+}
+
+// TestHandleBucketLookupTimeout_PreservesConditionOnConflict verifies that
+// when r.Status().Update returns Conflict on the first attempt, the
+// UpdateStatusWithRetry helper's re-fetch + retry path still preserves the
+// BucketLookupStuck condition we set in-memory. The fix passes a mutate
+// callback that re-applies the condition after the helper re-fetches the
+// object from the fake client; without it, the freshly-fetched object's
+// old (empty) Conditions slice would silently overwrite our change.
+func TestHandleBucketLookupTimeout_PreservesConditionOnConflict(t *testing.T) {
+	ctx := context.Background()
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "conflict-bucket",
+			Namespace: testNamespace,
+			// Pre-seed counter so a single handleBucketLookupTimeout call hits
+			// the threshold and tries to set the condition.
+			Annotations: map[string]string{
+				garagev1beta1.AnnotationBucketLookupTimeouts: fmt.Sprintf("%d", BucketLookupStuckThreshold-1),
+			},
+		},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef:  garagev1beta1.ClusterReference{Name: testClusterName},
+			GlobalAlias: "conflict-alias",
+		},
+	}
+
+	s := runtime.NewScheme()
+	if err := garagev1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme v1beta1: %v", err)
+	}
+	if err := garagev1beta2.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme v1beta2: %v", err)
+	}
+
+	// Intercept SubResourceUpdate (used by Status().Update) and return
+	// Conflict on the FIRST call only. The helper should then re-fetch and
+	// retry — and the mutate callback must re-apply the condition so the
+	// retry succeeds with the condition persisted.
+	var statusUpdates int32
+	base := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(bucket).
+		WithStatusSubresource(&garagev1beta1.GarageBucket{}).
+		Build()
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if subResourceName == "status" && atomic.AddInt32(&statusUpdates, 1) == 1 {
+				gr := schema.GroupResource{Group: "garage.rajsingh.info", Resource: "garagebuckets"}
+				return errors.NewConflict(gr, obj.GetName(), fmt.Errorf("simulated conflict"))
+			}
+			return c.Status().Update(ctx, obj, opts...)
+		},
+	})
+	r := &GarageBucketReconciler{Client: wrapped, Scheme: s}
+
+	live := &garagev1beta1.GarageBucket{}
+	if err := wrapped.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, live); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+
+	res, err := r.handleBucketLookupTimeout(ctx, live)
+	if err != nil {
+		t.Fatalf("handleBucketLookupTimeout: %v", err)
+	}
+	if res.RequeueAfter != RequeueAfterUnhealthy {
+		t.Errorf("RequeueAfter=%s, want %s", res.RequeueAfter, RequeueAfterUnhealthy)
+	}
+	if got := atomic.LoadInt32(&statusUpdates); got < 2 {
+		t.Errorf("expected at least 2 status updates (conflict + retry), got %d", got)
+	}
+
+	// Re-fetch from the fake store: the condition MUST be persisted despite
+	// the conflict on the first attempt.
+	fresh := &garagev1beta1.GarageBucket{}
+	if err := wrapped.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, fresh); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	cond := meta.FindStatusCondition(fresh.Status.Conditions, garagev1beta1.ConditionBucketLookupStuck)
+	if cond == nil {
+		t.Fatal("BucketLookupStuck condition missing on retry: mutate fn likely not re-applied")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("cond.Status=%v, want True", cond.Status)
+	}
+	if cond.Reason != garagev1beta1.ReasonBucketLookupStuck {
+		t.Errorf("cond.Reason=%q, want %q", cond.Reason, garagev1beta1.ReasonBucketLookupStuck)
+	}
+	if !strings.Contains(cond.Message, "conflict-alias") {
+		t.Errorf("cond.Message does not name alias: %q", cond.Message)
 	}
 }

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -54,6 +56,58 @@ const (
 // GarageNode in Auto mode for a given storage-tier ordinal.
 func autoModeGarageNodeName(clusterName string, ordinal int32) string {
 	return fmt.Sprintf("%s-storage-%d", clusterName, ordinal)
+}
+
+// parseAutoModeOrdinal extracts the storage-tier ordinal embedded in a
+// GarageNode name produced by autoModeGarageNodeName. Returns (ordinal, true)
+// when the name matches `<cluster>-storage-<N>` for a non-negative integer N;
+// otherwise (0, false).
+func parseAutoModeOrdinal(nodeName, clusterName string) (int32, bool) {
+	prefix := clusterName + "-storage-"
+	if !strings.HasPrefix(nodeName, prefix) {
+		return 0, false
+	}
+	ord, err := strconv.ParseInt(nodeName[len(prefix):], 10, 32)
+	if err != nil || ord < 0 {
+		return 0, false
+	}
+	return int32(ord), true
+}
+
+// clusterOwnsAutoModePerNodeService reports whether the cluster controller
+// owns the per-pod RPC LoadBalancer Service for this node (in which case the
+// GarageNode controller must not create a duplicate). True when the GarageNode
+// CR carries the operator-managed label AND was named via autoModeGarageNodeName
+// AND has publicEndpoint configured as LoadBalancer (the only shape for which
+// reconcilePerNodeLoadBalancerServices creates `<cluster>-<ord>-rpc`).
+func clusterOwnsAutoModePerNodeService(node *garagev1beta1.GarageNode) bool {
+	if node == nil || node.Spec.PublicEndpoint == nil {
+		return false
+	}
+	if node.Spec.PublicEndpoint.Type != publicEndpointTypeLoadBalancer {
+		return false
+	}
+	if node.Labels[labelAppManagedBy] != managedByOperatorValue {
+		return false
+	}
+	if _, ok := parseAutoModeOrdinal(node.Name, node.Spec.ClusterRef.Name); !ok {
+		return false
+	}
+	return true
+}
+
+// effectiveNodeRPCServiceName returns the Service name from which to derive
+// rpc_public_addr for this GarageNode. For operator-owned auto-mode nodes the
+// cluster controller provisions the per-pod Service at `<cluster>-<ord>-rpc`
+// (see perNodeRPCServiceName); other nodes use the GarageNode-controller-owned
+// `<node>-rpc` name.
+func effectiveNodeRPCServiceName(node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) string {
+	if clusterOwnsAutoModePerNodeService(node) {
+		if ord, ok := parseAutoModeOrdinal(node.Name, cluster.Name); ok {
+			return perNodeRPCServiceName(cluster.Name, ord)
+		}
+	}
+	return node.Name + "-rpc"
 }
 
 // reconcileAutoModeStorageNodes generates and reconciles one GarageNode CR per
@@ -113,6 +167,9 @@ func (r *GarageClusterReconciler) reconcileAutoModeStorageNodes(ctx context.Cont
 			current.Spec.Zone = desired.Spec.Zone
 			current.Spec.Capacity = desired.Spec.Capacity
 			current.Spec.Tags = desired.Spec.Tags
+			// PublicEndpoint propagates from the cluster spec; treat as
+			// authoritative (the operator owns this field on auto-mode nodes).
+			current.Spec.PublicEndpoint = desired.Spec.PublicEndpoint
 			// We intentionally do not overwrite Storage.{Metadata,Data}.ExistingClaim
 			// when it's already set — that's used by migration to bind the new
 			// GarageNode to legacy PVCs, and overwriting would re-create from
@@ -326,11 +383,76 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 		},
 	}
 
+	// Propagate the cluster's publicEndpoint onto each operator-owned GarageNode
+	// so the GarageNode controller can derive rpc_public_addr from the per-pod
+	// LoadBalancer Service the cluster controller already provisions at
+	// `<cluster>-<ord>-rpc`. Without this, pods come up with no rpc_public_addr
+	// and peers learn the pod's TCP source IP — the `known_addrs` pollution
+	// failure mode that drops cross-cluster RPC reliability.
+	//
+	// Only LoadBalancer with perNode=true gives each pod its own externally
+	// routable address; the other PublicEndpoint shapes (single shared LB,
+	// shared NodePort) don't change behavior per-pod, so we skip propagation
+	// to avoid having the GarageNode controller create redundant per-node
+	// Services that overlap with the cluster-owned one.
+	if ep := cluster.Spec.PublicEndpoint; ep != nil &&
+		ep.Type == publicEndpointTypeLoadBalancer &&
+		ep.LoadBalancer != nil && ep.LoadBalancer.PerNode {
+		nodeEP, err := convertClusterPublicEndpointToNode(ep)
+		if err != nil {
+			return nil, fmt.Errorf("converting publicEndpoint for GarageNode %s: %w", name, err)
+		}
+		node.Spec.PublicEndpoint = nodeEP
+	}
+
 	if err := controllerutil.SetControllerReference(cluster, node, r.Scheme); err != nil {
 		return nil, err
 	}
 
 	return node, nil
+}
+
+// publicEndpointsEqual returns true when two GarageNode publicEndpoint configs
+// have the same observable shape. JSON marshaling normalizes ordering and
+// nil/empty distinctions, which is sufficient for drift detection on a field
+// the operator overwrites wholesale.
+func publicEndpointsEqual(a, b *garagev1beta1.PublicEndpointConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	ab, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}
+
+// convertClusterPublicEndpointToNode copies a v1beta2.PublicEndpointConfig into
+// a v1beta1.PublicEndpointConfig by JSON round-trip. The two structures are
+// field-compatible (see api/v1beta1/garagecluster_conversion.go for the
+// authoritative use of this same pattern); a JSON round-trip avoids hand-coding
+// the conversion and ensures we automatically pick up any new fields added on
+// either side.
+func convertClusterPublicEndpointToNode(src *garagev1beta2.PublicEndpointConfig) (*garagev1beta1.PublicEndpointConfig, error) {
+	if src == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(src)
+	if err != nil {
+		return nil, err
+	}
+	dst := &garagev1beta1.PublicEndpointConfig{}
+	if err := json.Unmarshal(b, dst); err != nil {
+		return nil, err
+	}
+	return dst, nil
 }
 
 // autoModeStorageNodeNeedsUpdate returns true when the desired GarageNode spec
@@ -348,6 +470,9 @@ func autoModeStorageNodeNeedsUpdate(current, desired *garagev1beta1.GarageNode) 
 		}
 	}
 	if !tagsEqualCluster(current.Spec.Tags, desired.Spec.Tags) {
+		return true
+	}
+	if !publicEndpointsEqual(current.Spec.PublicEndpoint, desired.Spec.PublicEndpoint) {
 		return true
 	}
 	// Storage size / storage class drift only meaningful when not bound to existingClaim.
@@ -479,10 +604,29 @@ func (r *GarageClusterReconciler) migrateLegacyStorageSTSIfNeeded(ctx context.Co
 		if err := UpdateStatusWithRetry(ctx, r.Client, cluster, apply); err != nil {
 			return fmt.Errorf("clearing migration condition for retry: %w", err)
 		}
-		delete(cluster.Annotations, garagev1beta1.AnnotationRetryMigration)
-		if err := r.Update(ctx, cluster); err != nil {
+		// Strip the retry annotation with conflict retry. Without retry, a
+		// competing reconcile that bumped ResourceVersion between the status
+		// write above and this Update would 409 and the annotation persists —
+		// the next reconcile would clear the condition again, looping forever
+		// with no user-visible signal.
+		key := client.ObjectKeyFromObject(cluster)
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest := &garagev1beta2.GarageCluster{}
+			if err := r.Get(ctx, key, latest); err != nil {
+				return err
+			}
+			if _, ok := latest.Annotations[garagev1beta1.AnnotationRetryMigration]; !ok {
+				// Already stripped by a concurrent actor; nothing to do.
+				return nil
+			}
+			delete(latest.Annotations, garagev1beta1.AnnotationRetryMigration)
+			return r.Update(ctx, latest)
+		}); err != nil {
 			return fmt.Errorf("removing retry-migration annotation: %w", err)
 		}
+		// Keep the in-memory cluster in sync so the rest of this reconcile pass
+		// sees the annotation as removed.
+		delete(cluster.Annotations, garagev1beta1.AnnotationRetryMigration)
 	}
 
 	// Short-circuit when the condition reports Completed.

--- a/internal/controller/garagecluster_automode_test.go
+++ b/internal/controller/garagecluster_automode_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +37,29 @@ import (
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
 )
+
+// conflictInjectingClient wraps a client.Client and injects a Conflict error
+// on the first Update of a target GarageCluster, then passes through. Used
+// by the bug #3 regression test to exercise the retry-on-conflict path in
+// migrateLegacyStorageSTSIfNeeded.
+type conflictInjectingClient struct {
+	client.Client
+	targetName         string
+	conflictsRemaining int
+	updates            int
+}
+
+func (c *conflictInjectingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updates++
+	if c.conflictsRemaining > 0 {
+		if gc, ok := obj.(*garagev1beta2.GarageCluster); ok && gc.Name == c.targetName {
+			c.conflictsRemaining--
+			gvr := schema.GroupResource{Group: garagev1beta2.GroupVersion.Group, Resource: "garageclusters"}
+			return errors.NewConflict(gvr, gc.Name, fmt.Errorf("injected conflict"))
+		}
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
 
 // uniqueClusterName returns a per-test cluster name based on the spec subject
 // so each test gets its own resources in the shared testNamespace.
@@ -456,6 +481,63 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 			Expect(updated.Status.Phase).To(Equal("Degraded"))
 		})
 
+		It("strips the retry-migration annotation through a Conflict on first Update", func() {
+			// Regression for bug #3: when a competing reconcile bumps
+			// ResourceVersion between the migration status write and the
+			// annotation-strip Update, the bare r.Update returned Conflict
+			// and the annotation persisted forever — looping the migration.
+			// The fix wraps the strip in retry.RetryOnConflict.
+			clusterNN = types.NamespacedName{Name: uniqueClusterName("auto-retry-anno"), Namespace: testNamespace}
+			cluster = &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        clusterNN.Name,
+					Namespace:   testNamespace,
+					Annotations: map[string]string{garagev1beta1.AnnotationRetryMigration: annotationTrue},
+				},
+				Spec: garagev1beta2.GarageClusterSpec{
+					LayoutPolicy: LayoutPolicyAuto,
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 1,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			// Wrap k8sClient so the first Update of *this* cluster returns
+			// Conflict, then passes through. Status().Update() and Get() are
+			// unaffected so UpdateStatusWithRetry still progresses; the
+			// retry-on-conflict loop being exercised is the one around the
+			// annotation strip.
+			injector := &conflictInjectingClient{
+				Client:             k8sClient,
+				targetName:         clusterNN.Name,
+				conflictsRemaining: 1,
+			}
+			testReconciler := &GarageClusterReconciler{Client: injector, Scheme: k8sClient.Scheme()}
+
+			Expect(testReconciler.migrateLegacyStorageSTSIfNeeded(ctx, cluster)).To(Succeed())
+
+			// First Update was returned Conflict by the wrapper; the retry
+			// loop must have re-fetched and succeeded on the second attempt.
+			Expect(injector.conflictsRemaining).To(Equal(0), "wrapper should have consumed its conflict budget")
+			Expect(injector.updates).To(BeNumerically(">=", 2), "retry loop should issue at least two Update calls (conflict + success)")
+
+			// Annotation must be removed on the server.
+			fresh := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, clusterNN, fresh)).To(Succeed())
+			Expect(fresh.Annotations).NotTo(HaveKey(garagev1beta1.AnnotationRetryMigration))
+
+			// Migration condition should still be set to Completed (no legacy
+			// STS exists for this cluster).
+			cond := meta.FindStatusCondition(fresh.Status.Conditions, garagev1beta1.ConditionLegacySTSMigrated)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("Completed"))
+		})
+
 		It("is idempotent after Completed", func() {
 			clusterNN = types.NamespacedName{Name: uniqueClusterName("auto-idem"), Namespace: testNamespace}
 			cluster = &garagev1beta2.GarageCluster{
@@ -485,6 +567,154 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 			Expect(after.Status).To(Equal(before.Status))
 			Expect(after.Reason).To(Equal(before.Reason))
 		})
+	})
+})
+
+var _ = Describe("buildAutoModeStorageNode PublicEndpoint propagation (bug #7)", func() {
+	// Regression for bug #7: per-node LoadBalancer Services were created by
+	// the cluster controller at `<cluster>-<i>-rpc` but the per-node
+	// GarageNodes never had spec.PublicEndpoint set, so the GarageNode
+	// controller had no signal to derive rpc_public_addr from the LB. Pods
+	// came up advertising the pod TCP source IP — the `known_addrs`
+	// pollution failure mode.
+
+	makeReconciler := func() *GarageClusterReconciler {
+		return &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+	}
+	makeCluster := func(name string, ep *garagev1beta2.PublicEndpointConfig) *garagev1beta2.GarageCluster {
+		return &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: "test-uid"},
+			Spec: garagev1beta2.GarageClusterSpec{
+				LayoutPolicy: LayoutPolicyAuto,
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas: 2,
+					Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+				},
+				Replication:    &garagev1beta2.ReplicationConfig{Factor: 2},
+				PublicEndpoint: ep,
+			},
+		}
+	}
+
+	It("propagates LoadBalancer+perNode=true onto each operator-owned GarageNode", func() {
+		r := makeReconciler()
+		cluster := makeCluster("ep-perNode", &garagev1beta2.PublicEndpointConfig{
+			Type: publicEndpointTypeLoadBalancer,
+			LoadBalancer: &garagev1beta2.LoadBalancerEndpointConfig{
+				PerNode: true,
+				ServiceMeta: garagev1beta2.ServiceMeta{
+					Annotations: map[string]string{"example.com/key": "bar"},
+				},
+			},
+		})
+
+		for ord := int32(0); ord < 2; ord++ {
+			node, err := r.buildAutoModeStorageNode(cluster, ord, "", "", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(node.Spec.PublicEndpoint).NotTo(BeNil(),
+				"buildAutoModeStorageNode must propagate PublicEndpoint to operator-owned GarageNode ord=%d", ord)
+			Expect(node.Spec.PublicEndpoint.Type).To(Equal(publicEndpointTypeLoadBalancer))
+			Expect(node.Spec.PublicEndpoint.LoadBalancer).NotTo(BeNil())
+			Expect(node.Spec.PublicEndpoint.LoadBalancer.PerNode).To(BeTrue())
+			Expect(node.Spec.PublicEndpoint.LoadBalancer.Annotations).To(HaveKeyWithValue("foo", "bar"))
+
+			// effectiveNodeRPCServiceName must point at the cluster-owned
+			// per-node Service so the GarageNode controller derives
+			// rpc_public_addr from the right LB.
+			Expect(effectiveNodeRPCServiceName(node, cluster)).
+				To(Equal(perNodeRPCServiceName(cluster.Name, ord)))
+
+			// And clusterOwnsAutoModePerNodeService must report true so
+			// reconcileNodeService skips creating a duplicate Service.
+			Expect(clusterOwnsAutoModePerNodeService(node)).To(BeTrue())
+		}
+	})
+
+	It("does NOT propagate a shared (non-perNode) LoadBalancer endpoint", func() {
+		// A single shared LB Service doesn't give per-pod addressing, so
+		// propagating it would just make the GarageNode controller try to
+		// create a duplicate per-node Service for no benefit.
+		r := makeReconciler()
+		cluster := makeCluster("ep-shared", &garagev1beta2.PublicEndpointConfig{
+			Type: publicEndpointTypeLoadBalancer,
+			LoadBalancer: &garagev1beta2.LoadBalancerEndpointConfig{
+				PerNode: false,
+			},
+		})
+		node, err := r.buildAutoModeStorageNode(cluster, 0, "", "", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Spec.PublicEndpoint).To(BeNil())
+		Expect(clusterOwnsAutoModePerNodeService(node)).To(BeFalse())
+		Expect(effectiveNodeRPCServiceName(node, cluster)).To(Equal(node.Name + "-rpc"))
+	})
+
+	It("does NOT propagate when the cluster has no PublicEndpoint", func() {
+		r := makeReconciler()
+		cluster := makeCluster("ep-none", nil)
+		node, err := r.buildAutoModeStorageNode(cluster, 0, "", "", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Spec.PublicEndpoint).To(BeNil())
+	})
+
+	It("treats PublicEndpoint changes as drift on existing operator-owned nodes", func() {
+		// reconcileAutoModeStorageNodes must propagate PublicEndpoint
+		// changes to existing GarageNodes; otherwise toggling perNode after
+		// initial reconcile would leave the operator-owned nodes without
+		// their LB hint.
+		r := makeReconciler()
+
+		// Start with no PublicEndpoint, then add one.
+		clusterName := uniqueClusterName("ep-drift")
+		cluster := makeCluster(clusterName, nil)
+		cluster.UID = "" // let the API server assign
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		DeferCleanup(func() {
+			fresh := &garagev1beta2.GarageCluster{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: testNamespace}, fresh); err == nil {
+				fresh.Finalizers = nil
+				_ = k8sClient.Update(ctx, fresh)
+				_ = k8sClient.Delete(ctx, fresh)
+			}
+			gnList := &garagev1beta1.GarageNodeList{}
+			_ = k8sClient.List(ctx, gnList, client.InNamespace(testNamespace), client.MatchingLabels(map[string]string{labelCluster: clusterName}))
+			for i := range gnList.Items {
+				n := gnList.Items[i]
+				n.Finalizers = nil
+				_ = k8sClient.Update(ctx, &n)
+				_ = k8sClient.Delete(ctx, &n)
+			}
+		})
+
+		Expect(r.reconcileAutoModeStorageNodes(ctx, cluster)).To(Succeed())
+		gnList := listOperatorOwnedStorageNodes(clusterName)
+		Expect(gnList.Items).To(HaveLen(2))
+		for _, n := range gnList.Items {
+			Expect(n.Spec.PublicEndpoint).To(BeNil())
+		}
+
+		// Add the PublicEndpoint and reconcile again — existing nodes
+		// should pick up the new PublicEndpoint via the drift path.
+		fresh := &garagev1beta2.GarageCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: testNamespace}, fresh)).To(Succeed())
+		fresh.Spec.PublicEndpoint = &garagev1beta2.PublicEndpointConfig{
+			Type: publicEndpointTypeLoadBalancer,
+			LoadBalancer: &garagev1beta2.LoadBalancerEndpointConfig{
+				PerNode: true,
+			},
+		}
+		Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+
+		Expect(r.reconcileAutoModeStorageNodes(ctx, fresh)).To(Succeed())
+
+		gnList = listOperatorOwnedStorageNodes(clusterName)
+		Expect(gnList.Items).To(HaveLen(2))
+		for _, n := range gnList.Items {
+			Expect(n.Spec.PublicEndpoint).NotTo(BeNil(), "drift detection must propagate PublicEndpoint to existing node %s", n.Name)
+			Expect(n.Spec.PublicEndpoint.Type).To(Equal(publicEndpointTypeLoadBalancer))
+			Expect(n.Spec.PublicEndpoint.LoadBalancer).NotTo(BeNil())
+			Expect(n.Spec.PublicEndpoint.LoadBalancer.PerNode).To(BeTrue())
+		}
 	})
 })
 

--- a/internal/controller/garagecluster_automode_test.go
+++ b/internal/controller/garagecluster_automode_test.go
@@ -617,7 +617,7 @@ var _ = Describe("buildAutoModeStorageNode PublicEndpoint propagation (bug #7)",
 			Expect(node.Spec.PublicEndpoint.Type).To(Equal(publicEndpointTypeLoadBalancer))
 			Expect(node.Spec.PublicEndpoint.LoadBalancer).NotTo(BeNil())
 			Expect(node.Spec.PublicEndpoint.LoadBalancer.PerNode).To(BeTrue())
-			Expect(node.Spec.PublicEndpoint.LoadBalancer.Annotations).To(HaveKeyWithValue("foo", "bar"))
+			Expect(node.Spec.PublicEndpoint.LoadBalancer.Annotations).To(HaveKeyWithValue("example.com/key", "bar"))
 
 			// effectiveNodeRPCServiceName must point at the cluster-owned
 			// per-node Service so the GarageNode controller derives

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -32,6 +32,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -168,6 +169,13 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Create or update API Service (primary <cr>, scoped to storage tier when
 	// present, else to the gateway tier for edge-gateway clusters)
 	if err := r.reconcileAPIService(ctx, cluster); err != nil {
+		return r.updateStatus(ctx, cluster, PhaseFailed, err)
+	}
+
+	// Reconcile PodDisruptionBudget for the storage tier (covers all per-node
+	// STSes via cluster+tier label selector, since each per-node STS has 1
+	// replica and a per-STS PDB would be meaningless).
+	if err := r.reconcilePodDisruptionBudget(ctx, cluster); err != nil {
 		return r.updateStatus(ctx, cluster, PhaseFailed, err)
 	}
 
@@ -1512,6 +1520,89 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 
 	log.Info("Reconciling API Service", "name", serviceName, "tier", primaryTier)
 	return reconcileService(ctx, r.Client, svc, cluster, r.Scheme)
+}
+
+// reconcilePodDisruptionBudget creates/updates a PDB covering the storage tier
+// when spec.storage.podDisruptionBudget.enabled is true. Deletes the PDB if it
+// exists but is no longer wanted (storage tier dropped, or enabled flipped to
+// false). PDB targets pods via the operator-stamped cluster+tier label pair so
+// it spans every per-node StatefulSet introduced in #190 — a per-STS PDB on a
+// 1-replica STS is meaningless. Regression of #196: this reconcile was deleted
+// in #192 along with the legacy cluster-level StatefulSet, but the spec field
+// and its CRD validation stayed in place, silently no-op'ing user PDB configs.
+func (r *GarageClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	pdbName := cluster.Name
+	pdbKey := types.NamespacedName{Name: pdbName, Namespace: cluster.Namespace}
+
+	wantPDB := cluster.HasStorageTier() &&
+		cluster.Spec.Storage.PodDisruptionBudget != nil &&
+		cluster.Spec.Storage.PodDisruptionBudget.Enabled
+
+	if !wantPDB {
+		existing := &policyv1.PodDisruptionBudget{}
+		if err := r.Get(ctx, pdbKey, existing); err == nil {
+			log.Info("Deleting PDB (no longer requested)", "name", pdbName)
+			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("deleting PDB: %w", err)
+			}
+		} else if !errors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
+	pdbCfg := cluster.Spec.Storage.PodDisruptionBudget
+	spec := policyv1.PodDisruptionBudgetSpec{
+		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+			labelCluster: cluster.Name,
+			labelTier:    tierStorage,
+		}},
+	}
+	// Webhook enforces exactly one of MinAvailable/MaxUnavailable; defaulter
+	// fills MinAvailable=1 when both are unset (mirrors the v1beta1 default).
+	if pdbCfg.MinAvailable != nil {
+		spec.MinAvailable = pdbCfg.MinAvailable
+	} else if pdbCfg.MaxUnavailable != nil {
+		spec.MaxUnavailable = pdbCfg.MaxUnavailable
+	} else {
+		one := intstr.FromInt(1)
+		spec.MinAvailable = &one
+	}
+
+	desired := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pdbName,
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				labelAppName:      defaultAppName,
+				labelAppInstance:  cluster.Name,
+				labelAppManagedBy: operatorName,
+				labelCluster:      cluster.Name,
+				labelTier:         tierStorage,
+			},
+		},
+		Spec: spec,
+	}
+	if err := controllerutil.SetControllerReference(cluster, desired, r.Scheme); err != nil {
+		return err
+	}
+
+	existing := &policyv1.PodDisruptionBudget{}
+	err := r.Get(ctx, pdbKey, existing)
+	if errors.IsNotFound(err) {
+		log.Info("Creating PDB", "name", pdbName)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
+		return nil
+	}
+	existing.Spec = desired.Spec
+	log.Info("Updating PDB", "name", pdbName)
+	return r.Update(ctx, existing)
 }
 
 // reconcileGatewayAPIService reconciles a tier-scoped <cr>-gateway Service so

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -1525,11 +1525,15 @@ func (r *GarageClusterReconciler) reconcileAPIService(ctx context.Context, clust
 // reconcilePodDisruptionBudget creates/updates a PDB covering the storage tier
 // when spec.storage.podDisruptionBudget.enabled is true. Deletes the PDB if it
 // exists but is no longer wanted (storage tier dropped, or enabled flipped to
-// false). PDB targets pods via the operator-stamped cluster+tier label pair so
-// it spans every per-node StatefulSet introduced in #190 — a per-STS PDB on a
-// 1-replica STS is meaningless. Regression of #196: this reconcile was deleted
-// in #192 along with the legacy cluster-level StatefulSet, but the spec field
-// and its CRD validation stayed in place, silently no-op'ing user PDB configs.
+// false). Regression of #196: this reconcile was deleted in #192 along with
+// the legacy cluster-level StatefulSet, but the spec field and its CRD
+// validation stayed in place, silently no-op'ing user PDB configs.
+//
+// Selector matches pre-#192 ({labelAppName, labelAppInstance, labelTier}) so
+// existing PDBs upgrade in place without hitting the spec.selector immutability
+// error. Storage pods (per-node STSes from #190) carry these labels as well as
+// {labelCluster, labelTier}, so either selector is functionally correct; the
+// pre-#192 shape is preferred only for upgrade compatibility.
 func (r *GarageClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
 	log := logf.FromContext(ctx)
 	pdbName := cluster.Name
@@ -1541,46 +1545,50 @@ func (r *GarageClusterReconciler) reconcilePodDisruptionBudget(ctx context.Conte
 
 	if !wantPDB {
 		existing := &policyv1.PodDisruptionBudget{}
-		if err := r.Get(ctx, pdbKey, existing); err == nil {
-			log.Info("Deleting PDB (no longer requested)", "name", pdbName)
-			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("deleting PDB: %w", err)
-			}
-		} else if !errors.IsNotFound(err) {
+		err := r.Get(ctx, pdbKey, existing)
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
 			return err
+		}
+		// Don't touch a PDB we don't own — could be user- or policy-engine-managed.
+		if !metav1.IsControlledBy(existing, cluster) {
+			return nil
+		}
+		log.Info("Deleting PDB (no longer requested)", "name", pdbName)
+		if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("deleting PDB: %w", err)
 		}
 		return nil
 	}
 
 	pdbCfg := cluster.Spec.Storage.PodDisruptionBudget
 	spec := policyv1.PodDisruptionBudgetSpec{
-		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
-			labelCluster: cluster.Name,
-			labelTier:    tierStorage,
-		}},
+		Selector: &metav1.LabelSelector{MatchLabels: r.selectorLabelsForTier(cluster, tierStorage)},
 	}
-	// Webhook enforces exactly one of MinAvailable/MaxUnavailable; defaulter
-	// fills MinAvailable=1 when both are unset (mirrors the v1beta1 default).
-	if pdbCfg.MinAvailable != nil {
+	switch {
+	case pdbCfg.MinAvailable != nil:
 		spec.MinAvailable = pdbCfg.MinAvailable
-	} else if pdbCfg.MaxUnavailable != nil {
+	case pdbCfg.MaxUnavailable != nil:
 		spec.MaxUnavailable = pdbCfg.MaxUnavailable
-	} else {
-		one := intstr.FromInt(1)
-		spec.MinAvailable = &one
+	default:
+		// Default to (replicas-1) with a floor of 1 — preserves quorum on drain
+		// for 3+ replica clusters. Matches the pre-#192 default and the warning
+		// emitted by the v1beta1/v1beta2 validating webhooks.
+		replicas := cluster.StorageReplicas()
+		if replicas < 2 {
+			replicas = 2
+		}
+		minAvail := intstr.FromInt(int(replicas - 1))
+		spec.MinAvailable = &minAvail
 	}
 
 	desired := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pdbName,
 			Namespace: cluster.Namespace,
-			Labels: map[string]string{
-				labelAppName:      defaultAppName,
-				labelAppInstance:  cluster.Name,
-				labelAppManagedBy: operatorName,
-				labelCluster:      cluster.Name,
-				labelTier:         tierStorage,
-			},
+			Labels:    r.labelsForTier(cluster, tierStorage),
 		},
 		Spec: spec,
 	}
@@ -1597,12 +1605,35 @@ func (r *GarageClusterReconciler) reconcilePodDisruptionBudget(ctx context.Conte
 	if err != nil {
 		return err
 	}
-	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
+	// If a foreign PDB already squats on our name, leave it alone rather than
+	// fight a policy engine. The operator surfaces this via the reconcile log;
+	// users can rename the foreign PDB or disable spec.storage.podDisruptionBudget.
+	if existing.UID != "" && len(existing.OwnerReferences) > 0 && !metav1.IsControlledBy(existing, cluster) {
+		log.Info("PDB exists but is not controlled by this GarageCluster; skipping update", "name", pdbName)
 		return nil
 	}
+	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) &&
+		equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+		metav1.IsControlledBy(existing, cluster) {
+		return nil
+	}
+	existing.Labels = desired.Labels
+	existing.OwnerReferences = desired.OwnerReferences
 	existing.Spec = desired.Spec
 	log.Info("Updating PDB", "name", pdbName)
-	return r.Update(ctx, existing)
+	if err := r.Update(ctx, existing); err != nil {
+		// PDB selector is immutable post-creation. If an upgrade-from-old-shape
+		// PDB has a different selector, recreate it so the new selector lands.
+		if errors.IsInvalid(err) {
+			log.Info("PDB update rejected (likely selector immutable); recreating", "name", pdbName)
+			if delErr := r.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {
+				return fmt.Errorf("deleting PDB for recreate: %w", delErr)
+			}
+			return r.Create(ctx, desired)
+		}
+		return err
+	}
+	return nil
 }
 
 // reconcileGatewayAPIService reconciles a tier-scoped <cr>-gateway Service so
@@ -4819,6 +4850,7 @@ func (r *GarageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(&corev1.PersistentVolumeClaim{}, pvcMapper).
 		Named("garagecluster").
 		Complete(r)

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -24,10 +24,12 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -600,5 +602,108 @@ var _ = Describe("GarageCluster Controller", func() {
 			}, autoSecret)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
+	})
+})
+
+// Regression guard for #196: spec.storage.podDisruptionBudget was a no-op
+// after #192 removed the legacy reconcilePDB along with the cluster-level
+// StatefulSet. The replacement reconcile lives on the cluster controller and
+// targets the storage tier via {labelCluster, labelTier=storage} so it
+// covers every per-node StatefulSet introduced in #190.
+var _ = Describe("GarageCluster PodDisruptionBudget reconcile", func() {
+	const clusterName = "pdb-cluster"
+	var (
+		ctx        context.Context
+		reconciler *GarageClusterReconciler
+		key        types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		reconciler = &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		key = types.NamespacedName{Name: clusterName, Namespace: testNamespace}
+	})
+
+	AfterEach(func() {
+		// Drop finalizer first so Delete actually GC's — the cluster's normal
+		// finalizer makes admin-API calls that envtest can't service.
+		cluster := &garagev1beta2.GarageCluster{}
+		if err := k8sClient.Get(ctx, key, cluster); err == nil {
+			cluster.Finalizers = nil
+			_ = k8sClient.Update(ctx, cluster)
+			_ = k8sClient.Delete(ctx, cluster)
+		}
+		_ = k8sClient.Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace}})
+		_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: clusterName + "-rpc-secret", Namespace: testNamespace}})
+		_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: clusterName + "-config", Namespace: testNamespace}})
+	})
+
+	newCluster := func(pdb *garagev1beta2.PodDisruptionBudgetConfig) *garagev1beta2.GarageCluster {
+		return &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace},
+			Spec: garagev1beta2.GarageClusterSpec{
+				Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas:            3,
+					Metadata:            &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					Data:                &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					PodDisruptionBudget: pdb,
+				},
+			},
+		}
+	}
+
+	driveReconciles := func() {
+		// Twice — first adds finalizer, second creates resources.
+		for i := 0; i < 2; i++ {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	It("creates a PDB with MinAvailable=1 when enabled with no explicit value", func() {
+		Expect(k8sClient.Create(ctx, newCluster(&garagev1beta2.PodDisruptionBudgetConfig{Enabled: true}))).To(Succeed())
+		driveReconciles()
+
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, key, pdb)).To(Succeed())
+		Expect(pdb.Spec.MinAvailable).NotTo(BeNil())
+		Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(1))
+		Expect(pdb.Spec.MaxUnavailable).To(BeNil())
+		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelCluster, clusterName))
+		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelTier, tierStorage))
+	})
+
+	It("honors an explicit MaxUnavailable", func() {
+		one := intstr.FromInt(1)
+		Expect(k8sClient.Create(ctx, newCluster(&garagev1beta2.PodDisruptionBudgetConfig{Enabled: true, MaxUnavailable: &one}))).To(Succeed())
+		driveReconciles()
+
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, key, pdb)).To(Succeed())
+		Expect(pdb.Spec.MinAvailable).To(BeNil())
+		Expect(pdb.Spec.MaxUnavailable).NotTo(BeNil())
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).To(Equal(1))
+	})
+
+	It("deletes the PDB when enabled flips to false", func() {
+		Expect(k8sClient.Create(ctx, newCluster(&garagev1beta2.PodDisruptionBudgetConfig{Enabled: true}))).To(Succeed())
+		driveReconciles()
+		Expect(k8sClient.Get(ctx, key, &policyv1.PodDisruptionBudget{})).To(Succeed())
+
+		updated := &garagev1beta2.GarageCluster{}
+		Expect(k8sClient.Get(ctx, key, updated)).To(Succeed())
+		updated.Spec.Storage.PodDisruptionBudget.Enabled = false
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+		driveReconciles()
+
+		Expect(errors.IsNotFound(k8sClient.Get(ctx, key, &policyv1.PodDisruptionBudget{}))).To(BeTrue())
+	})
+
+	It("does not create a PDB when the field is omitted", func() {
+		Expect(k8sClient.Create(ctx, newCluster(nil))).To(Succeed())
+		driveReconciles()
+
+		Expect(errors.IsNotFound(k8sClient.Get(ctx, key, &policyv1.PodDisruptionBudget{}))).To(BeTrue())
 	})
 })

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -661,16 +661,20 @@ var _ = Describe("GarageCluster PodDisruptionBudget reconcile", func() {
 		}
 	}
 
-	It("creates a PDB with MinAvailable=1 when enabled with no explicit value", func() {
+	It("defaults MinAvailable to replicas-1 to preserve quorum on drain", func() {
+		// newCluster sets storage.replicas=3 → expect MinAvailable=2.
 		Expect(k8sClient.Create(ctx, newCluster(&garagev1beta2.PodDisruptionBudgetConfig{Enabled: true}))).To(Succeed())
 		driveReconciles()
 
 		pdb := &policyv1.PodDisruptionBudget{}
 		Expect(k8sClient.Get(ctx, key, pdb)).To(Succeed())
 		Expect(pdb.Spec.MinAvailable).NotTo(BeNil())
-		Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(1))
+		Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(2))
 		Expect(pdb.Spec.MaxUnavailable).To(BeNil())
-		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelCluster, clusterName))
+		// Selector matches the pre-#192 shape so existing PDBs upgrade in place
+		// (spec.selector is immutable).
+		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelAppName, defaultAppName))
+		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelAppInstance, clusterName))
 		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelTier, tierStorage))
 	})
 
@@ -705,5 +709,66 @@ var _ = Describe("GarageCluster PodDisruptionBudget reconcile", func() {
 		driveReconciles()
 
 		Expect(errors.IsNotFound(k8sClient.Get(ctx, key, &policyv1.PodDisruptionBudget{}))).To(BeTrue())
+	})
+
+	It("floors MinAvailable at 1 for a single-replica cluster", func() {
+		size := resource.MustParse("1Gi")
+		Expect(k8sClient.Create(ctx, &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace},
+			Spec: garagev1beta2.GarageClusterSpec{
+				Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas:            1,
+					Metadata:            &garagev1beta2.VolumeConfig{Size: &size},
+					Data:                &garagev1beta2.VolumeConfig{Size: &size},
+					PodDisruptionBudget: &garagev1beta2.PodDisruptionBudgetConfig{Enabled: true},
+				},
+			},
+		})).To(Succeed())
+		driveReconciles()
+
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, key, pdb)).To(Succeed())
+		Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(1))
+	})
+
+	It("leaves a foreign PDB with the same name alone (no ownerRef)", func() {
+		foreign := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: testNamespace,
+				Labels:    map[string]string{"managed-by": "policy-engine"},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "policy.example.com/v1",
+					Kind:       "PolicyTemplate",
+					Name:       "external",
+					UID:        "00000000-0000-0000-0000-000000000001",
+					Controller: ptr.To(true),
+				}},
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"foreign": annotationTrue}},
+				MinAvailable: ptr.To(intstr.FromInt(7)),
+			},
+		}
+		Expect(k8sClient.Create(ctx, foreign)).To(Succeed())
+
+		Expect(k8sClient.Create(ctx, newCluster(&garagev1beta2.PodDisruptionBudgetConfig{Enabled: true}))).To(Succeed())
+		driveReconciles()
+
+		got := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, key, got)).To(Succeed())
+		Expect(got.Spec.MinAvailable.IntValue()).To(Equal(7))
+		Expect(got.Spec.Selector.MatchLabels).To(HaveKeyWithValue("foreign", "true"))
+
+		// And the foreign PDB also isn't deleted when wantPDB=false.
+		updated := &garagev1beta2.GarageCluster{}
+		Expect(k8sClient.Get(ctx, key, updated)).To(Succeed())
+		updated.Spec.Storage.PodDisruptionBudget.Enabled = false
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+		driveReconciles()
+		Expect(k8sClient.Get(ctx, key, &policyv1.PodDisruptionBudget{})).To(Succeed())
+
+		_ = k8sClient.Delete(ctx, foreign)
 	})
 })

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,6 +46,11 @@ import (
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
+
+// finalizeOrphanedTimeout caps the best-effort layout-removal call made when
+// the parent GarageCluster CR has already vanished. We don't want a hung
+// external admin API to deadlock GarageNode finalization, so cap aggressively.
+const finalizeOrphanedTimeout = 5 * time.Second
 
 const (
 	garageNodeFinalizer = "garagenode.garage.rajsingh.info/finalizer"
@@ -88,13 +94,26 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		Namespace: clusterNamespace,
 	}, cluster); err != nil {
 		// Cluster gone (the cluster-level finalizer ran ahead of GC catching up to
-		// this GarageNode) → no admin API to talk to; the layout entries were
-		// already drained by the cluster finalizer's removeNodesFromLayout call.
-		// Drop the per-node finalizer so the GarageNode + its owned STS get GC'd
-		// instead of wedging this namespace forever.
+		// this GarageNode) → no admin API to talk to via the cluster spec; for
+		// unified clusters the layout entries were already drained by the cluster
+		// finalizer's removeNodesFromLayout call, so nothing to do. For edge
+		// gateways (spec.connectTo.adminApiEndpoint), the layout entry still lives
+		// on the *remote* cluster — make a best-effort attempt against the admin
+		// endpoint we captured on the last successful reconcile so we don't leave
+		// a dead layout entry on the federated peer. Either way, never block
+		// finalizer release indefinitely — the worst case is a manual
+		// `garage layout remove` on the remote.
 		if errors.IsNotFound(err) && !node.DeletionTimestamp.IsZero() {
 			if controllerutil.ContainsFinalizer(node, garageNodeFinalizer) {
-				log.Info("Parent cluster already deleted; releasing GarageNode finalizer", "node", node.Name)
+				if err := r.attemptOrphanedFinalize(ctx, node); err != nil {
+					log.Info("Best-effort layout cleanup against captured admin endpoint failed; releasing finalizer anyway",
+						"node", node.Name, "endpoint", node.Status.ClusterAdminEndpoint, "error", err.Error())
+				} else if node.Status.ClusterAdminEndpoint != "" {
+					log.Info("Removed node from layout via captured admin endpoint after parent cluster deletion",
+						"node", node.Name, "endpoint", node.Status.ClusterAdminEndpoint)
+				} else {
+					log.Info("Parent cluster already deleted; releasing GarageNode finalizer", "node", node.Name)
+				}
 				controllerutil.RemoveFinalizer(node, garageNodeFinalizer)
 				if updateErr := r.Update(ctx, node); updateErr != nil {
 					return ctrl.Result{}, updateErr
@@ -223,6 +242,12 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err != nil {
 		return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("failed to create garage client: %w", err))
 	}
+
+	// Capture the resolved admin endpoint + token ref on status so the
+	// orphaned-finalize path can still reach the right Garage admin API
+	// (especially the *remote* one for edge gateways) when the parent
+	// GarageCluster CR has been deleted before we get a chance to clean up.
+	captureAdminEndpoint(node, cluster, r.ClusterDomain)
 
 	// Reconcile the node layout
 	if err := r.reconcileNode(ctx, node, cluster, garageClient); err != nil {
@@ -1245,6 +1270,123 @@ func (r *GarageNodeReconciler) connectNodeToCluster(ctx context.Context, garageC
 	return nil
 }
 
+// attemptOrphanedFinalize tries a best-effort layout removal when the parent
+// GarageCluster CR has already been deleted. Returns nil when there is nothing
+// to do (no captured endpoint, no node ID, or remote token secret already
+// gone). Returns an error on a real RPC failure so the caller can log it, but
+// the caller MUST release the finalizer regardless — we never block teardown
+// on this best-effort cleanup.
+func (r *GarageNodeReconciler) attemptOrphanedFinalize(ctx context.Context, node *garagev1beta1.GarageNode) error {
+	if node.Status.NodeID == "" {
+		return nil
+	}
+	if node.Status.ClusterAdminEndpoint == "" || node.Status.ClusterAdminTokenSecretRef == nil {
+		// No captured endpoint to call. For unified clusters this is fine —
+		// the cluster finalizer already removed the layout entry. For edge
+		// gateways this means we never reached a successful reconcile that
+		// captured the endpoint; a manual `garage layout remove` is needed.
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      node.Status.ClusterAdminTokenSecretRef.Name,
+		Namespace: node.Namespace,
+	}, secret); err != nil {
+		if errors.IsNotFound(err) {
+			// Secret is already gone — we can't authenticate to the remote
+			// admin API. Nothing more to do.
+			return nil
+		}
+		return fmt.Errorf("get admin token secret %s: %w", node.Status.ClusterAdminTokenSecretRef.Name, err)
+	}
+	tokenKey := node.Status.ClusterAdminTokenSecretRef.Key
+	if tokenKey == "" {
+		tokenKey = DefaultAdminTokenKey
+	}
+	tokenData, ok := secret.Data[tokenKey]
+	if !ok || len(tokenData) == 0 {
+		return fmt.Errorf("admin token secret %s missing key %q", secret.Name, tokenKey)
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, finalizeOrphanedTimeout)
+	defer cancel()
+
+	client := garage.NewClient(node.Status.ClusterAdminEndpoint, string(tokenData))
+	return r.removeNodeFromExternalLayout(cctx, node, client)
+}
+
+// removeNodeFromExternalLayout stages and applies a layout removal for the
+// node against an arbitrary admin client. Mirrors the relevant logic in
+// finalize() but without the "last storage node" / gateway-specific
+// skip-dead-nodes guard rails — when called from the orphaned path, the
+// parent cluster is already gone and the remote cluster will reconcile
+// independently.
+func (r *GarageNodeReconciler) removeNodeFromExternalLayout(ctx context.Context, node *garagev1beta1.GarageNode, garageClient *garage.Client) error {
+	layout, err := garageClient.GetClusterLayout(ctx)
+	if err != nil {
+		return fmt.Errorf("get cluster layout: %w", err)
+	}
+
+	inLayout := false
+	for _, role := range layout.Roles {
+		if role.ID == node.Status.NodeID {
+			inLayout = true
+			break
+		}
+	}
+	if !inLayout {
+		return nil
+	}
+
+	updates := []garage.NodeRoleChange{{ID: node.Status.NodeID, Remove: true}}
+	if err := garageClient.UpdateClusterLayout(ctx, updates); err != nil {
+		return fmt.Errorf("stage node removal: %w", err)
+	}
+	stagedVersion := layout.Version + 1
+	if err := garageClient.ApplyClusterLayout(ctx, stagedVersion); err != nil {
+		if garage.IsConflict(err) {
+			return fmt.Errorf("layout version mismatch: %w", err)
+		}
+		if garage.IsReplicationConstraint(err) {
+			// Best-effort cleanup; admin will need to add capacity or
+			// reduce replication to actually drop this entry.
+			return nil
+		}
+		return fmt.Errorf("apply layout removal: %w", err)
+	}
+	return nil
+}
+
+// captureAdminEndpoint stores the resolved admin endpoint + token reference
+// on the GarageNode status so a delete-time finalizer can still attempt a
+// layout removal against an external cluster after the parent GarageCluster
+// CR has been deleted. For unified clusters this captures the in-cluster svc
+// FQDN; the captured value is still useful for diagnostics (e.g. `kubectl
+// describe garagenode`) even when no orphaned-finalize attempt fires.
+func captureAdminEndpoint(node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster, clusterDomain string) {
+	// Edge-gateway: layout lives on the external storage cluster.
+	if cluster.HasGatewayTier() && cluster.Spec.ConnectTo != nil && cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
+		if cluster.Spec.ConnectTo.AdminTokenSecretRef == nil {
+			return
+		}
+		node.Status.ClusterAdminEndpoint = cluster.Spec.ConnectTo.AdminAPIEndpoint
+		ref := *cluster.Spec.ConnectTo.AdminTokenSecretRef
+		node.Status.ClusterAdminTokenSecretRef = &ref
+		return
+	}
+	// Unified / storage-only: layout lives on the local cluster admin.
+	if cluster.Spec.Admin != nil && cluster.Spec.Admin.AdminTokenSecretRef != nil {
+		adminPort := DefaultAdminPort
+		if cluster.Spec.Admin.BindPort != 0 {
+			adminPort = cluster.Spec.Admin.BindPort
+		}
+		node.Status.ClusterAdminEndpoint = "http://" + svcFQDN(cluster.Name, cluster.Namespace, adminPort, clusterDomain)
+		ref := *cluster.Spec.Admin.AdminTokenSecretRef
+		node.Status.ClusterAdminTokenSecretRef = &ref
+	}
+}
+
 func (r *GarageNodeReconciler) finalize(ctx context.Context, node *garagev1beta1.GarageNode, garageClient *garage.Client) error {
 	log := logf.FromContext(ctx)
 
@@ -1467,8 +1609,20 @@ func tagsEqual(a, b []string) bool {
 }
 
 // reconcileNodeService creates or updates a per-node LoadBalancer/NodePort service for
-// exposing the RPC port externally. Only called when spec.network.publicEndpoint is set.
+// exposing the RPC port externally. Only called when spec.publicEndpoint is set.
+//
+// When this GarageNode is operator-owned in Auto mode (the cluster controller
+// stamped publicEndpoint onto us as part of buildAutoModeStorageNode), the
+// cluster controller already provisions the per-pod LoadBalancer Service at
+// `<cluster>-<ord>-rpc` via reconcilePerNodeLoadBalancerServices. Creating a
+// second Service from here would race with that one and split traffic across
+// two different LB IPs. Skip the create in that case — reconcileNodeConfigMap
+// still derives rpc_public_addr from the cluster-owned Service via
+// effectiveNodeRPCServiceName.
 func (r *GarageNodeReconciler) reconcileNodeService(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) error {
+	if clusterOwnsAutoModePerNodeService(node) {
+		return nil
+	}
 	ep := node.Spec.PublicEndpoint
 	svcName := node.Name + "-rpc"
 
@@ -1552,7 +1706,8 @@ func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node 
 		switch node.Spec.PublicEndpoint.Type {
 		case publicEndpointTypeLoadBalancer:
 			svc := &corev1.Service{}
-			if err := r.Get(ctx, types.NamespacedName{Name: node.Name + "-rpc", Namespace: cluster.Namespace}, svc); err == nil {
+			svcName := effectiveNodeRPCServiceName(node, cluster)
+			if err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: cluster.Namespace}, svc); err == nil {
 				for _, ing := range svc.Status.LoadBalancer.Ingress {
 					addr := ing.IP
 					if addr == "" {
@@ -1673,13 +1828,27 @@ func effectiveNodeLogging(cluster *garagev1beta2.LoggingConfig, override *garage
 
 // SetupWithManager sets up the controller with the Manager.
 //
-// Watches GarageCluster so cluster-level spec changes (which rewrite the
-// cluster-shared ConfigMap and therefore change the per-node STS config-hash
-// annotation) immediately fan out to every child GarageNode. Without this
-// fan-out the GarageNode controller only sees its own CR + owned objects,
-// and a cluster CM rewrite would only propagate on the next periodic
-// requeue — fails the e2e config-change-triggers-restart test and means a
-// real config update can sit unrolled for minutes.
+// Watches in addition to the per-node Owns:
+//
+//   - GarageCluster (with GenerationChangedPredicate): cluster-level spec
+//     changes that rewrite the cluster-shared ConfigMap need to fan out so
+//     every per-node StatefulSet picks up the new config-hash annotation.
+//     Not every spec change goes through a CM regen (e.g.,
+//     spec.replication.factor, layoutManagement toggles) — watching the CR
+//     covers those too.
+//
+//   - corev1.ConfigMap (label-gated): the cluster-shared CM `<cluster>-config`
+//     is owned by the cluster controller, not by GarageNode, so the
+//     controller's own Owns(ConfigMap) (which is for the per-node override
+//     CM, absent on Auto-mode nodes without overrides) does NOT wake us
+//     when the cluster CM is rewritten. Without this, a CM rewrite would
+//     have to wait for the GarageCluster generation bump to fan out, which
+//     means a CM edit by hand or by a non-spec-changing code path would sit
+//     unrolled until the next periodic requeue.
+//
+// Both predicates are intentionally narrow — generation predicate on the CR
+// + label gating in the CM mapper — to avoid waking GarageNode reconciles
+// for unrelated objects.
 func (r *GarageNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&garagev1beta1.GarageNode{}).
@@ -1690,6 +1859,10 @@ func (r *GarageNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&garagev1beta2.GarageCluster{},
 			handler.EnqueueRequestsFromMapFunc(r.nodesForCluster),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.nodesForClusterConfigMap),
 		).
 		Named("garagenode").
 		Complete(r)
@@ -1716,6 +1889,50 @@ func (r *GarageNodeReconciler) nodesForCluster(ctx context.Context, obj client.O
 			continue
 		}
 		if n.Spec.ClusterRef.Namespace != "" && n.Spec.ClusterRef.Namespace != cluster.Namespace {
+			continue
+		}
+		out = append(out, reconcile.Request{NamespacedName: types.NamespacedName{Name: n.Name, Namespace: n.Namespace}})
+	}
+	return out
+}
+
+// nodesForClusterConfigMap maps a cluster-shared ConfigMap (<cluster>-config)
+// to reconcile requests for every GarageNode in the same namespace whose
+// ClusterRef matches. Gated on operator-stamped labels so unrelated CMs in
+// the namespace don't wake every GarageNode on every CM change.
+//
+// Naming: the cluster controller writes the shared CM as `<cluster>-config`
+// (see labelsForCluster + writeConfigMap in garagecluster_controller.go),
+// labelled with {labelCluster: <cluster>, labelAppManagedBy: operator}. We
+// match on the labels first to avoid useless wake-ups, then verify the
+// name matches the cluster-shared convention so we don't fan out for the
+// `<cluster>-gateway-config` CM (which only the gateway Deployment consumes).
+func (r *GarageNodeReconciler) nodesForClusterConfigMap(ctx context.Context, obj client.Object) []reconcile.Request {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return nil
+	}
+	labels := cm.GetLabels()
+	clusterName := labels[labelCluster]
+	if clusterName == "" || labels[labelAppManagedBy] != operatorName {
+		return nil
+	}
+	// Per-node override CMs are already covered by Owns(ConfigMap); skip
+	// the gateway-only CM since no GarageNode consumes it.
+	if cm.Name != clusterName+"-config" {
+		return nil
+	}
+	nodes := &garagev1beta1.GarageNodeList{}
+	if err := r.List(ctx, nodes, client.InNamespace(cm.Namespace)); err != nil {
+		return nil
+	}
+	var out []reconcile.Request
+	for i := range nodes.Items {
+		n := &nodes.Items[i]
+		if n.Spec.ClusterRef.Name != clusterName {
+			continue
+		}
+		if n.Spec.ClusterRef.Namespace != "" && n.Spec.ClusterRef.Namespace != cm.Namespace {
 			continue
 		}
 		out = append(out, reconcile.Request{NamespacedName: types.NamespacedName{Name: n.Name, Namespace: n.Namespace}})

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -33,9 +33,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
@@ -60,7 +64,7 @@ type GarageNodeReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
 
 func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -201,6 +205,14 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// For managed nodes (not external), create/update the StatefulSet
 	if node.Spec.External == nil {
+		// Expand bound PVCs first if the spec grew. StatefulSet selectors are
+		// immutable but PVCs can be resized in place when the StorageClass has
+		// allowVolumeExpansion=true. Order matters: the STS template carries the
+		// new size, so without expanding the existing PVCs first the new
+		// template would silently disagree with the bound claims.
+		if err := r.expandNodePVCs(ctx, node, cluster); err != nil {
+			return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("expanding PVCs: %w", err))
+		}
 		if err := r.reconcileStatefulSet(ctx, node, cluster); err != nil {
 			return r.updateStatus(ctx, node, PhaseFailed, err)
 		}
@@ -431,9 +443,10 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 				ObjectMeta: metav1.ObjectMeta{Labels: podLabels, Annotations: podAnnotations},
 				Spec:       podSpec,
 			},
-			VolumeClaimTemplates: volumeClaimTemplates,
-			PodManagementPolicy:  appsv1.ParallelPodManagement,
-			UpdateStrategy:       appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
+			VolumeClaimTemplates:                 volumeClaimTemplates,
+			PodManagementPolicy:                  appsv1.ParallelPodManagement,
+			UpdateStrategy:                       appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
+			PersistentVolumeClaimRetentionPolicy: stsPVCRetentionPolicy(cluster, node),
 		},
 	}
 
@@ -475,6 +488,103 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 	existing.Spec.Template = sts.Spec.Template
 	log.Info("Updating StatefulSet for GarageNode", "name", stsName)
 	return r.Update(ctx, existing)
+}
+
+// stsPVCRetentionPolicy translates spec.storage.pvcRetentionPolicy into the
+// StatefulSet PVC retention policy. Returns nil for clusters that don't set
+// the field, which leaves K8s' default of "Retain" — safe for stateful data
+// and matches the v1beta2 type defaults. #196 follow-up: this was a silent
+// no-op on storage STSes after #192 (the gateway STS already wires it).
+// pvcRetentionDelete is the API string for "delete PVCs when the STS is
+// deleted/scaled" — matches the enum value in the v1beta2 CRD.
+const pvcRetentionDelete = "Delete"
+
+func stsPVCRetentionPolicy(cluster *garagev1beta2.GarageCluster, node *garagev1beta1.GarageNode) *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy {
+	if node.Spec.Gateway || !cluster.HasStorageTier() || cluster.Spec.Storage.PVCRetentionPolicy == nil {
+		return nil
+	}
+	rp := cluster.Spec.Storage.PVCRetentionPolicy
+	out := &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+		WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+	}
+	if rp.WhenDeleted == pvcRetentionDelete {
+		out.WhenDeleted = appsv1.DeletePersistentVolumeClaimRetentionPolicyType
+	}
+	if rp.WhenScaled == pvcRetentionDelete {
+		out.WhenScaled = appsv1.DeletePersistentVolumeClaimRetentionPolicyType
+	}
+	return out
+}
+
+// expandNodePVCs resizes bound PVCs in-place when spec.storage.{metadata,data}.size
+// grows. Required because StatefulSet.volumeClaimTemplates is immutable: a
+// fresh template with a larger size won't propagate to existing PVCs without
+// an explicit Update. Shrink is not supported and silently skipped — the
+// underlying StorageClass would reject it anyway.
+//
+// #196 follow-up: PVC expansion was deleted in #192 with the legacy
+// reconcileStatefulSet and never reimplemented; bumping size silently no-op'd.
+func (r *GarageNodeReconciler) expandNodePVCs(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) error {
+	if node.Spec.Storage == nil {
+		return nil
+	}
+	log := logf.FromContext(ctx)
+	stsName := node.Name
+
+	// Build a list of (PVC-name-prefix, desired size). PVCs created from
+	// volumeClaimTemplates follow the convention <template-name>-<sts>-<ord>;
+	// for our 1-replica per-node STS that's <template>-<stsName>-0. Skip any
+	// volume backed by existingClaim (migration adoption) — those PVCs are
+	// user-managed; we don't own their size policy.
+	type want struct {
+		name string
+		size resource.Quantity
+	}
+	var wants []want
+	if m := node.Spec.Storage.Metadata; m != nil && m.ExistingClaim == "" && m.Type != garagev1beta1.VolumeTypeEmptyDir && m.Size != nil {
+		wants = append(wants, want{name: fmt.Sprintf("%s-%s-0", metadataVolName, stsName), size: *m.Size})
+	}
+	if !node.Spec.Gateway {
+		switch {
+		case nodeHasMultiHDD(node):
+			for i, dp := range node.Spec.Storage.DataPaths {
+				if dp.ExistingClaim != "" || dp.Type == garagev1beta1.VolumeTypeEmptyDir || dp.Size == nil {
+					continue
+				}
+				wants = append(wants, want{name: fmt.Sprintf("%s-%s-0", nodeMultiHDDDataVolName(i), stsName), size: *dp.Size})
+			}
+		default:
+			if d := node.Spec.Storage.Data; d != nil && d.ExistingClaim == "" && d.Type != garagev1beta1.VolumeTypeEmptyDir && d.Size != nil {
+				wants = append(wants, want{name: fmt.Sprintf("%s-%s-0", dataVolName, stsName), size: *d.Size})
+			}
+		}
+	}
+
+	for _, w := range wants {
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: w.name, Namespace: cluster.Namespace}, pvc); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("get PVC %s: %w", w.name, err)
+		}
+		current, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		if !ok || current.Cmp(w.size) >= 0 {
+			continue
+		}
+		log.Info("Expanding PVC", "pvc", w.name, "from", current.String(), "to", w.size.String())
+		if pvc.Spec.Resources.Requests == nil {
+			pvc.Spec.Resources.Requests = corev1.ResourceList{}
+		}
+		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = w.size
+		if err := r.Update(ctx, pvc); err != nil {
+			// Surface but don't fatal — likely the StorageClass disallows
+			// expansion; admin can resolve out-of-band.
+			log.Error(err, "PVC expand rejected", "pvc", w.name)
+		}
+	}
+	return nil
 }
 
 // nodeMultiHDDDataPath returns the mount path for the i-th data volume on a
@@ -1562,12 +1672,53 @@ func effectiveNodeLogging(cluster *garagev1beta2.LoggingConfig, override *garage
 }
 
 // SetupWithManager sets up the controller with the Manager.
+//
+// Watches GarageCluster so cluster-level spec changes (which rewrite the
+// cluster-shared ConfigMap and therefore change the per-node STS config-hash
+// annotation) immediately fan out to every child GarageNode. Without this
+// fan-out the GarageNode controller only sees its own CR + owned objects,
+// and a cluster CM rewrite would only propagate on the next periodic
+// requeue — fails the e2e config-change-triggers-restart test and means a
+// real config update can sit unrolled for minutes.
 func (r *GarageNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&garagev1beta1.GarageNode{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
+		Watches(
+			&garagev1beta2.GarageCluster{},
+			handler.EnqueueRequestsFromMapFunc(r.nodesForCluster),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		Named("garagenode").
 		Complete(r)
+}
+
+// nodesForCluster maps a GarageCluster event to reconcile requests for every
+// GarageNode whose ClusterRef points at it.
+func (r *GarageNodeReconciler) nodesForCluster(ctx context.Context, obj client.Object) []reconcile.Request {
+	cluster, ok := obj.(*garagev1beta2.GarageCluster)
+	if !ok {
+		return nil
+	}
+	nodes := &garagev1beta1.GarageNodeList{}
+	if err := r.List(ctx, nodes, client.InNamespace(cluster.Namespace)); err != nil {
+		return nil
+	}
+	var out []reconcile.Request
+	for i := range nodes.Items {
+		n := &nodes.Items[i]
+		// Cross-namespace ClusterRef is supported, but the common case keeps
+		// node + cluster co-located. Match by name (and matching namespace
+		// when ClusterRef.Namespace is explicitly set).
+		if n.Spec.ClusterRef.Name != cluster.Name {
+			continue
+		}
+		if n.Spec.ClusterRef.Namespace != "" && n.Spec.ClusterRef.Namespace != cluster.Namespace {
+			continue
+		}
+		out = append(out, reconcile.Request{NamespacedName: types.NamespacedName{Name: n.Name, Namespace: n.Namespace}})
+	}
+	return out
 }

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -27,7 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
@@ -1219,5 +1221,152 @@ var _ = Describe("GarageNode labelsForNode tier label", func() {
 		Expect(sel).To(HaveKeyWithValue(labelAppManagedBy, operatorName))
 		Expect(sel).NotTo(HaveKey(labelAppName))
 		Expect(sel).NotTo(HaveKey(labelAppInstance))
+	})
+})
+
+// Regression guard for #196 follow-ups: spec.storage.pvcRetentionPolicy was
+// silently dropped after #192 on per-node STSes (the gateway STS still wired
+// it in via garagecluster_gateway.go). Storage STSes now honor it too.
+var _ = Describe("stsPVCRetentionPolicy", func() {
+	mkNode := func(gateway bool) *garagev1beta1.GarageNode {
+		return &garagev1beta1.GarageNode{Spec: garagev1beta1.GarageNodeSpec{Gateway: gateway}}
+	}
+	mkCluster := func(rp *garagev1beta2.PVCRetentionPolicy) *garagev1beta2.GarageCluster {
+		return &garagev1beta2.GarageCluster{Spec: garagev1beta2.GarageClusterSpec{
+			Storage: &garagev1beta2.StorageSpec{PVCRetentionPolicy: rp},
+		}}
+	}
+
+	It("returns nil for gateway nodes (gateway STS owns its own policy)", func() {
+		got := stsPVCRetentionPolicy(mkCluster(&garagev1beta2.PVCRetentionPolicy{WhenDeleted: pvcRetentionDelete}), mkNode(true))
+		Expect(got).To(BeNil())
+	})
+
+	It("returns nil when cluster.storage.pvcRetentionPolicy is unset (k8s default of Retain stands)", func() {
+		got := stsPVCRetentionPolicy(mkCluster(nil), mkNode(false))
+		Expect(got).To(BeNil())
+	})
+
+	It("translates WhenDeleted=Delete and WhenScaled=Delete", func() {
+		got := stsPVCRetentionPolicy(mkCluster(&garagev1beta2.PVCRetentionPolicy{WhenDeleted: pvcRetentionDelete, WhenScaled: pvcRetentionDelete}), mkNode(false))
+		Expect(got).NotTo(BeNil())
+		Expect(got.WhenDeleted).To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+		Expect(got.WhenScaled).To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+	})
+
+	It("defaults missing fields to Retain", func() {
+		got := stsPVCRetentionPolicy(mkCluster(&garagev1beta2.PVCRetentionPolicy{WhenDeleted: pvcRetentionDelete}), mkNode(false))
+		Expect(got).NotTo(BeNil())
+		Expect(got.WhenDeleted).To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+		Expect(got.WhenScaled).To(Equal(appsv1.RetainPersistentVolumeClaimRetentionPolicyType))
+	})
+})
+
+// Regression guard for #196 follow-up: PVC expansion path was deleted with
+// reconcilePVCExpansion in #192 and never reimplemented. Bumping
+// spec.storage.metadata.size silently no-op'd. expandNodePVCs now patches
+// bound PVCs in place when the desired size grows.
+//
+// envtest's API server enforces PVC spec immutability (no provisioner/CSI
+// to service the resize), so the happy-path expansion is exercised via a
+// fake client that doesn't apply that admission check. Real clusters with
+// a CSI driver and allowVolumeExpansion=true accept the same Update.
+var _ = Describe("expandNodePVCs", func() {
+	const (
+		ns       = "default"
+		nodeName = "expand-node"
+	)
+	var (
+		ctx     context.Context
+		cluster *garagev1beta2.GarageCluster
+		scheme  *runtime.Scheme
+	)
+
+	mkPVC := func(name, size string) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)}},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		cluster = &garagev1beta2.GarageCluster{ObjectMeta: metav1.ObjectMeta{Name: "expand-cluster", Namespace: ns}}
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta2.AddToScheme(scheme)).To(Succeed())
+	})
+
+	It("expands the metadata PVC when spec.storage.metadata.size grows", func() {
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			mkPVC("metadata-"+nodeName+"-0", "1Gi"),
+			mkPVC("data-"+nodeName+"-0", "10Gi"),
+		).Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		newMeta := resource.MustParse("5Gi")
+		oldData := resource.MustParse("10Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: ns},
+			Spec: garagev1beta1.GarageNodeSpec{
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Size: &newMeta},
+					Data:     &garagev1beta1.NodeVolumeConfig{Size: &oldData},
+				},
+			},
+		}
+		Expect(r.expandNodePVCs(ctx, node, cluster)).To(Succeed())
+
+		got := &corev1.PersistentVolumeClaim{}
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "metadata-" + nodeName + "-0", Namespace: ns}, got)).To(Succeed())
+		Expect(got.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(newMeta))
+	})
+
+	It("does not shrink a PVC when the spec is smaller (storage class would reject anyway)", func() {
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			mkPVC("metadata-"+nodeName+"-0", "5Gi"),
+		).Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		smaller := resource.MustParse("1Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: ns},
+			Spec: garagev1beta1.GarageNodeSpec{
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Size: &smaller},
+				},
+			},
+		}
+		Expect(r.expandNodePVCs(ctx, node, cluster)).To(Succeed())
+
+		got := &corev1.PersistentVolumeClaim{}
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "metadata-" + nodeName + "-0", Namespace: ns}, got)).To(Succeed())
+		Expect(got.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("5Gi")))
+	})
+
+	It("skips PVCs bound via existingClaim (user-managed)", func() {
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			mkPVC("legacy-meta", "1Gi"),
+		).Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		bigger := resource.MustParse("5Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: ns},
+			Spec: garagev1beta1.GarageNodeSpec{
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{ExistingClaim: "legacy-meta", Size: &bigger},
+				},
+			},
+		}
+		Expect(r.expandNodePVCs(ctx, node, cluster)).To(Succeed())
+
+		got := &corev1.PersistentVolumeClaim{}
+		Expect(fc.Get(ctx, types.NamespacedName{Name: "legacy-meta", Namespace: ns}, got)).To(Succeed())
+		Expect(got.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
 	})
 })

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -18,7 +18,11 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,11 +33,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 const testNodeZone = "dc1"
@@ -1368,5 +1375,304 @@ var _ = Describe("expandNodePVCs", func() {
 		got := &corev1.PersistentVolumeClaim{}
 		Expect(fc.Get(ctx, types.NamespacedName{Name: "legacy-meta", Namespace: ns}, got)).To(Succeed())
 		Expect(got.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+	})
+})
+
+// Bug #4 — orphaned-finalize path. When the parent GarageCluster CR is gone
+// and the GarageNode is being deleted, the operator MUST attempt a best-effort
+// layout removal against the captured external admin endpoint (so we don't
+// leave a dead layout entry on the remote cluster) but MUST NOT block
+// finalizer release indefinitely if the remote call fails.
+const goneClusterName = "gone-cluster"
+
+var _ = Describe("GarageNode orphaned-finalize against external admin endpoint", func() {
+	const (
+		ns         = "orphan-finalize-ns"
+		nodeName   = "orphan-finalize-node"
+		secretName = "ext-admin-token"
+		nodeID     = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	)
+
+	var (
+		bctx   context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		bctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta2.AddToScheme(scheme)).To(Succeed())
+	})
+
+	// mockGarage builds a tiny admin-API mock that counts UpdateClusterLayout
+	// and ApplyClusterLayout calls so the test can assert removal was attempted.
+	mockGarage := func(extraNodeID string) (*httptest.Server, *int32, *int32) {
+		var updates, applies int32
+		mux := http.NewServeMux()
+		mux.HandleFunc("/v2/GetClusterLayout", func(w http.ResponseWriter, _ *http.Request) {
+			roles := []garage.LayoutRole{{ID: extraNodeID, Zone: "z"}}
+			_ = json.NewEncoder(w).Encode(garage.ClusterLayout{Version: 1, Roles: roles})
+		})
+		mux.HandleFunc("/v2/UpdateClusterLayout", func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&updates, 1)
+			w.WriteHeader(http.StatusOK)
+		})
+		mux.HandleFunc("/v2/ApplyClusterLayout", func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&applies, 1)
+			w.WriteHeader(http.StatusOK)
+		})
+		return httptest.NewServer(mux), &updates, &applies
+	}
+
+	It("calls UpdateClusterLayout+ApplyClusterLayout against the captured admin endpoint when the parent cluster is NotFound", func() {
+		srv, updates, applies := mockGarage(nodeID)
+		defer srv.Close()
+
+		// The admin token secret survives the cluster deletion (typical
+		// when it's user-managed). Token value matches what the mock would
+		// accept — the mock doesn't actually validate, but we still want
+		// the request to be well-formed.
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+			Data:       map[string][]byte{DefaultAdminTokenKey: []byte("test-token")},
+		}
+
+		// GarageNode with the orphaned-finalize hints captured on Status,
+		// a DeletionTimestamp, and the finalizer still set. Spec.ClusterRef
+		// points at a cluster that has already been deleted.
+		now := metav1.Now()
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              nodeName,
+				Namespace:         ns,
+				Finalizers:        []string{garageNodeFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: goneClusterName},
+				Zone:       "z",
+			},
+			Status: garagev1beta1.GarageNodeStatus{
+				NodeID:               nodeID,
+				ClusterAdminEndpoint: srv.URL,
+				ClusterAdminTokenSecretRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  DefaultAdminTokenKey,
+				},
+			},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(secret, node).
+			WithStatusSubresource(&garagev1beta1.GarageNode{}).
+			Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		_, err := r.Reconcile(bctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: nodeName, Namespace: ns},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(atomic.LoadInt32(updates)).To(Equal(int32(1)),
+			"expected exactly one UpdateClusterLayout call against captured admin endpoint")
+		Expect(atomic.LoadInt32(applies)).To(Equal(int32(1)),
+			"expected exactly one ApplyClusterLayout call against captured admin endpoint")
+
+		expectFinalizerReleased(bctx, fc, nodeName, ns)
+	})
+
+	It("releases the finalizer even when the captured admin endpoint is unreachable", func() {
+		// Build a server, then close it immediately so the URL fails on
+		// dial. The 5s timeout in attemptOrphanedFinalize keeps the test
+		// fast.
+		srv, _, _ := mockGarage(nodeID)
+		srv.Close()
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+			Data:       map[string][]byte{DefaultAdminTokenKey: []byte("test-token")},
+		}
+		now := metav1.Now()
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              nodeName,
+				Namespace:         ns,
+				Finalizers:        []string{garageNodeFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: goneClusterName},
+				Zone:       "z",
+			},
+			Status: garagev1beta1.GarageNodeStatus{
+				NodeID:               nodeID,
+				ClusterAdminEndpoint: srv.URL,
+				ClusterAdminTokenSecretRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  DefaultAdminTokenKey,
+				},
+			},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(secret, node).
+			WithStatusSubresource(&garagev1beta1.GarageNode{}).
+			Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		_, err := r.Reconcile(bctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: nodeName, Namespace: ns},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		expectFinalizerReleased(bctx, fc, nodeName, ns)
+	})
+
+	It("releases the finalizer immediately when no admin endpoint was captured (unified cluster path)", func() {
+		now := metav1.Now()
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              nodeName,
+				Namespace:         ns,
+				Finalizers:        []string{garageNodeFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: goneClusterName},
+				Zone:       "z",
+			},
+			Status: garagev1beta1.GarageNodeStatus{NodeID: nodeID},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(node).
+			WithStatusSubresource(&garagev1beta1.GarageNode{}).
+			Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		_, err := r.Reconcile(bctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: nodeName, Namespace: ns},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		expectFinalizerReleased(bctx, fc, nodeName, ns)
+	})
+})
+
+// expectFinalizerReleased asserts that the named GarageNode either no longer
+// exists (fake client GC'd it once the last finalizer was dropped) or still
+// exists without the garageNodeFinalizer. Either outcome is correct — both
+// mean the operator released the finalizer.
+func expectFinalizerReleased(ctx context.Context, c client.Client, name, namespace string) {
+	got := &garagev1beta1.GarageNode{}
+	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, got)
+	if err == nil {
+		Expect(controllerutil.ContainsFinalizer(got, garageNodeFinalizer)).To(BeFalse(),
+			"GarageNode %s/%s still carries the finalizer after delete", namespace, name)
+		return
+	}
+	Expect(errors.IsNotFound(err)).To(BeTrue(),
+		"unexpected error fetching GarageNode %s/%s: %v", namespace, name, err)
+}
+
+// Bug #6 — nodesForClusterConfigMap mapper. The cluster controller owns the
+// cluster-shared `<cluster>-config` ConfigMap. GarageNode's own
+// Owns(ConfigMap) only catches the per-node override CM (absent on Auto-mode
+// nodes without overrides), so a cluster CM rewrite would otherwise sit
+// unrolled until the next periodic requeue. The mapper must enqueue every
+// matching GarageNode and ignore unrelated CMs.
+var _ = Describe("nodesForClusterConfigMap mapper", func() {
+	const ns = "cm-mapper-ns"
+
+	var (
+		bctx   context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		bctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta2.AddToScheme(scheme)).To(Succeed())
+	})
+
+	mkNode := func(name, clusterName string) *garagev1beta1.GarageNode {
+		return &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       "z",
+			},
+		}
+	}
+
+	It("enqueues every GarageNode whose ClusterRef matches the labelled cluster CM", func() {
+		const clusterName = "stable-cluster"
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName + "-config",
+				Namespace: ns,
+				Labels: map[string]string{
+					labelCluster:      clusterName,
+					labelAppManagedBy: operatorName,
+				},
+			},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			mkNode("n1", clusterName),
+			mkNode("n2", clusterName),
+			mkNode("n-other", "other-cluster"),
+		).Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		reqs := r.nodesForClusterConfigMap(bctx, cm)
+		names := make([]string, 0, len(reqs))
+		for _, req := range reqs {
+			names = append(names, req.Name)
+		}
+		Expect(names).To(ConsistOf("n1", "n2"))
+	})
+
+	It("ignores CMs without operator-stamped labels (defense against fan-out storms)", func() {
+		const clusterName = "labelless-cluster"
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName + "-config",
+				Namespace: ns,
+				// No labels — must NOT fan out.
+			},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			mkNode("n1", clusterName),
+		).Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		Expect(r.nodesForClusterConfigMap(bctx, cm)).To(BeEmpty())
+	})
+
+	It("ignores the gateway-only CM (<cluster>-gateway-config) since no GarageNode consumes it", func() {
+		const clusterName = "gw-cluster"
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName + "-gateway-config",
+				Namespace: ns,
+				Labels: map[string]string{
+					labelCluster:      clusterName,
+					labelAppManagedBy: operatorName,
+				},
+			},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			mkNode("n1", clusterName),
+		).Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		Expect(r.nodesForClusterConfigMap(bctx, cm)).To(BeEmpty())
 	})
 })

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -961,8 +961,8 @@ func TestComputePodSpecHash(t *testing.T) {
 
 func TestBuildGaragePodSpec_UserEnv(t *testing.T) {
 	userEnv := []corev1.EnvVar{
-		{Name: "GARAGE_ALLOW_WORLD_READABLE_SECRETS", Value: "true"},
-		{Name: "MY_EXTRA", Value: "foo"},
+		{Name: "GARAGE_ALLOW_WORLD_READABLE_SECRETS", Value: annotationTrue},
+		{Name: "MY_EXTRA", Value: "user-supplied-value"},
 		// Intentional override: user re-declares GARAGE_NODE_HOST. Since user env
 		// is appended AFTER the built-in, this entry must appear after the
 		// built-in in the resulting container.Env slice.

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -995,8 +995,8 @@ func TestBuildGaragePodSpec_UserEnv(t *testing.T) {
 	if vs, ok := got["GARAGE_ALLOW_WORLD_READABLE_SECRETS"]; !ok || vs[0] != "true" {
 		t.Errorf("expected GARAGE_ALLOW_WORLD_READABLE_SECRETS=true, got %v", vs)
 	}
-	if vs, ok := got["MY_EXTRA"]; !ok || vs[0] != "foo" {
-		t.Errorf("expected MY_EXTRA=foo, got %v", vs)
+	if vs, ok := got["MY_EXTRA"]; !ok || vs[0] != "user-supplied-value" {
+		t.Errorf("expected MY_EXTRA=user-supplied-value, got %v", vs)
 	}
 
 	// Built-in must still be present, and the user override must appear AFTER

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -164,6 +164,13 @@ func NewClient(baseURL, adminToken string) *Client {
 	}
 }
 
+// SetHTTPTimeout overrides the underlying http.Client.Timeout. Intended for
+// tests that need a much shorter transport-level deadline than the 90s
+// production default.
+func (c *Client) SetHTTPTimeout(d time.Duration) {
+	c.httpClient.Timeout = d
+}
+
 // doRequest performs an HTTP request to the Garage Admin API
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
 	return c.doRequestWithQuery(ctx, method, path, nil, body)

--- a/schemas/garagenode_v1beta1.json
+++ b/schemas/garagenode_v1beta1.json
@@ -2066,6 +2066,34 @@
           "format": "int32",
           "type": "integer"
         },
+        "clusterAdminEndpoint": {
+          "description": "ClusterAdminEndpoint is the resolved Garage Admin API endpoint last used\nto manage this node's layout entry. Captured on each successful reconcile\nso that a delete-time finalizer can still attempt to drop the layout\nentry when the parent GarageCluster CR has already been deleted (edge\ngateway pattern via spec.connectTo.adminApiEndpoint).",
+          "type": "string"
+        },
+        "clusterAdminTokenSecretRef": {
+          "description": "ClusterAdminTokenSecretRef references the Admin API token secret last\nused to manage this node's layout entry. The secret lives in the same\nnamespace as the GarageNode. Paired with ClusterAdminEndpoint to enable\nbest-effort finalize against an external admin API after the parent\nGarageCluster CR is gone.",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
         "conditions": {
           "description": "Conditions represent the current state",
           "items": {


### PR DESCRIPTION
Fixes #196 and bundles the silent-no-op regressions surfaced by a high-effort review of the v0.6.x change set. Most of these share a root cause: #190 split the cluster-level StatefulSet into per-node GarageNodes and #192 deleted the legacy reconciliation along with it, but the spec fields and their CRD validation stayed in place — users configured features that quietly did nothing.

## Commits

| | Title | What it fixes |
|---|---|---|
| `beec5d6` | reconcile spec.storage.podDisruptionBudget | Re-adds the PDB reconciler that was deleted in #192. PDB targets the storage tier (per-node STSes are 1-replica — a per-STS PDB would be meaningless). |
| `d0ce52c` | default minAvailable to replicas-1, harden upgrade path | `MinAvailable=1` hardcode in beec5d6 broke quorum on drain for 3+ replica clusters; webhook warning documented `replicas-1`. Selector switched to the pre-#192 shape so v0.5.x→v0.6.x upgrade doesn't hit selector-immutable. `IsControlledBy` checks so foreign PDBs are left alone. `Owns(PDB)` so manual deletions trigger immediate reconcile. |
| `96c8d6c` | pvcRetentionPolicy, PVC expansion, CM-change fan-out | `spec.storage.pvcRetentionPolicy` had no caller; gateway STS wired it but per-node STSes didn't. PVC expansion was deleted with the legacy STS and never reimplemented on the GarageNode controller. v1beta1 storage shape decoded through v1beta2 zero-filled `Replicas` (full storage teardown on a conversion-webhook hiccup). `BucketLookupStuck` condition was lost on Status conflict (re-fetch overwrote the in-memory mutation). `getBucketWithTimeout` only matched `context.DeadlineExceeded`, missing transport-level `i/o timeout`. GarageCluster generation-changed watch wakes GarageNodes when cluster spec changes that don't regen the CM (e.g., `spec.replication.factor`). |
| `534c225` | retry-migration race, perNode rpc_public_addr, orphan finalize layout cleanup | `retry-migration` annotation strip raced on Conflict → permanent migration-restart loop. `publicEndpoint.loadBalancer.perNode=true` never produced `rpc_public_addr` in Auto mode — pods advertised pod source IP (`known_addrs` cross-cluster pollution). GarageNode orphan-finalize (9b6fc3e) released without cleaning external-cluster layout. Cluster-shared `<cluster>-config` rewrite didn't fan out to GarageNodes (`Owns(ConfigMap)` is for the per-node override CM, absent on Auto-mode nodes without overrides). |

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1 -timeout 600s` — passes; new specs:
  - 4 PDB reconcile specs (default, explicit max, disable, foreign PDB protection)
  - 3 v1beta2 unmarshal specs (legacy storage leak, real v1beta2, explicit-pause preservation)
  - 2 bucket condition/timeout specs (`PreservesConditionOnConflict`, `TransportTimeoutClassified`) + classification table test
  - 5 automode specs (retry-migration conflict retry, 4 perNode propagation cases)
  - 6 GarageNode specs (3 orphan-finalize cases, 3 CM mapper cases)
  - PVC expand/retention specs from 96c8d6c
- [x] `bin/golangci-lint run` clean
- [x] CRDs regenerated (`make generate manifests`) for new GarageNode `Status.ClusterAdminEndpoint` / `Status.ClusterAdminTokenSecretRef`