### PR TITLE
fix(migration): preserve cluster per-disk paths + readOnly + guard replicas=0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,18 +281,44 @@ emits `DataPaths` when the bucketed PVC list has more than one entry, and
 `bucketLegacyDataPVCs` discovers the multi-HDD layout. End-state and
 observability are identical to single-HDD migrations (`phase: Completed`).
 
-Each migrated multi-HDD `DataPaths[i]` carries both `existingClaim` (binds the
-legacy PVC) and `size` (advertised to Garage as the per-disk capacity in
-`data_dir = [{path, capacity}]`). Without `capacity` upstream
-`make_data_dirs` (../garage `src/block/layout.rs`) rejects the config and
-the pod crashloops (#205). The `NodeVolumeConfig` webhook explicitly allows
-`existingClaim + size` together for this reason.
+Each migrated multi-HDD `DataPaths[i]` carries:
+
+- `existingClaim` — binds to the legacy PVC (`data-<idx>-<cluster>-<ord>`).
+- `size` — advertised to Garage as the per-disk capacity in
+  `data_dir = [{path, capacity}]`. Without `capacity` upstream
+  `make_data_dirs` (../garage `src/block/layout.rs`) rejects the config and
+  the pod crashloops (#205). The `NodeVolumeConfig` webhook explicitly
+  allows `existingClaim + size` together for this reason.
+- `path` and `readOnly` — copied index-aligned from
+  `cluster.spec.storage.data.paths[i]`. Garage's on-disk `DataLayout`
+  (G09bmdl) is keyed by `path`, so preserving the user's original mount
+  paths means Garage finds the same partitions at the same paths after
+  upgrade. Without this, `DataLayout::update` sees the old path missing +
+  the new path empty, reassigns partitions, and refetches blocks from
+  peers even though the same on-disk data is still present (just at the
+  hardcoded `/data/data-<i>` mount). `readOnly: true` emits `read_only =
+  true` in the TOML entry and drops capacity (parity with upstream
+  `DataDir.read_only`). The webhook accepts `readOnly: true` alone with
+  no `size`/`existingClaim` on `dataPaths[]` entries.
+
+`NodeVolumeConfig.Path` and `ReadOnly` apply only inside multi-HDD
+`storage.dataPaths[]`. On `storage.{metadata,data}` they're harmless but
+have no effect since those slots don't render TOML capacity/path fields.
 
 As a defensive fallback, the per-node ConfigMap renderer
 (`reconcileNodeConfigMap`) auto-heals multi-HDD nodes whose
 `dataPaths[].size` is unset by looking up the bound PVC's requested storage
 at render time, so any GarageNode migrated by a pre-#205 operator boots
 cleanly on the next reconcile without a spec edit.
+
+When the legacy STS has `replicas=0` AND legacy PVCs (metadata or data)
+still exist, the operator **refuses to migrate** (`failMigration` with
+`reason: Failed`, message containing `replicas=0`). Without this guard
+the per-ordinal loop iterates zero times, the STS is orphan-deleted, the
+condition is set to Completed, and the PVCs are stranded forever. The
+user must scale the STS back up to its original replica count (so the
+migration can adopt each metadata + data PVC by name) or delete the
+leftover PVCs to abandon the data.
 
 Implementation: `migrateLegacyStorageSTSIfNeeded` in
 `internal/controller/garagecluster_automode.go`. Idempotent and resumable via

--- a/api/v1beta1/garagenode_types.go
+++ b/api/v1beta1/garagenode_types.go
@@ -131,6 +131,23 @@ type NodeVolumeConfig struct {
 	// Defaults to [ReadWriteOnce] if not specified.
 	// +optional
 	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
+
+	// Path is the in-container mount path for this volume. Only honored on
+	// multi-HDD `storage.dataPaths[]` entries — both the K8s volumeMount and
+	// the rendered garage.toml `data_dir = [{ path = ... }]` use this value.
+	// Defaults to `/data/data-<i>` when unset. The legacy-STS migration
+	// propagates `cluster.spec.storage.data.paths[i].path` so that on first
+	// boot Garage's DataLayout sees the same paths it stored under
+	// pre-migration, avoiding partition reassignment and unnecessary
+	// cross-peer block refetch (../garage src/block/layout.rs).
+	// +optional
+	Path string `json:"path,omitempty"`
+
+	// ReadOnly marks the entry as a legacy read-only path on multi-HDD
+	// `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+	// no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+	// +optional
+	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
 // GarageNodeSpec defines the desired state of GarageNode.

--- a/api/v1beta1/garagenode_webhook.go
+++ b/api/v1beta1/garagenode_webhook.go
@@ -207,8 +207,12 @@ func validateVolumeSource(vs *NodeVolumeConfig, fieldPath string) error {
 	// (#205) populates both so the operator's per-node ConfigMap renderer
 	// emits a complete `data_dir = [{ path = ..., capacity = ... }]` for
 	// multi-HDD nodes adopted from pre-#190 layouts.
-	if !hasExistingClaim && !hasSize {
-		return fmt.Errorf("%s: must specify either existingClaim or size", fieldPath)
+	//
+	// readOnly satisfies the requirement on its own — upstream Garage allows
+	// `data_dir` entries with `read_only = true` and no capacity (see
+	// ../garage src/block/layout.rs `make_data_dirs`).
+	if !hasExistingClaim && !hasSize && !vs.ReadOnly {
+		return fmt.Errorf("%s: must specify existingClaim, size, or readOnly", fieldPath)
 	}
 
 	if vs.StorageClassName != nil && hasExistingClaim {

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
@@ -2040,17 +2040,34 @@ spec:
                           type: string
                         type: array
                       existingClaim:
-                        description: |-
-                          ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                          Mutually exclusive with Size.
+                        description: ExistingClaim references a pre-existing PVC by
+                          name in the cluster namespace.
                         type: string
+                      path:
+                        description: |-
+                          Path is the in-container mount path for this volume. Only honored on
+                          multi-HDD `storage.dataPaths[]` entries — both the K8s volumeMount and
+                          the rendered garage.toml `data_dir = [{ path = ... }]` use this value.
+                          Defaults to `/data/data-<i>` when unset. The legacy-STS migration
+                          propagates `cluster.spec.storage.data.paths[i].path` so that on first
+                          boot Garage's DataLayout sees the same paths it stored under
+                          pre-migration, avoiding partition reassignment and unnecessary
+                          cross-peer block refetch (../garage src/block/layout.rs).
+                        type: string
+                      readOnly:
+                        description: |-
+                          ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                          `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                          no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                        type: boolean
                       size:
                         anyOf:
                         - type: integer
                         - type: string
                         description: |-
-                          Size creates a dynamically provisioned PVC with this capacity.
-                          Mutually exclusive with ExistingClaim.
+                          Size creates a dynamically provisioned PVC with this capacity. For
+                          multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                          `existingClaim` to declare the capacity advertised to Garage.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       storageClassName:
@@ -2086,7 +2103,13 @@ spec:
                       description: |-
                         NodeVolumeConfig defines the source of a storage volume for a GarageNode.
                         Parallel to GarageCluster's VolumeConfig, extended with existingClaim for
-                        pre-provisioned PVCs. Either ExistingClaim or Size must be specified, not both.
+                        pre-provisioned PVCs. Either ExistingClaim or Size must be specified.
+
+                        ExistingClaim and Size may also be set together inside a multi-HDD
+                        `storage.dataPaths[]` entry — there ExistingClaim binds the PVC and Size
+                        is the capacity advertised to Garage in `data_dir = [{path, capacity}]`.
+                        Combining them on `storage.{metadata,data}` is allowed by the webhook but
+                        has no effect since those slots don't emit a TOML capacity field.
                       properties:
                         accessModes:
                           description: |-
@@ -2096,17 +2119,34 @@ spec:
                             type: string
                           type: array
                         existingClaim:
-                          description: |-
-                            ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                            Mutually exclusive with Size.
+                          description: ExistingClaim references a pre-existing PVC
+                            by name in the cluster namespace.
                           type: string
+                        path:
+                          description: |-
+                            Path is the in-container mount path for this volume. Only honored on
+                            multi-HDD `storage.dataPaths[]` entries — both the K8s volumeMount and
+                            the rendered garage.toml `data_dir = [{ path = ... }]` use this value.
+                            Defaults to `/data/data-<i>` when unset. The legacy-STS migration
+                            propagates `cluster.spec.storage.data.paths[i].path` so that on first
+                            boot Garage's DataLayout sees the same paths it stored under
+                            pre-migration, avoiding partition reassignment and unnecessary
+                            cross-peer block refetch (../garage src/block/layout.rs).
+                          type: string
+                        readOnly:
+                          description: |-
+                            ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                            `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                            no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                          type: boolean
                         size:
                           anyOf:
                           - type: integer
                           - type: string
                           description: |-
-                            Size creates a dynamically provisioned PVC with this capacity.
-                            Mutually exclusive with ExistingClaim.
+                            Size creates a dynamically provisioned PVC with this capacity. For
+                            multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                            `existingClaim` to declare the capacity advertised to Garage.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         storageClassName:
@@ -2139,17 +2179,34 @@ spec:
                           type: string
                         type: array
                       existingClaim:
-                        description: |-
-                          ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                          Mutually exclusive with Size.
+                        description: ExistingClaim references a pre-existing PVC by
+                          name in the cluster namespace.
                         type: string
+                      path:
+                        description: |-
+                          Path is the in-container mount path for this volume. Only honored on
+                          multi-HDD `storage.dataPaths[]` entries — both the K8s volumeMount and
+                          the rendered garage.toml `data_dir = [{ path = ... }]` use this value.
+                          Defaults to `/data/data-<i>` when unset. The legacy-STS migration
+                          propagates `cluster.spec.storage.data.paths[i].path` so that on first
+                          boot Garage's DataLayout sees the same paths it stored under
+                          pre-migration, avoiding partition reassignment and unnecessary
+                          cross-peer block refetch (../garage src/block/layout.rs).
+                        type: string
+                      readOnly:
+                        description: |-
+                          ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                          `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                          no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                        type: boolean
                       size:
                         anyOf:
                         - type: integer
                         - type: string
                         description: |-
-                          Size creates a dynamically provisioned PVC with this capacity.
-                          Mutually exclusive with ExistingClaim.
+                          Size creates a dynamically provisioned PVC with this capacity. For
+                          multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                          `existingClaim` to declare the capacity advertised to Garage.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       storageClassName:

--- a/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
@@ -2040,17 +2040,34 @@ spec:
                           type: string
                         type: array
                       existingClaim:
-                        description: |-
-                          ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                          Mutually exclusive with Size.
+                        description: ExistingClaim references a pre-existing PVC by
+                          name in the cluster namespace.
                         type: string
+                      path:
+                        description: |-
+                          Path is the in-container mount path for this volume. Only honored on
+                          multi-HDD `storage.dataPaths[]` entries — both the K8s volumeMount and
+                          the rendered garage.toml `data_dir = [{ path = ... }]` use this value.
+                          Defaults to `/data/data-<i>` when unset. The legacy-STS migration
+                          propagates `cluster.spec.storage.data.paths[i].path` so that on first
+                          boot Garage's DataLayout sees the same paths it stored under
+                          pre-migration, avoiding partition reassignment and unnecessary
+                          cross-peer block refetch (../garage src/block/layout.rs).
+                        type: string
+                      readOnly:
+                        description: |-
+                          ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                          `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                          no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                        type: boolean
                       size:
                         anyOf:
                         - type: integer
                         - type: string
                         description: |-
-                          Size creates a dynamically provisioned PVC with this capacity.
-                          Mutually exclusive with ExistingClaim.
+                          Size creates a dynamically provisioned PVC with this capacity. For
+                          multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                          `existingClaim` to declare the capacity advertised to Garage.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       storageClassName:
@@ -2086,7 +2103,13 @@ spec:
                       description: |-
                         NodeVolumeConfig defines the source of a storage volume for a GarageNode.
                         Parallel to GarageCluster's VolumeConfig, extended with existingClaim for
-                        pre-provisioned PVCs. Either ExistingClaim or Size must be specified, not both.
+                        pre-provisioned PVCs. Either ExistingClaim or Size must be specified.
+
+                        ExistingClaim and Size may also be set together inside a multi-HDD
+                        `storage.dataPaths[]` entry — there ExistingClaim binds the PVC and Size
+                        is the capacity advertised to Garage in `data_dir = [{path, capacity}]`.
+                        Combining them on `storage.{metadata,data}` is allowed by the webhook but
+                        has no effect since those slots don't emit a TOML capacity field.
                       properties:
                         accessModes:
                           description: |-
@@ -2096,17 +2119,34 @@ spec:
                             type: string
                           type: array
                         existingClaim:
-                          description: |-
-                            ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                            Mutually exclusive with Size.
+                          description: ExistingClaim references a pre-existing PVC
+                            by name in the cluster namespace.
                           type: string
+                        path:
+                          description: |-
+                            Path is the in-container mount path for this volume. Only honored on
+                            multi-HDD `storage.dataPaths[]` entries — both the K8s volumeMount and
+                            the rendered garage.toml `data_dir = [{ path = ... }]` use this value.
+                            Defaults to `/data/data-<i>` when unset. The legacy-STS migration
+                            propagates `cluster.spec.storage.data.paths[i].path` so that on first
+                            boot Garage's DataLayout sees the same paths it stored under
+                            pre-migration, avoiding partition reassignment and unnecessary
+                            cross-peer block refetch (../garage src/block/layout.rs).
+                          type: string
+                        readOnly:
+                          description: |-
+                            ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                            `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                            no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                          type: boolean
                         size:
                           anyOf:
                           - type: integer
                           - type: string
                           description: |-
-                            Size creates a dynamically provisioned PVC with this capacity.
-                            Mutually exclusive with ExistingClaim.
+                            Size creates a dynamically provisioned PVC with this capacity. For
+                            multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                            `existingClaim` to declare the capacity advertised to Garage.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         storageClassName:
@@ -2139,17 +2179,34 @@ spec:
                           type: string
                         type: array
                       existingClaim:
-                        description: |-
-                          ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                          Mutually exclusive with Size.
+                        description: ExistingClaim references a pre-existing PVC by
+                          name in the cluster namespace.
                         type: string
+                      path:
+                        description: |-
+                          Path is the in-container mount path for this volume. Only honored on
+                          multi-HDD `storage.dataPaths[]` entries — both the K8s volumeMount and
+                          the rendered garage.toml `data_dir = [{ path = ... }]` use this value.
+                          Defaults to `/data/data-<i>` when unset. The legacy-STS migration
+                          propagates `cluster.spec.storage.data.paths[i].path` so that on first
+                          boot Garage's DataLayout sees the same paths it stored under
+                          pre-migration, avoiding partition reassignment and unnecessary
+                          cross-peer block refetch (../garage src/block/layout.rs).
+                        type: string
+                      readOnly:
+                        description: |-
+                          ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                          `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                          no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                        type: boolean
                       size:
                         anyOf:
                         - type: integer
                         - type: string
                         description: |-
-                          Size creates a dynamically provisioned PVC with this capacity.
-                          Mutually exclusive with ExistingClaim.
+                          Size creates a dynamically provisioned PVC with this capacity. For
+                          multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                          `existingClaim` to declare the capacity advertised to Garage.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       storageClassName:

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -319,10 +319,21 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 	//   * len(dataPVCs) == 0 → fresh create: pass through cluster.Spec.Storage.Data
 	//                          (or its Paths[]) so the GarageNode controller provisions
 	//                          via volumeClaimTemplates.
+	// clusterPaths is the index-aligned source of per-disk path/readOnly when
+	// the cluster spec declared a multi-HDD layout. Migration uses these to
+	// preserve the user's original mount paths so Garage's on-disk DataLayout
+	// (../garage src/block/layout.rs `update`) sees the same paths it indexed
+	// pre-upgrade — otherwise partitions get reassigned and blocks are
+	// refetched from peers even though they live at the new mount.
+	var clusterPaths []garagev1beta2.DataPath
+	if cluster.Spec.Storage.Data != nil {
+		clusterPaths = cluster.Spec.Storage.Data.Paths
+	}
+
 	switch {
 	case len(dataPVCs) > 1:
 		paths := make([]garagev1beta1.NodeVolumeConfig, 0, len(dataPVCs))
-		for _, pvc := range dataPVCs {
+		for i, pvc := range dataPVCs {
 			entry := garagev1beta1.NodeVolumeConfig{ExistingClaim: pvc.name}
 			// Garage rejects multi-`data_dir` entries with no capacity
 			// (config.rs DataDir requires capacity unless read_only=true).
@@ -331,6 +342,10 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 			if pvc.size != nil && !pvc.size.IsZero() {
 				s := pvc.size.DeepCopy()
 				entry.Size = &s
+			}
+			if i < len(clusterPaths) {
+				entry.Path = clusterPaths[i].Path
+				entry.ReadOnly = clusterPaths[i].ReadOnly
 			}
 			paths = append(paths, entry)
 		}
@@ -344,7 +359,7 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 			paths := make([]garagev1beta1.NodeVolumeConfig, 0, len(cluster.Spec.Storage.Data.Paths))
 			topLevel := cluster.Spec.Storage.Data
 			for _, p := range cluster.Spec.Storage.Data.Paths {
-				v := garagev1beta1.NodeVolumeConfig{}
+				v := garagev1beta1.NodeVolumeConfig{Path: p.Path, ReadOnly: p.ReadOnly}
 				switch {
 				case p.Volume != nil && p.Volume.Size != nil && !p.Volume.Size.IsZero():
 					s := p.Volume.Size.DeepCopy()
@@ -365,6 +380,11 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 					v.AccessModes = p.Volume.AccessModes
 				} else {
 					v.AccessModes = topLevel.AccessModes
+				}
+				// Propagate Volume.Type so cluster-level `type: EmptyDir` on a
+				// per-disk volume reaches the GarageNode unchanged (audit #4).
+				if p.Volume != nil && p.Volume.Type != "" {
+					v.Type = garagev1beta1.VolumeType(p.Volume.Type)
 				}
 				paths = append(paths, v)
 			}
@@ -699,6 +719,16 @@ func (r *GarageClusterReconciler) migrateLegacyStorageSTSIfNeeded(ctx context.Co
 		replicas = *legacySTS.Spec.Replicas
 	}
 
+	// replicas=0 + matching legacy PVCs is dangerous: the loop would iterate
+	// zero times, the STS would be orphan-deleted, the migration marked
+	// Completed, and the metadata/data PVCs would be left stranded with no
+	// controller. Refuse and surface a clear status condition so the user
+	// can either scale the STS back up (to migrate) or delete the leftover
+	// PVCs intentionally before re-running. (audit #6)
+	if replicas == 0 && legacyStorageHasLeftoverPVCs(pvcList.Items, cluster.Name, dataPVCsByOrdinal) {
+		return r.failMigration(ctx, cluster, "legacy storage StatefulSet has replicas=0 but legacy PVCs still exist; scale the StatefulSet back up to its original replica count before the operator can migrate, or delete the leftover PVCs to abandon their data")
+	}
+
 	// Try to discover node IDs from live cluster layout (best effort: identity
 	// also survives via the node_key in the metadata PVC, so this is
 	// belt-and-suspenders).
@@ -818,6 +848,36 @@ func (r *GarageClusterReconciler) deleteOrphanLegacyStoragePods(ctx context.Cont
 		}
 	}
 	return nil
+}
+
+// legacyStorageHasLeftoverPVCs reports whether any legacy-shape PVCs for the
+// cluster still exist in the namespace. Used to refuse migration when the
+// legacy STS has replicas=0 but PVCs remain (audit #6). Both metadata
+// (`metadata-<cluster>-<N>`) and data (single-HDD `data-<cluster>-<N>`,
+// multi-HDD `data-<idx>-<cluster>-<N>`) shapes count.
+func legacyStorageHasLeftoverPVCs(pvcs []corev1.PersistentVolumeClaim, clusterName string, multiHDD map[int32][]legacyDataPVC) bool {
+	if len(multiHDD) > 0 {
+		return true
+	}
+	metaPrefix := metadataVolName + "-" + clusterName + "-"
+	singleDataPrefix := dataVolName + "-" + clusterName + "-"
+	for i := range pvcs {
+		name := pvcs[i].Name
+		if !strings.HasPrefix(name, metaPrefix) && !strings.HasPrefix(name, singleDataPrefix) {
+			continue
+		}
+		var suffix string
+		switch {
+		case strings.HasPrefix(name, metaPrefix):
+			suffix = name[len(metaPrefix):]
+		default:
+			suffix = name[len(singleDataPrefix):]
+		}
+		if _, err := strconv.Atoi(suffix); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // bucketLegacyDataPVCs scans a list of PVCs and returns a map of ordinal to

--- a/internal/controller/garagecluster_automode_test.go
+++ b/internal/controller/garagecluster_automode_test.go
@@ -282,7 +282,17 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 					Storage: &garagev1beta2.StorageSpec{
 						Replicas: 2,
 						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
-						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+						Data: &garagev1beta2.VolumeConfig{
+							Size: ptrQuantity(resource.MustParse("10Gi")),
+							// Cluster-level per-disk paths: the legacy STS mounted
+							// data at /mnt/ssd-0 and /mnt/cold-1 (a frozen archive).
+							// Migration must preserve these so Garage's DataLayout
+							// finds blocks at the same paths after upgrade.
+							Paths: []garagev1beta2.DataPath{
+								{Path: "/mnt/ssd-0", Capacity: ptrQuantity(resource.MustParse("10Gi"))},
+								{Path: "/mnt/cold-1", ReadOnly: true},
+							},
+						},
 					},
 					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
 				},
@@ -317,7 +327,57 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 				Expect(n.Spec.Storage.DataPaths).To(HaveLen(2))
 				Expect(n.Spec.Storage.DataPaths[0].ExistingClaim).To(HavePrefix("data-0-" + clusterNN.Name))
 				Expect(n.Spec.Storage.DataPaths[1].ExistingClaim).To(HavePrefix("data-1-" + clusterNN.Name))
+				// Migration must propagate the cluster's per-disk paths and
+				// the read_only flag — DataLayout indexes by path on disk.
+				Expect(n.Spec.Storage.DataPaths[0].Path).To(Equal("/mnt/ssd-0"))
+				Expect(n.Spec.Storage.DataPaths[0].ReadOnly).To(BeFalse())
+				Expect(n.Spec.Storage.DataPaths[1].Path).To(Equal("/mnt/cold-1"))
+				Expect(n.Spec.Storage.DataPaths[1].ReadOnly).To(BeTrue())
 			}
+		})
+
+		It("refuses to mark migration Completed when legacy STS has replicas=0 but PVCs exist", func() {
+			clusterNN = types.NamespacedName{Name: uniqueClusterName("auto-zero-replicas"), Namespace: testNamespace}
+			cluster = &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterNN.Name, Namespace: testNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					LayoutPolicy: LayoutPolicyAuto,
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 2,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			// Legacy STS scaled to zero, but PVCs from the original 2-replica
+			// run are still around — exactly the data-loss scenario the guard
+			// closes (audit #6).
+			legacySTS := makeFakeLegacySTS(clusterNN.Name, 0)
+			Expect(k8sClient.Create(ctx, legacySTS)).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeFakePVC(fmt.Sprintf("metadata-%s-0", clusterNN.Name)))).To(Succeed())
+			Expect(k8sClient.Create(ctx, makeFakePVC(fmt.Sprintf("data-%s-0", clusterNN.Name)))).To(Succeed())
+
+			err := reconciler.migrateLegacyStorageSTSIfNeeded(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("replicas=0"))
+
+			updated := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, clusterNN, updated)).To(Succeed())
+			cond := meta.FindStatusCondition(updated.Status.Conditions, garagev1beta1.ConditionLegacySTSMigrated)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("Failed"))
+			Expect(cond.Message).To(ContainSubstring("replicas=0"))
+
+			// STS must NOT be orphan-deleted; PVCs must still exist.
+			sts := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clusterNN.Name, Namespace: testNamespace}, sts)).To(Succeed())
+			Expect(sts.DeletionTimestamp.IsZero()).To(BeTrue())
+			pvc := &corev1.PersistentVolumeClaim{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("metadata-%s-0", clusterNN.Name), Namespace: testNamespace}, pvc)).To(Succeed())
 		})
 
 		It("migrates a single-HDD legacy STS to per-node GarageNodes with existingClaim set", func() {

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -812,7 +812,8 @@ type configContext struct {
 // NodeDataDirPath is one mount path in a per-node multi-HDD garage.toml data_dir array.
 type NodeDataDirPath struct {
 	Path     string
-	Capacity string // optional; if empty, the entry is emitted without a capacity attribute
+	Capacity string // optional; if empty and ReadOnly is false the entry has no capacity attribute
+	ReadOnly bool   // emits `read_only = true`; mutually exclusive with Capacity per Garage's parser
 }
 
 // buildConfigContext creates a configContext by resolving secrets referenced in the cluster spec.
@@ -921,7 +922,10 @@ func writeDataDirConfig(config *strings.Builder, cluster *garagev1beta2.GarageCl
 		config.WriteString("data_dir = [\n")
 		for i, p := range cfgCtx.NodeDataDirPaths {
 			fmt.Fprintf(config, "    { path = \"%s\"", p.Path)
-			if p.Capacity != "" {
+			switch {
+			case p.ReadOnly:
+				config.WriteString(", read_only = true")
+			case p.Capacity != "":
 				fmt.Fprintf(config, ", capacity = \"%s\"", p.Capacity)
 			}
 			config.WriteString(" }")

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -612,12 +612,25 @@ func (r *GarageNodeReconciler) expandNodePVCs(ctx context.Context, node *garagev
 	return nil
 }
 
-// nodeMultiHDDDataPath returns the mount path for the i-th data volume on a
-// multi-HDD GarageNode. Single-HDD nodes continue to use the legacy `/data/data`
-// (see helpers.go `dataPath`). Multi-HDD mount paths are sibling directories
-// under /data so they match the cluster-tier multi-HDD layout.
+// nodeMultiHDDDataPath returns the default mount path for the i-th data volume
+// on a multi-HDD GarageNode when the spec carries no explicit Path. Single-HDD
+// nodes continue to use the legacy `/data/data` (see helpers.go `dataPath`).
+// Multi-HDD mount paths are sibling directories under /data so they match the
+// cluster-tier multi-HDD layout.
 func nodeMultiHDDDataPath(i int) string {
 	return fmt.Sprintf("/data/data-%d", i)
+}
+
+// effectiveDataPathMount returns the in-container mount path for the i-th
+// multi-HDD data volume: the user-provided dp.Path when set, otherwise the
+// default `/data/data-<i>`. Used by both the StatefulSet volumeMounts and the
+// per-node ConfigMap renderer so the K8s mount path and Garage's
+// `data_dir = [{ path = ... }]` always agree.
+func effectiveDataPathMount(dp garagev1beta1.NodeVolumeConfig, i int) string {
+	if dp.Path != "" {
+		return dp.Path
+	}
+	return nodeMultiHDDDataPath(i)
 }
 
 // nodeMultiHDDDataVolName returns the volume/PVC-template name for the i-th
@@ -664,10 +677,10 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1beta1.Gar
 		{Name: metadataVolName, MountPath: metadataPath},
 	}
 	if nodeHasMultiHDD(node) {
-		for i := range node.Spec.Storage.DataPaths {
+		for i, dp := range node.Spec.Storage.DataPaths {
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      nodeMultiHDDDataVolName(i),
-				MountPath: nodeMultiHDDDataPath(i),
+				MountPath: effectiveDataPathMount(dp, i),
 			})
 		}
 	} else {
@@ -1768,13 +1781,15 @@ func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node 
 		if len(node.Spec.Storage.DataPaths) > 0 {
 			paths := make([]NodeDataDirPath, 0, len(node.Spec.Storage.DataPaths))
 			for i, dp := range node.Spec.Storage.DataPaths {
-				p := NodeDataDirPath{Path: nodeMultiHDDDataPath(i)}
-				switch {
-				case dp.Size != nil && !dp.Size.IsZero():
-					p.Capacity = dp.Size.String()
-				case dp.ExistingClaim != "":
-					if cap := r.lookupPVCCapacity(ctx, cluster.Namespace, dp.ExistingClaim); cap != "" {
-						p.Capacity = cap
+				p := NodeDataDirPath{Path: effectiveDataPathMount(dp, i), ReadOnly: dp.ReadOnly}
+				if !dp.ReadOnly {
+					switch {
+					case dp.Size != nil && !dp.Size.IsZero():
+						p.Capacity = dp.Size.String()
+					case dp.ExistingClaim != "":
+						if cap := r.lookupPVCCapacity(ctx, cluster.Namespace, dp.ExistingClaim); cap != "" {
+							p.Capacity = cap
+						}
 					}
 				}
 				paths = append(paths, p)

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -1090,6 +1090,54 @@ var _ = Describe("GarageNode multi-HDD storage layout", func() {
 		Expect(toml).To(ContainSubstring(`{ path = "/data/data-0", capacity = "33Gi" }`))
 		Expect(toml).To(ContainSubstring(`{ path = "/data/data-1", capacity = "44Gi" }`))
 	})
+
+	// #205 follow-up: dataPaths[].path honored in both K8s mount and TOML.
+	It("uses dp.Path as the mount + TOML path; ReadOnly drops capacity", func() {
+		cluster := makeCluster(ctx)
+		nodeName := "path-readonly-node"
+		capacity := resource.MustParse("100Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &capacity,
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					DataPaths: []garagev1beta1.NodeVolumeConfig{
+						{Path: "/mnt/ssd-fast", Size: ptrQuantity(resource.MustParse("50Gi"))},
+						{Path: "/mnt/legacy-cold", ReadOnly: true},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		defer func() {
+			n := &garagev1beta1.GarageNode{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, n); err == nil {
+				n.Finalizers = nil
+				_ = k8sClient.Update(ctx, n)
+				_ = k8sClient.Delete(ctx, n)
+			}
+			_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-config", Namespace: testNamespace}})
+		}()
+
+		r := &GarageNodeReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		Expect(r.reconcileNodeConfigMap(ctx, node, cluster)).To(Succeed())
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName + "-config", Namespace: testNamespace}, cm)).To(Succeed())
+		toml := cm.Data["garage.toml"]
+		Expect(toml).To(ContainSubstring(`{ path = "/mnt/ssd-fast", capacity = "50Gi" }`))
+		Expect(toml).To(ContainSubstring(`{ path = "/mnt/legacy-cold", read_only = true }`))
+
+		_, mounts := r.buildNodeVolumesAndMounts(node, cluster)
+		mountByName := map[string]string{}
+		for _, m := range mounts {
+			mountByName[m.Name] = m.MountPath
+		}
+		Expect(mountByName["data-0"]).To(Equal("/mnt/ssd-fast"))
+		Expect(mountByName["data-1"]).To(Equal("/mnt/legacy-cold"))
+	})
 })
 
 var _ = Describe("GarageNode per-node env/envFrom/logging/snapshots", func() {

--- a/schemas/garagenode_v1beta1.json
+++ b/schemas/garagenode_v1beta1.json
@@ -1721,8 +1721,16 @@
                   "type": "array"
                 },
                 "existingClaim": {
-                  "description": "ExistingClaim references a pre-existing PVC by name in the cluster namespace.\nMutually exclusive with Size.",
+                  "description": "ExistingClaim references a pre-existing PVC by name in the cluster namespace.",
                   "type": "string"
+                },
+                "path": {
+                  "description": "Path is the in-container mount path for this volume. Only honored on\nmulti-HDD `storage.dataPaths[]` entries \u2014 both the K8s volumeMount and\nthe rendered garage.toml `data_dir = [{ path = ... }]` use this value.\nDefaults to `/data/data-<i>` when unset. The legacy-STS migration\npropagates `cluster.spec.storage.data.paths[i].path` so that on first\nboot Garage's DataLayout sees the same paths it stored under\npre-migration, avoiding partition reassignment and unnecessary\ncross-peer block refetch (../garage src/block/layout.rs).",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "ReadOnly marks the entry as a legacy read-only path on multi-HDD\n`storage.dataPaths[]`. Renders as garage.toml `read_only = true`;\nno `capacity` is emitted. Ignored on `storage.{metadata,data}`.",
+                  "type": "boolean"
                 },
                 "size": {
                   "anyOf": [
@@ -1733,7 +1741,7 @@
                       "type": "string"
                     }
                   ],
-                  "description": "Size creates a dynamically provisioned PVC with this capacity.\nMutually exclusive with ExistingClaim.",
+                  "description": "Size creates a dynamically provisioned PVC with this capacity. For\nmulti-HDD `storage.dataPaths[]` entries it may also be set alongside\n`existingClaim` to declare the capacity advertised to Garage.",
                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                   "x-kubernetes-int-or-string": true
                 },
@@ -1770,7 +1778,7 @@
             "dataPaths": {
               "description": "DataPaths configures multiple data directories for multi-HDD nodes.\nEach entry produces a separate volume/mount/PVC at /var/lib/garage/data-<idx>\nand the corresponding garage.toml `data_dir = [...]` array form. Use this for\nmulti-HDD nodes; mutually exclusive with .data.",
               "items": {
-                "description": "NodeVolumeConfig defines the source of a storage volume for a GarageNode.\nParallel to GarageCluster's VolumeConfig, extended with existingClaim for\npre-provisioned PVCs. Either ExistingClaim or Size must be specified, not both.",
+                "description": "NodeVolumeConfig defines the source of a storage volume for a GarageNode.\nParallel to GarageCluster's VolumeConfig, extended with existingClaim for\npre-provisioned PVCs. Either ExistingClaim or Size must be specified.\n\nExistingClaim and Size may also be set together inside a multi-HDD\n`storage.dataPaths[]` entry \u2014 there ExistingClaim binds the PVC and Size\nis the capacity advertised to Garage in `data_dir = [{path, capacity}]`.\nCombining them on `storage.{metadata,data}` is allowed by the webhook but\nhas no effect since those slots don't emit a TOML capacity field.",
                 "properties": {
                   "accessModes": {
                     "description": "AccessModes for the dynamically provisioned PVC.\nDefaults to [ReadWriteOnce] if not specified.",
@@ -1780,8 +1788,16 @@
                     "type": "array"
                   },
                   "existingClaim": {
-                    "description": "ExistingClaim references a pre-existing PVC by name in the cluster namespace.\nMutually exclusive with Size.",
+                    "description": "ExistingClaim references a pre-existing PVC by name in the cluster namespace.",
                     "type": "string"
+                  },
+                  "path": {
+                    "description": "Path is the in-container mount path for this volume. Only honored on\nmulti-HDD `storage.dataPaths[]` entries \u2014 both the K8s volumeMount and\nthe rendered garage.toml `data_dir = [{ path = ... }]` use this value.\nDefaults to `/data/data-<i>` when unset. The legacy-STS migration\npropagates `cluster.spec.storage.data.paths[i].path` so that on first\nboot Garage's DataLayout sees the same paths it stored under\npre-migration, avoiding partition reassignment and unnecessary\ncross-peer block refetch (../garage src/block/layout.rs).",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly marks the entry as a legacy read-only path on multi-HDD\n`storage.dataPaths[]`. Renders as garage.toml `read_only = true`;\nno `capacity` is emitted. Ignored on `storage.{metadata,data}`.",
+                    "type": "boolean"
                   },
                   "size": {
                     "anyOf": [
@@ -1792,7 +1808,7 @@
                         "type": "string"
                       }
                     ],
-                    "description": "Size creates a dynamically provisioned PVC with this capacity.\nMutually exclusive with ExistingClaim.",
+                    "description": "Size creates a dynamically provisioned PVC with this capacity. For\nmulti-HDD `storage.dataPaths[]` entries it may also be set alongside\n`existingClaim` to declare the capacity advertised to Garage.",
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
@@ -1835,8 +1851,16 @@
                   "type": "array"
                 },
                 "existingClaim": {
-                  "description": "ExistingClaim references a pre-existing PVC by name in the cluster namespace.\nMutually exclusive with Size.",
+                  "description": "ExistingClaim references a pre-existing PVC by name in the cluster namespace.",
                   "type": "string"
+                },
+                "path": {
+                  "description": "Path is the in-container mount path for this volume. Only honored on\nmulti-HDD `storage.dataPaths[]` entries \u2014 both the K8s volumeMount and\nthe rendered garage.toml `data_dir = [{ path = ... }]` use this value.\nDefaults to `/data/data-<i>` when unset. The legacy-STS migration\npropagates `cluster.spec.storage.data.paths[i].path` so that on first\nboot Garage's DataLayout sees the same paths it stored under\npre-migration, avoiding partition reassignment and unnecessary\ncross-peer block refetch (../garage src/block/layout.rs).",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "ReadOnly marks the entry as a legacy read-only path on multi-HDD\n`storage.dataPaths[]`. Renders as garage.toml `read_only = true`;\nno `capacity` is emitted. Ignored on `storage.{metadata,data}`.",
+                  "type": "boolean"
                 },
                 "size": {
                   "anyOf": [
@@ -1847,7 +1871,7 @@
                       "type": "string"
                     }
                   ],
-                  "description": "Size creates a dynamically provisioned PVC with this capacity.\nMutually exclusive with ExistingClaim.",
+                  "description": "Size creates a dynamically provisioned PVC with this capacity. For\nmulti-HDD `storage.dataPaths[]` entries it may also be set alongside\n`existingClaim` to declare the capacity advertised to Garage.",
                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                   "x-kubernetes-int-or-string": true
                 },


### PR DESCRIPTION
## Summary

Follow-up to PR #206 against #205. Closes three migration gaps surfaced by an audit against `../garage/src/block/layout.rs` plus the comment from @aimoff on the original issue.

- **`NodeVolumeConfig.Path`** — previously missing. Both the K8s `volumeMount` and the TOML `data_dir = [{ path = ... }]` were hardcoded to `/data/data-<i>`. Any custom `cluster.spec.storage.data.paths[i].path` (e.g. `/mnt/ssd-0`) was silently dropped during migration, which made Garage's `DataLayout::update` treat the relocated disks as fresh ones — partitions get reassigned and blocks refetched from peers despite the data sitting on the same disk at a different mount.
- **`NodeVolumeConfig.ReadOnly`** — previously missing. Cluster-level `paths[i].readOnly` had no per-node equivalent so legacy read-only archives could not be represented. Renders as `read_only = true` (no capacity), per upstream `DataDir`. Webhook accepts `readOnly: true` alone on `dataPaths[]` entries.
- **Cluster-level `paths[i].volume.type: EmptyDir`** was silently dropped during projection — operator provisioned a real PVC the user explicitly opted out of (audit #4). Now propagated.
- **Migration guard for `replicas=0`** — when the legacy STS has `replicas=0` AND legacy PVCs still exist, the previous code iterated zero ordinals, orphan-deleted the STS, marked Completed, and stranded the PVCs forever. Refused now with a clear `Failed` condition (audit #6).

## Architectural cross-check vs upstream `../garage`

`src/block/layout.rs::DataLayout::update` matches old/new data directories by `path` — if the path changes, the directory is treated as new (empty), partition assignments shift, and the rebalance worker rebuilds the slot from peers. Preserving the user's original paths through migration keeps the on-disk layout stable.

`src/util/config.rs::DataDir` accepts either `{ capacity }` (writable) or `{ read_only = true }` — both now representable per node.

## Test plan

- [x] Unit tests: dp.Path drives mount + TOML; ReadOnly drops capacity; multi-HDD migration carries cluster `Paths[i].{Path, ReadOnly}`; replicas=0 + leftover PVCs returns Failed.
- [x] `go test ./... -count=1` green
- [x] `make lint` 0 issues
- [x] Kind: legacy STS with cluster spec paths `/mnt/ssd-fast` + `/mnt/archive` (read-only) → migrated GarageNode has both paths; rendered TOML emits `{ path = "/mnt/ssd-fast", capacity = "200Mi" }` and `{ path = "/mnt/archive", read_only = true }`; StatefulSet volume mounts use the same paths.
- [ ] GitHub workflows: test, lint, test-e2e, docker, helm