### PR TITLE
fix(migration): populate multi-HDD data_dir capacity, heal pre-#205 nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,10 +277,22 @@ status:
 **Multi-HDD clusters auto-migrate to per-node `GarageNode`s with
 `spec.storage.dataPaths[]` populated** (one entry per legacy
 `data-<idx>-<cluster>-<ord>` PVC, index-ordered). `buildAutoModeStorageNode`
-at `internal/controller/garagecluster_automode.go:313` emits `DataPaths` when
-the bucketed PVC list has more than one entry, and `bucketLegacyDataPVCs`
-discovers the multi-HDD layout. End-state and observability are identical
-to single-HDD migrations (`phase: Completed`).
+emits `DataPaths` when the bucketed PVC list has more than one entry, and
+`bucketLegacyDataPVCs` discovers the multi-HDD layout. End-state and
+observability are identical to single-HDD migrations (`phase: Completed`).
+
+Each migrated multi-HDD `DataPaths[i]` carries both `existingClaim` (binds the
+legacy PVC) and `size` (advertised to Garage as the per-disk capacity in
+`data_dir = [{path, capacity}]`). Without `capacity` upstream
+`make_data_dirs` (../garage `src/block/layout.rs`) rejects the config and
+the pod crashloops (#205). The `NodeVolumeConfig` webhook explicitly allows
+`existingClaim + size` together for this reason.
+
+As a defensive fallback, the per-node ConfigMap renderer
+(`reconcileNodeConfigMap`) auto-heals multi-HDD nodes whose
+`dataPaths[].size` is unset by looking up the bound PVC's requested storage
+at render time, so any GarageNode migrated by a pre-#205 operator boots
+cleanly on the next reconcile without a spec edit.
 
 Implementation: `migrateLegacyStorageSTSIfNeeded` in
 `internal/controller/garagecluster_automode.go`. Idempotent and resumable via

--- a/api/v1beta1/garagenode_types.go
+++ b/api/v1beta1/garagenode_types.go
@@ -98,15 +98,21 @@ type NodeLoggingConfig struct {
 
 // NodeVolumeConfig defines the source of a storage volume for a GarageNode.
 // Parallel to GarageCluster's VolumeConfig, extended with existingClaim for
-// pre-provisioned PVCs. Either ExistingClaim or Size must be specified, not both.
+// pre-provisioned PVCs. Either ExistingClaim or Size must be specified.
+//
+// ExistingClaim and Size may also be set together inside a multi-HDD
+// `storage.dataPaths[]` entry — there ExistingClaim binds the PVC and Size
+// is the capacity advertised to Garage in `data_dir = [{path, capacity}]`.
+// Combining them on `storage.{metadata,data}` is allowed by the webhook but
+// has no effect since those slots don't emit a TOML capacity field.
 type NodeVolumeConfig struct {
 	// ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-	// Mutually exclusive with Size.
 	// +optional
 	ExistingClaim string `json:"existingClaim,omitempty"`
 
-	// Size creates a dynamically provisioned PVC with this capacity.
-	// Mutually exclusive with ExistingClaim.
+	// Size creates a dynamically provisioned PVC with this capacity. For
+	// multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+	// `existingClaim` to declare the capacity advertised to Garage.
 	// +optional
 	Size *resource.Quantity `json:"size,omitempty"`
 

--- a/api/v1beta1/garagenode_webhook.go
+++ b/api/v1beta1/garagenode_webhook.go
@@ -201,10 +201,12 @@ func validateVolumeSource(vs *NodeVolumeConfig, fieldPath string) error {
 	hasExistingClaim := vs.ExistingClaim != ""
 	hasSize := vs.Size != nil
 
-	if hasExistingClaim && hasSize {
-		return fmt.Errorf("%s: cannot specify both existingClaim and size (choose one)", fieldPath)
-	}
-
+	// existingClaim + size is permitted: in multi-HDD `storage.dataPaths[]`
+	// entries Size is the capacity advertised to Garage in `data_dir`, which
+	// has independent semantics from PVC binding. The legacy-STS migration
+	// (#205) populates both so the operator's per-node ConfigMap renderer
+	// emits a complete `data_dir = [{ path = ..., capacity = ... }]` for
+	// multi-HDD nodes adopted from pre-#190 layouts.
 	if !hasExistingClaim && !hasSize {
 		return fmt.Errorf("%s: must specify either existingClaim or size", fieldPath)
 	}

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -258,11 +258,21 @@ func (r *GarageClusterReconciler) listAutoModeStorageNodes(ctx context.Context, 
 // storage.dataPaths[].existingClaim). Empty/nil arguments tell the GarageNode
 // controller to provision fresh PVCs via volumeClaimTemplates from the
 // cluster's storage spec.
+// legacyDataPVC is the {name, size} pair the migration path threads from
+// listed PVCs into buildAutoModeStorageNode so the resulting GarageNode's
+// DataPaths[i].Size mirrors the legacy PVC's requested storage. Without
+// Size the per-node ConfigMap renders multi-HDD data_dir entries without
+// a capacity field, which Garage's parser rejects (#205).
+type legacyDataPVC struct {
+	name string
+	size *resource.Quantity
+}
+
 func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 	cluster *garagev1beta2.GarageCluster,
 	ordinal int32,
 	nodeID, metadataPVC string,
-	dataPVCs []string,
+	dataPVCs []legacyDataPVC,
 ) (*garagev1beta1.GarageNode, error) {
 	name := autoModeGarageNodeName(cluster.Name, ordinal)
 
@@ -313,11 +323,20 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 	case len(dataPVCs) > 1:
 		paths := make([]garagev1beta1.NodeVolumeConfig, 0, len(dataPVCs))
 		for _, pvc := range dataPVCs {
-			paths = append(paths, garagev1beta1.NodeVolumeConfig{ExistingClaim: pvc})
+			entry := garagev1beta1.NodeVolumeConfig{ExistingClaim: pvc.name}
+			// Garage rejects multi-`data_dir` entries with no capacity
+			// (config.rs DataDir requires capacity unless read_only=true).
+			// Carry the legacy PVC's requested storage forward so the per-node
+			// ConfigMap renderer emits `capacity = "<size>"`.
+			if pvc.size != nil && !pvc.size.IsZero() {
+				s := pvc.size.DeepCopy()
+				entry.Size = &s
+			}
+			paths = append(paths, entry)
 		}
 		storage.DataPaths = paths
 	case len(dataPVCs) == 1:
-		storage.Data = &garagev1beta1.NodeVolumeConfig{ExistingClaim: dataPVCs[0]}
+		storage.Data = &garagev1beta1.NodeVolumeConfig{ExistingClaim: dataPVCs[0].name}
 	default:
 		// Fresh create — mirror cluster's Data spec. Multi-path on the cluster
 		// projects to per-node DataPaths[] (one PVC per path on each node).
@@ -705,7 +724,7 @@ func (r *GarageClusterReconciler) migrateLegacyStorageSTSIfNeeded(ctx context.Co
 				msg := fmt.Sprintf("ordinal %d: data PVC %q not found: %v", ord, single, err)
 				return r.failMigration(ctx, cluster, msg)
 			}
-			dataPVCs = []string{single}
+			dataPVCs = []legacyDataPVC{{name: single, size: pvcRequestedStorage(dPVC)}}
 		}
 
 		desired, err := r.buildAutoModeStorageNode(cluster, ord, nodeIDByOrdinal[ord], metadataPVC, dataPVCs)
@@ -719,7 +738,11 @@ func (r *GarageClusterReconciler) migrateLegacyStorageSTSIfNeeded(ctx context.Co
 		if err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing); err == nil {
 			log.Info("Migration: GarageNode already exists, leaving in place", "name", desired.Name)
 		} else if errors.IsNotFound(err) {
-			log.Info("Migration: creating GarageNode bound to legacy PVCs", "name", desired.Name, "metadataPVC", metadataPVC, "dataPVCs", dataPVCs, "nodeID", nodeIDByOrdinal[ord])
+			dataPVCNames := make([]string, len(dataPVCs))
+			for i, p := range dataPVCs {
+				dataPVCNames[i] = p.name
+			}
+			log.Info("Migration: creating GarageNode bound to legacy PVCs", "name", desired.Name, "metadataPVC", metadataPVC, "dataPVCs", dataPVCNames, "nodeID", nodeIDByOrdinal[ord])
 			if createErr := r.Create(ctx, desired); createErr != nil && !errors.IsAlreadyExists(createErr) {
 				return fmt.Errorf("migration: creating GarageNode %s: %w", desired.Name, createErr)
 			}
@@ -798,20 +821,22 @@ func (r *GarageClusterReconciler) deleteOrphanLegacyStoragePods(ctx context.Cont
 }
 
 // bucketLegacyDataPVCs scans a list of PVCs and returns a map of ordinal to
-// the sorted list of multi-HDD data PVC names (`data-<idx>-<cluster>-<ord>`)
+// the sorted list of multi-HDD data PVCs (`data-<idx>-<cluster>-<ord>`)
 // belonging to that ordinal, ordered by idx ascending. Single-HDD PVCs
 // (`data-<cluster>-<ord>`) are not returned here — the caller handles those by
 // direct name lookup. PVCs with names that don't match the multi-HDD layout
-// are silently ignored.
-func bucketLegacyDataPVCs(pvcs []corev1.PersistentVolumeClaim, clusterName string) map[int32][]string {
+// are silently ignored. Each returned entry carries the PVC's requested
+// storage so the migration can populate `DataPaths[i].Size`.
+func bucketLegacyDataPVCs(pvcs []corev1.PersistentVolumeClaim, clusterName string) map[int32][]legacyDataPVC {
 	type entry struct {
-		idx  int
-		name string
+		idx int
+		pvc legacyDataPVC
 	}
 	tmp := map[int32][]entry{}
 	prefix := dataVolName + "-"
 	clusterMarker := "-" + clusterName + "-"
-	for _, pvc := range pvcs {
+	for i := range pvcs {
+		pvc := &pvcs[i]
 		name := pvc.Name
 		if !strings.HasPrefix(name, prefix) {
 			continue
@@ -837,18 +862,45 @@ func bucketLegacyDataPVCs(pvcs []corev1.PersistentVolumeClaim, clusterName strin
 			continue
 		}
 		ord := int32(ord64)
-		tmp[ord] = append(tmp[ord], entry{idx: idx, name: name})
+		tmp[ord] = append(tmp[ord], entry{idx: idx, pvc: legacyDataPVC{name: name, size: pvcRequestedStorage(pvc)}})
 	}
-	out := make(map[int32][]string, len(tmp))
+	out := make(map[int32][]legacyDataPVC, len(tmp))
 	for ord, entries := range tmp {
 		sort.Slice(entries, func(i, j int) bool { return entries[i].idx < entries[j].idx })
-		names := make([]string, len(entries))
+		items := make([]legacyDataPVC, len(entries))
 		for i, e := range entries {
-			names[i] = e.name
+			items[i] = e.pvc
 		}
-		out[ord] = names
+		out[ord] = items
 	}
 	return out
+}
+
+// pvcRequestedStorage returns the storage request from a PVC spec, or nil
+// when unset. The migration prefers spec.resources.requests over
+// status.capacity because:
+//   - spec is the user-declared size, which matches what Garage was
+//     configured with originally;
+//   - status.capacity may be larger after a resize, which is fine, but it
+//     can also be unset if the PVC is still Pending.
+//
+// The fallback in the per-node ConfigMap renderer (garagenode_controller.go)
+// independently looks up PVCs by name at render time, so a nil here is not
+// catastrophic — it just means the heal happens at config render rather
+// than at migration time.
+func pvcRequestedStorage(pvc *corev1.PersistentVolumeClaim) *resource.Quantity {
+	if pvc == nil {
+		return nil
+	}
+	if req, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok && !req.IsZero() {
+		q := req.DeepCopy()
+		return &q
+	}
+	if cap, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok && !cap.IsZero() {
+		q := cap.DeepCopy()
+		return &q
+	}
+	return nil
 }
 
 // discoverLegacyNodeIDsByOrdinal fetches the Garage cluster layout and maps

--- a/internal/controller/garagecluster_automode_test.go
+++ b/internal/controller/garagecluster_automode_test.go
@@ -719,28 +719,47 @@ var _ = Describe("buildAutoModeStorageNode PublicEndpoint propagation (bug #7)",
 })
 
 var _ = Describe("bucketLegacyDataPVCs", func() {
-	makePVC := func(name string) corev1.PersistentVolumeClaim {
-		return corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	makePVC := func(name, size string) corev1.PersistentVolumeClaim {
+		return corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
+				},
+			},
+		}
+	}
+	names := func(bucket []legacyDataPVC) []string {
+		out := make([]string, len(bucket))
+		for i, p := range bucket {
+			out[i] = p.name
+		}
+		return out
 	}
 
-	It("buckets multi-HDD PVCs by ordinal in index order", func() {
+	It("buckets multi-HDD PVCs by ordinal in index order, carrying PVC sizes", func() {
 		pvcs := []corev1.PersistentVolumeClaim{
-			makePVC("data-1-my-cluster-0"),
-			makePVC("data-0-my-cluster-0"),
-			makePVC("data-2-my-cluster-1"),
-			makePVC("data-0-my-cluster-1"),
-			makePVC("data-1-my-cluster-1"),
+			makePVC("data-1-my-cluster-0", "20Gi"),
+			makePVC("data-0-my-cluster-0", "10Gi"),
+			makePVC("data-2-my-cluster-1", "30Gi"),
+			makePVC("data-0-my-cluster-1", "10Gi"),
+			makePVC("data-1-my-cluster-1", "20Gi"),
 		}
 		got := bucketLegacyDataPVCs(pvcs, "my-cluster")
 		Expect(got).To(HaveLen(2))
-		Expect(got[0]).To(Equal([]string{"data-0-my-cluster-0", "data-1-my-cluster-0"}))
-		Expect(got[1]).To(Equal([]string{"data-0-my-cluster-1", "data-1-my-cluster-1", "data-2-my-cluster-1"}))
+		Expect(names(got[0])).To(Equal([]string{"data-0-my-cluster-0", "data-1-my-cluster-0"}))
+		Expect(names(got[1])).To(Equal([]string{"data-0-my-cluster-1", "data-1-my-cluster-1", "data-2-my-cluster-1"}))
+		// Sizes propagate so the GarageNode controller emits TOML
+		// `data_dir = [{ path = ..., capacity = ... }]` per #205.
+		Expect(got[0][0].size.String()).To(Equal("10Gi"))
+		Expect(got[0][1].size.String()).To(Equal("20Gi"))
+		Expect(got[1][2].size.String()).To(Equal("30Gi"))
 	})
 
 	It("ignores single-HDD PVCs (caller resolves those by direct lookup)", func() {
 		pvcs := []corev1.PersistentVolumeClaim{
-			makePVC("data-my-cluster-0"),
-			makePVC("metadata-my-cluster-0"),
+			makePVC("data-my-cluster-0", "10Gi"),
+			makePVC("metadata-my-cluster-0", "1Gi"),
 		}
 		got := bucketLegacyDataPVCs(pvcs, "my-cluster")
 		Expect(got).To(BeEmpty())
@@ -748,9 +767,9 @@ var _ = Describe("bucketLegacyDataPVCs", func() {
 
 	It("ignores unrelated PVCs and name-collisions with non-numeric idx", func() {
 		pvcs := []corev1.PersistentVolumeClaim{
-			makePVC("data-abc-my-cluster-0"),
-			makePVC("other-thing"),
-			makePVC("data-0-other-cluster-0"),
+			makePVC("data-abc-my-cluster-0", "10Gi"),
+			makePVC("other-thing", "10Gi"),
+			makePVC("data-0-other-cluster-0", "10Gi"),
 		}
 		got := bucketLegacyDataPVCs(pvcs, "my-cluster")
 		Expect(got).To(BeEmpty())

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -635,6 +635,27 @@ func nodeHasMultiHDD(node *garagev1beta1.GarageNode) bool {
 	return len(node.Spec.Storage.DataPaths) > 0
 }
 
+// lookupPVCCapacity returns a TOML-ready capacity string (e.g. "10Gi") for
+// the named PVC, preferring its spec.resources.requests.storage and falling
+// back to status.capacity.storage. Returns "" if neither is set or the PVC
+// is not found. Used by the per-node ConfigMap renderer to heal multi-HDD
+// GarageNodes whose `spec.storage.dataPaths[].size` is unset — a state the
+// pre-#205 legacy-STS migration would leave behind, causing Garage to
+// reject `data_dir` (no capacity) and the storage pod to crashloop.
+func (r *GarageNodeReconciler) lookupPVCCapacity(ctx context.Context, ns, name string) string {
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, pvc); err != nil {
+		return ""
+	}
+	if req, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok && !req.IsZero() {
+		return req.String()
+	}
+	if cap, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok && !cap.IsZero() {
+		return cap.String()
+	}
+	return ""
+}
+
 // buildNodeVolumesAndMounts returns volumes and volume mounts for a GarageNode's StatefulSet.
 func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumeMounts := []corev1.VolumeMount{
@@ -1738,13 +1759,23 @@ func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node 
 		cfgCtx.NodeMetadataAutoSnapshotInterval = node.Spec.Storage.MetadataAutoSnapshotInterval
 
 		// Multi-HDD data_dir: one TOML entry per mounted disk. Capacity is taken
-		// from the PVC Size when present (the disk size).
+		// from the PVC Size when present (the disk size). When Size is unset
+		// and the entry is pinned to an existing PVC (the legacy-STS migration
+		// path before #205 left Size empty), fall back to the PVC's requested
+		// storage so Garage's parser accepts the data_dir block — upstream
+		// `make_data_dirs` rejects entries with no capacity unless read_only
+		// is set (../garage src/block/layout.rs).
 		if len(node.Spec.Storage.DataPaths) > 0 {
 			paths := make([]NodeDataDirPath, 0, len(node.Spec.Storage.DataPaths))
 			for i, dp := range node.Spec.Storage.DataPaths {
 				p := NodeDataDirPath{Path: nodeMultiHDDDataPath(i)}
-				if dp.Size != nil && !dp.Size.IsZero() {
+				switch {
+				case dp.Size != nil && !dp.Size.IsZero():
 					p.Capacity = dp.Size.String()
+				case dp.ExistingClaim != "":
+					if cap := r.lookupPVCCapacity(ctx, cluster.Namespace, dp.ExistingClaim); cap != "" {
+						p.Capacity = cap
+					}
 				}
 				paths = append(paths, p)
 			}

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -1017,6 +1017,79 @@ var _ = Describe("GarageNode multi-HDD storage layout", func() {
 		Expect(toml).To(ContainSubstring(`{ path = "/data/data-0", capacity = "50Gi" }`))
 		Expect(toml).To(ContainSubstring(`{ path = "/data/data-1", capacity = "70Gi" }`))
 	})
+
+	// #205: pre-fix legacy-STS migrations created multi-HDD GarageNodes with
+	// `dataPaths[].existingClaim` set but no Size, so the ConfigMap rendered
+	// `data_dir = [{ path = "..." }]` without capacity — which Garage's
+	// parser (../garage src/block/layout.rs `make_data_dirs`) rejects, killing
+	// the storage pod. The renderer must heal these by reading the bound
+	// PVC's requested storage at render time.
+	It("falls back to the bound PVC capacity when dataPaths[].size is unset (#205 heal)", func() {
+		cluster := makeCluster(ctx)
+		nodeName := "heal-205-node"
+		uniqueNS := nodeName
+		// Use existing-claim PVCs in the test namespace; the migration shape.
+		pvc0 := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: uniqueNS + "-data-0", Namespace: testNamespace},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("33Gi")},
+				},
+			},
+		}
+		pvc1 := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: uniqueNS + "-data-1", Namespace: testNamespace},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("44Gi")},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pvc0)).To(Succeed())
+		Expect(k8sClient.Create(ctx, pvc1)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, pvc0)
+			_ = k8sClient.Delete(ctx, pvc1)
+		}()
+
+		capacity := resource.MustParse("100Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &capacity,
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					DataPaths: []garagev1beta1.NodeVolumeConfig{
+						{ExistingClaim: pvc0.Name},
+						{ExistingClaim: pvc1.Name},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		defer func() {
+			n := &garagev1beta1.GarageNode{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, n); err == nil {
+				n.Finalizers = nil
+				_ = k8sClient.Update(ctx, n)
+				_ = k8sClient.Delete(ctx, n)
+			}
+			_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-config", Namespace: testNamespace}})
+		}()
+
+		r := &GarageNodeReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		Expect(r.reconcileNodeConfigMap(ctx, node, cluster)).To(Succeed())
+
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName + "-config", Namespace: testNamespace}, cm)).To(Succeed())
+		toml := cm.Data["garage.toml"]
+		Expect(toml).To(ContainSubstring(`{ path = "/data/data-0", capacity = "33Gi" }`))
+		Expect(toml).To(ContainSubstring(`{ path = "/data/data-1", capacity = "44Gi" }`))
+	})
 })
 
 var _ = Describe("GarageNode per-node env/envFrom/logging/snapshots", func() {


### PR DESCRIPTION
## Summary

- Multi-HDD migration (#190/#192) was creating `GarageNode`s with `spec.storage.dataPaths[].existingClaim` set but no `size`, so the per-node ConfigMap emitted `data_dir = [{ path = "..." }]` with no `capacity` — which upstream Garage's `make_data_dirs` (`src/block/layout.rs`) rejects, crashlooping the pod after upgrade from v0.5.11 to v0.6.x.
- Migration now threads each legacy PVC's requested storage into `DataPaths[i].Size`, and the `NodeVolumeConfig` webhook is relaxed to allow `existingClaim + size` together (independent semantics for `dataPaths[]`).
- ConfigMap renderer falls back to the bound PVC's requested storage when `dataPaths[i].size` is unset, so GarageNodes already created by a pre-fix operator heal on the next reconcile with no spec edit.

Fixes #205.

## Architectural cross-check vs upstream `../garage`

`src/util/config.rs`:
- `DataDirEnum::Multiple(Vec<DataDir>)` requires every entry to set either `capacity` or `read_only`.

`src/block/layout.rs` `make_data_dirs`:
```rust
Some(cap) if !dir.read_only => DataDirState::Active { capacity: parsed },
None if dir.read_only       => DataDirState::ReadOnly,
_ => return Err("data directories in data_dir should have a capacity value or be marked read_only, not the case for {path}")
```
Plus: needs at least one writable entry, otherwise `"incorrect data_dir configuration, no primary writable directory specified"`.

This PR's TOML always emits `capacity = "<bytesize>"` for every writable entry, which `bytesize::ByteSize::from_str` accepts in Kubernetes' `resource.Quantity` formats (e.g. `200Mi`, `2Gi`).

## Test plan

- [x] Unit tests for `bucketLegacyDataPVCs` capacity propagation
- [x] Unit test for `reconcileNodeConfigMap` PVC fallback when `dataPaths[].size` is unset
- [x] `go test ./... -count=1` green
- [x] `make lint` 0 issues
- [x] Kind: synthesised v0.5.x legacy multi-HDD layout → migrated `GarageNode` has `dataPaths[].{existingClaim,size}` populated, rendered TOML emits `data_dir = [{ path = ..., capacity = ... }]` per disk
- [x] Kind: stripping `size` from the spec confirms the PVC-fallback heal path renders capacity independently
- [ ] GitHub workflows: test, lint, test-e2e, docker, helm