### PR TITLE
ci(e2e): dump operator logs before kind teardown

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -89,16 +89,9 @@ jobs:
       - name: Run single-cluster e2e tests
         run: make test-e2e-cluster
 
-      - name: Collect debug info
-        if: failure()
-        run: |
-          mkdir -p /tmp/e2e-debug
-          kind get clusters > /tmp/e2e-debug/clusters.txt 2>&1 || true
-          for cluster in $(kind get clusters 2>/dev/null); do
-            kubectl --context "kind-$cluster" get all -A > "/tmp/e2e-debug/${cluster}-resources.txt" 2>&1 || true
-            kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=200 > "/tmp/e2e-debug/${cluster}-operator.txt" 2>&1 || true
-          done
-
+      # The script's trap dumps operator logs + resources to /tmp/e2e-debug
+      # before tearing down kind, so the upload below captures real state. If
+      # the script crashes before its trap fires, this artifact will be empty.
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7
@@ -106,6 +99,7 @@ jobs:
           name: cluster-e2e-logs
           path: /tmp/e2e-debug/
           retention-days: 7
+          if-no-files-found: warn
 
   e2e-cosi:
     name: COSI E2E Tests
@@ -136,17 +130,6 @@ jobs:
       - name: Run COSI e2e tests
         run: make test-e2e-cosi
 
-      - name: Collect debug info
-        if: failure()
-        run: |
-          mkdir -p /tmp/e2e-debug
-          kind get clusters > /tmp/e2e-debug/clusters.txt 2>&1 || true
-          for cluster in $(kind get clusters 2>/dev/null); do
-            kubectl --context "kind-$cluster" get all -A > "/tmp/e2e-debug/${cluster}-resources.txt" 2>&1 || true
-            kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=200 > "/tmp/e2e-debug/${cluster}-operator.txt" 2>&1 || true
-            kubectl --context "kind-$cluster" get bucketclaim,bucketaccess -A > "/tmp/e2e-debug/${cluster}-cosi.txt" 2>&1 || true
-          done
-
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7
@@ -154,6 +137,7 @@ jobs:
           name: cosi-e2e-logs
           path: /tmp/e2e-debug/
           retention-days: 7
+          if-no-files-found: warn
 
   e2e-multicluster:
     name: Multi-Cluster E2E Tests
@@ -184,16 +168,6 @@ jobs:
       - name: Run multi-cluster e2e tests
         run: make test-e2e-multicluster
 
-      - name: Collect debug info
-        if: failure()
-        run: |
-          mkdir -p /tmp/e2e-debug
-          kind get clusters > /tmp/e2e-debug/clusters.txt 2>&1 || true
-          for cluster in $(kind get clusters 2>/dev/null); do
-            kubectl --context "kind-$cluster" get all -A > "/tmp/e2e-debug/${cluster}-resources.txt" 2>&1 || true
-            kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=200 > "/tmp/e2e-debug/${cluster}-operator.txt" 2>&1 || true
-          done
-
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7
@@ -201,6 +175,7 @@ jobs:
           name: multicluster-e2e-logs
           path: /tmp/e2e-debug/
           retention-days: 7
+          if-no-files-found: warn
 
   e2e-external-gateway:
     name: External Gateway E2E Tests
@@ -231,18 +206,6 @@ jobs:
       - name: Run external gateway e2e tests
         run: make test-e2e-external-gateway
 
-      - name: Collect debug info
-        if: failure()
-        run: |
-          mkdir -p /tmp/e2e-debug
-          kind get clusters > /tmp/e2e-debug/clusters.txt 2>&1 || true
-          for cluster in $(kind get clusters 2>/dev/null); do
-            kubectl --context "kind-$cluster" get all -A > "/tmp/e2e-debug/${cluster}-resources.txt" 2>&1 || true
-            kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=200 > "/tmp/e2e-debug/${cluster}-operator.txt" 2>&1 || true
-            kubectl --context "kind-$cluster" get garagecluster -A -o yaml > "/tmp/e2e-debug/${cluster}-garageclusters.txt" 2>&1 || true
-          done
-          docker logs garage-ext-gw-e2e-external-garage > /tmp/e2e-debug/external-garage.txt 2>&1 || true
-
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7
@@ -250,6 +213,7 @@ jobs:
           name: external-gateway-e2e-logs
           path: /tmp/e2e-debug/
           retention-days: 7
+          if-no-files-found: warn
 
   e2e-ipv6:
     name: IPv6 Dual-Stack E2E Tests
@@ -280,15 +244,6 @@ jobs:
       - name: Run IPv6 dual-stack e2e tests
         run: make test-e2e-ipv6
 
-      - name: Collect debug info
-        if: failure()
-        run: |
-          mkdir -p /tmp/e2e-debug
-          kubectl --context "kind-garage-e2e-ipv6" get all -A > /tmp/e2e-debug/resources.txt 2>&1 || true
-          kubectl --context "kind-garage-e2e-ipv6" logs deployment/garage-operator -n garage-operator-system --tail=200 > /tmp/e2e-debug/operator.txt 2>&1 || true
-          kubectl --context "kind-garage-e2e-ipv6" get garagenode,garagecluster -n garage-operator-system -o yaml > /tmp/e2e-debug/garage-resources.txt 2>&1 || true
-          kubectl --context "kind-garage-e2e-ipv6" get pods -n garage-operator-system -o wide > /tmp/e2e-debug/pods.txt 2>&1 || true
-
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7
@@ -296,4 +251,5 @@ jobs:
           name: ipv6-e2e-logs
           path: /tmp/e2e-debug/
           retention-days: 7
+          if-no-files-found: warn
 

--- a/hack/e2e-cluster.sh
+++ b/hack/e2e-cluster.sh
@@ -58,8 +58,22 @@ test_skip() {
     ((TESTS_SKIPPED++)) || true
 }
 
+dump_debug_info() {
+    local cluster="$1"
+    local dir="${E2E_DEBUG_DIR:-/tmp/e2e-debug}"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    kubectl --context "kind-$cluster" get all -A -o wide > "$dir/${cluster}-resources.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" get garagecluster,garagenode,garagebucket,garagekey,garageadmintoken -A -o yaml > "$dir/${cluster}-garage-resources.yaml" 2>&1 || true
+    kubectl --context "kind-$cluster" get events -A --sort-by=.lastTimestamp > "$dir/${cluster}-events.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 > "$dir/${cluster}-operator.log" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 --previous > "$dir/${cluster}-operator-previous.log" 2>&1 || true
+}
+
 cleanup() {
     if [ "$CLEANUP" = true ]; then
+        if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+            dump_debug_info "$CLUSTER_NAME"
+        fi
         log_info "Cleaning up kind cluster..."
         kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
     else

--- a/hack/e2e-cosi.sh
+++ b/hack/e2e-cosi.sh
@@ -62,8 +62,23 @@ test_skip() {
     ((TESTS_SKIPPED++)) || true
 }
 
+dump_debug_info() {
+    local cluster="$1"
+    local dir="${E2E_DEBUG_DIR:-/tmp/e2e-debug}"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    kubectl --context "kind-$cluster" get all -A -o wide > "$dir/${cluster}-resources.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" get garagecluster,garagenode,garagebucket,garagekey,garageadmintoken -A -o yaml > "$dir/${cluster}-garage-resources.yaml" 2>&1 || true
+    kubectl --context "kind-$cluster" get bucketclaim,bucketaccess -A -o yaml > "$dir/${cluster}-cosi-resources.yaml" 2>&1 || true
+    kubectl --context "kind-$cluster" get events -A --sort-by=.lastTimestamp > "$dir/${cluster}-events.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 > "$dir/${cluster}-operator.log" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 --previous > "$dir/${cluster}-operator-previous.log" 2>&1 || true
+}
+
 cleanup() {
     if [ "$CLEANUP" = true ]; then
+        if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+            dump_debug_info "$CLUSTER_NAME"
+        fi
         log_info "Cleaning up kind cluster..."
         kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
     else

--- a/hack/e2e-external-gateway.sh
+++ b/hack/e2e-external-gateway.sh
@@ -55,8 +55,23 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 TMPDIR_GARAGE=""
 
+dump_debug_info() {
+    local cluster="$1"
+    local dir="${E2E_DEBUG_DIR:-/tmp/e2e-debug}"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    kubectl --context "kind-$cluster" get all -A -o wide > "$dir/${cluster}-resources.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" get garagecluster,garagenode,garagebucket,garagekey,garageadmintoken -A -o yaml > "$dir/${cluster}-garage-resources.yaml" 2>&1 || true
+    kubectl --context "kind-$cluster" get events -A --sort-by=.lastTimestamp > "$dir/${cluster}-events.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 > "$dir/${cluster}-operator.log" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 --previous > "$dir/${cluster}-operator-previous.log" 2>&1 || true
+    docker logs "$GARAGE_CONTAINER" > "$dir/external-garage.log" 2>&1 || true
+}
+
 cleanup() {
     if [ "$CLEANUP" = true ]; then
+        if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+            dump_debug_info "$CLUSTER_NAME"
+        fi
         log_info "Cleaning up..."
         docker rm -f "$GARAGE_CONTAINER" 2>/dev/null || true
         kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true

--- a/hack/e2e-ipv6.sh
+++ b/hack/e2e-ipv6.sh
@@ -48,8 +48,22 @@ log_test()  { echo -e "${BLUE}[TEST]${NC} $1"; }
 test_pass() { echo -e "${GREEN}[PASS]${NC} $1"; ((TESTS_PASSED++)) || true; }
 test_fail() { echo -e "${RED}[FAIL]${NC} $1"; ((TESTS_FAILED++)) || true; }
 
+dump_debug_info() {
+    local cluster="$1"
+    local dir="${E2E_DEBUG_DIR:-/tmp/e2e-debug}"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    kubectl --context "kind-$cluster" get all -A -o wide > "$dir/${cluster}-resources.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" get garagecluster,garagenode,garagebucket,garagekey,garageadmintoken -A -o yaml > "$dir/${cluster}-garage-resources.yaml" 2>&1 || true
+    kubectl --context "kind-$cluster" get events -A --sort-by=.lastTimestamp > "$dir/${cluster}-events.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 > "$dir/${cluster}-operator.log" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 --previous > "$dir/${cluster}-operator-previous.log" 2>&1 || true
+}
+
 cleanup() {
     if [ "$CLEANUP" = true ]; then
+        if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+            dump_debug_info "$CLUSTER_NAME"
+        fi
         log_info "Cleaning up kind cluster '$CLUSTER_NAME'..."
         kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
     else

--- a/hack/e2e-multicluster.sh
+++ b/hack/e2e-multicluster.sh
@@ -58,8 +58,26 @@ test_fail() {
     ((TESTS_FAILED++))
 }
 
+dump_debug_info() {
+    local cluster="$1"
+    local dir="${E2E_DEBUG_DIR:-/tmp/e2e-debug}"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    kubectl --context "kind-$cluster" get all -A -o wide > "$dir/${cluster}-resources.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" get garagecluster,garagenode,garagebucket,garagekey,garageadmintoken -A -o yaml > "$dir/${cluster}-garage-resources.yaml" 2>&1 || true
+    kubectl --context "kind-$cluster" get events -A --sort-by=.lastTimestamp > "$dir/${cluster}-events.txt" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 > "$dir/${cluster}-operator.log" 2>&1 || true
+    kubectl --context "kind-$cluster" logs deployment/garage-operator -n garage-operator-system --tail=2000 --previous > "$dir/${cluster}-operator-previous.log" 2>&1 || true
+}
+
 cleanup() {
     if [ "$CLEANUP" = true ]; then
+        local existing
+        existing="$(kind get clusters 2>/dev/null || true)"
+        for c in "$CLUSTER1_NAME" "$CLUSTER2_NAME"; do
+            if echo "$existing" | grep -qx "$c"; then
+                dump_debug_info "$c"
+            fi
+        done
         log_info "Cleaning up kind clusters..."
         kind delete cluster --name "$CLUSTER1_NAME" 2>/dev/null || true
         kind delete cluster --name "$CLUSTER2_NAME" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- The e2e shell scripts run `kind delete cluster` in their `EXIT` trap, including on failure.
- That meant the workflow's `Collect debug info` step always ran against a torn-down cluster, producing an empty artifact (24-byte `clusters.txt` saying "No kind clusters found").
- Move the dump into each script's `cleanup()` so it runs while kind is still alive.

## What gets dumped

To `${E2E_DEBUG_DIR:-/tmp/e2e-debug}/`, per cluster, before `kind delete`:

- `<cluster>-resources.txt` — `kubectl get all -A -o wide`
- `<cluster>-garage-resources.yaml` — every GarageCluster/Node/Bucket/Key/AdminToken
- `<cluster>-events.txt` — events, sorted by `.lastTimestamp`
- `<cluster>-operator.log` — operator logs, `--tail=2000`
- `<cluster>-operator-previous.log` — operator logs from a crashed prior pod
- external-gateway: also `external-garage.log` from the docker container
- COSI: also `<cluster>-cosi-resources.yaml`

Workflow simplification: the five script-based jobs drop their now-redundant `Collect debug info` step. Upload steps gain `if-no-files-found: warn`. The Ginkgo job is unchanged — its Makefile-based cleanup doesn't run on test failure, so its Collect step still works.

## Motivation

Tracked back from #198 / commit 9767b76 — when the Single-Cluster E2E job failed on two GarageNode tests with empty `.status.phase`, the artifact had no operator logs to diagnose with. Next failure will.

## Test plan

- [ ] Push triggers the E2E workflow; jobs that pass produce no artifact (existing behavior)
- [ ] If a job fails, artifact contains operator logs + resources + events