### PR TITLE
feat: unify gateway path under per-node GarageNodes + race-safe layout apply + cluster-health surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,16 @@ A `GarageCluster` describes two optional tiers, both reconciled from the same CR
   with metadata + data PVCs. The cluster spec generates N × `GarageNode` CRs
   (one per pod ordinal), and the GarageNode controller owns each node's 1-replica
   STS. Pod node identity persists across restarts via the metadata PVC.
-- `spec.gateway` — ephemeral **Deployment** with EmptyDir for both metadata and
-  data. Gateway pods generate a fresh Ed25519 node identity on every restart;
-  the operator garbage-collects stale layout entries via tombstone cleanup.
+- `spec.gateway` — in a **unified cluster** (storage + gateway in the same CR),
+  the gateway tier ALSO runs as N × per-node `GarageNode` CRs
+  (`<cr>-gateway-N`, `gateway: true`) — symmetric with storage — each with a
+  small metadata PVC (persistent identity) and EmptyDir data. The GarageNode
+  controller assigns each gateway pod a `capacity: nil` layout role so
+  `key_table`/`bucket_table` are full-replicated locally and S3 sig-auth resolves
+  keys via `get_local()` without a per-request quorum RPC to the storage tier
+  (issue #209). In an **edge gateway** (gateway-only CR + `connectTo`), the
+  gateway tier stays a cluster-level **StatefulSet** (`<cr>-gateway`) because its
+  layout lives on a remote storage cluster managed by the gateway-connection path.
 
 A CR must set at least one of `storage`, `gateway`, or `connectTo`. The webhook
 rejects empty specs and `gateway` without either `storage` (unified cluster) or
@@ -175,33 +182,50 @@ rejects empty specs and `gateway` without either `storage` (unified cluster) or
 
 ### Workload differences
 
-| Aspect | Storage tier | Gateway tier |
-|---|---|---|
-| Workload | N × `StatefulSet`s (one per GarageNode, `replicas: 1`) | `Deployment` (`<cr>-gateway`) |
-| GarageNode CRs | one per pod ordinal (Auto: operator-owned `<cr>-storage-N`; Manual: user-owned) | none |
-| metadata volume | PVC via volumeClaimTemplates (per node) | EmptyDir |
-| data volume | PVC via volumeClaimTemplates (per node) | EmptyDir |
-| Update strategy | per-node STS default | RollingUpdate with maxSurge:25%, maxUnavailable:25% |
-| Pod naming | `<garagenode>-0` (each STS has one pod) | random suffix |
-| Node identity | persists (PVC) | rotates per pod restart |
-| ConfigMap | per-node when overrides present, else shared | single shared |
-| Layout capacity | from PVC size | nil (gateway) |
+| Aspect | Storage tier | Gateway tier (unified) | Gateway tier (edge) |
+|---|---|---|---|
+| Workload | N × `StatefulSet`s (`replicas: 1`) | N × `StatefulSet`s (`replicas: 1`) | `StatefulSet` (`<cr>-gateway`) |
+| GarageNode CRs | one per ordinal (`<cr>-storage-N`) | one per ordinal (`<cr>-gateway-N`, `gateway: true`) | none |
+| metadata volume | PVC (per node) | PVC (per node, 1Gi default) | PVC (per replica) |
+| data volume | PVC (per node) | EmptyDir | EmptyDir |
+| Node identity | persists (PVC) | persists (PVC) | persists (PVC) |
+| ConfigMap | per-node when overrides present, else shared | **always per-node** (so it never inherits the storage `rpc_public_addr`) | gateway-specific |
+| Layout owner | per-`GarageNode` controller (local) | per-`GarageNode` controller (local) | gateway-connection path (remote) |
+| Layout capacity | from PVC size | nil (gateway) | nil (gateway) |
 
-In both Auto and Manual mode the storage tier is N × 1-replica StatefulSets,
-each owned by a `GarageNode` CR. The difference is **ownership** of those
-GarageNodes — the operator (Auto) or the user (Manual) — not the workload
-shape.
+In a unified cluster every tier is reconciled as per-pod `GarageNode`s; the
+difference between tiers is `gateway: true` (capacity nil, EmptyDir data) and
+between Auto/Manual is **ownership** of those GarageNodes (operator vs user),
+not the workload shape. Edge gateways (a separate gateway-only CR connecting to
+a remote storage cluster) keep the cluster-level StatefulSet because their layout
+is owned remotely.
+
+### Layout staging/apply concurrency
+
+Every layout mutation goes through `Client.ApplyStagedLayoutChanges`
+(`internal/garage/client.go`). Two upstream facts make a naive
+`ApplyClusterLayout(version+1)` wrong (validated against Garage v2.3.0):
+`ApplyClusterLayout`'s version-rejection is a generic error mapped to **HTTP 500,
+not 409** (so `garage.IsConflict` never caught an apply race), and apply
+**always** bumps the version (so an unconditional apply churns layout gossip).
+The helper re-reads the layout, skips apply when nothing is staged, and on
+failure re-reads to detect whether a concurrent writer already committed the
+staged change (staging is a per-node `LwwMap` that merges, so this is safe).
 
 ### Gateway tombstone cleanup
 
-Gateway node IDs are ephemeral. On each reconcile the operator:
+On each reconcile the operator:
 
 1. Picks the right admin client — local for unified clusters, remote for edge
    gateways (via `connectTo`).
 2. Queries the cluster's layout and lists entries tagged with both
    `cluster:<name>/<namespace>` and `tier:gateway`.
-3. Cross-references with the live gateway pods' current node IDs.
-4. Stages removal of any layout entry that has no matching pod.
+3. Cross-references with the live gateway pods (`isUp`) AND the node IDs claimed
+   by live operator-owned gateway `GarageNode` CRs (`status.nodeId`). A role
+   claimed by an existing gateway GarageNode is **never** removed — this keeps
+   the cluster-level cleanup from fighting the per-node controller during a brief
+   pod restart (the per-node finalizer owns role removal on delete).
+4. Stages removal of any remaining unclaimed `tier:gateway` entry.
 
 When `spec.layoutManagement.autoApply: true` the removal is applied immediately
 and `skip-dead-nodes` is called on the new layout version. Otherwise the
@@ -441,6 +465,27 @@ status:
 ```
 
 On failure, `succeeded: false` and `error` contains the message. The annotation is kept for retry.
+
+### Cluster-health conditions (validated against Garage v2.3.0)
+
+`updateStatusFromCluster` derives actionable conditions + a one-line
+`status.layoutDiagnosis` (shown as the `Diagnosis` printcolumn) via
+`setClusterHealthConditions` (`internal/controller/garagecluster_health.go`):
+
+| Condition | True/False means | Lever |
+|---|---|---|
+| `QuorumAtRisk` | True when Garage reports `PartitionsQuorum < Partitions` — object writes to those partitions block | restore storage nodes, or `consistencyMode: dangerous` (NOT a layout edit) |
+| `RemoteClustersHealthy` | False when a federated remote is unreachable > 1h (short blips ignored) | if a zone is permanently gone, reduce `replication.factor` |
+| `FederationConfigured` | False when `spec.remoteClusters` is set but no `rpc_public_addr`/`publicEndpoint` (HelloMessage advertises the unroutable pod IP) | set `spec.network.rpcPublicAddr` or a `publicEndpoint` (also a webhook admission warning) |
+
+Validation notes: a roleless gateway is **not** a deterministic 403 — S3 auth
+falls back to a quorum `get()` that succeeds in a healthy cluster; the
+`capacity: nil` gateway role is a resilience/latency optimization (local-first
+auth, decoupled from storage availability). `degraded` mode lowers only READ
+quorum; it does **not** unblock stuck metadata (GarageKey/bucket) writes — those
+need a reachable majority of roled nodes (`floor(N/2)+1`), and stale gateway
+entries inflate N only in `consistent` mode (so tombstone cleanup matters for
+admin-write availability).
 
 ---
 

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -73,6 +73,43 @@ const (
 	// successfully or no legacy STS was present. Status=False with
 	// Reason=InProgress or Reason=Failed surfaces partial progress / errors.
 	ConditionLegacySTSMigrated = "LegacySTSMigrated"
+
+	// ConditionQuorumAtRisk is True when one or more partitions lack write
+	// quorum (Garage's own PartitionsQuorum < Partitions) — i.e. object writes
+	// to those partitions will block. This is the actionable write-availability
+	// signal: validated against upstream, factor reduction or consistencyMode
+	// changes are the levers, NOT a layout edit. The message names the reachable
+	// vs total storage node counts and the remediation.
+	ConditionQuorumAtRisk = "QuorumAtRisk"
+
+	// ConditionRemoteClustersHealthy aggregates the reachability of federated
+	// remote clusters. False when a remote has been unreachable past a staleness
+	// threshold; the message names which cluster and for how long, so an operator
+	// can decide whether a zone is permanently gone.
+	ConditionRemoteClustersHealthy = "RemoteClustersHealthy"
+
+	// ConditionFederationConfigured is False when spec.remoteClusters is set but
+	// the cluster advertises no rpc_public_addr (network.rpcPublicAddr or a
+	// publicEndpoint). Without it, Garage's HelloMessage carries no server_addr
+	// and remote peers infer the unroutable pod IP — cross-cluster RPC degrades
+	// after any pod restart. Surfaced as a webhook warning at admission too.
+	ConditionFederationConfigured = "FederationConfigured"
+)
+
+// Condition reasons for the cluster-health surface.
+const (
+	// ReasonQuorumOK indicates all partitions have write quorum.
+	ReasonQuorumOK = "AllPartitionsQuorate"
+	// ReasonQuorumLost indicates one or more partitions lack write quorum.
+	ReasonQuorumLost = "PartitionsBelowQuorum"
+	// ReasonAllRemotesConnected indicates every federated remote is reachable.
+	ReasonAllRemotesConnected = "AllConnected"
+	// ReasonRemotesStale indicates one or more remotes are unreachable/stale.
+	ReasonRemotesStale = "RemotesUnreachable"
+	// ReasonMissingRPCPublicAddr indicates a federated cluster has no rpc_public_addr.
+	ReasonMissingRPCPublicAddr = "MissingRPCPublicAddr"
+	// ReasonFederationReady indicates federation networking is configured.
+	ReasonFederationReady = "Configured"
 )
 
 // GarageBucket condition types

--- a/api/v1beta2/garagecluster_types.go
+++ b/api/v1beta2/garagecluster_types.go
@@ -1177,6 +1177,13 @@ type GarageClusterStatus struct {
 	// +optional
 	PendingGatewayTombstones []string `json:"pendingGatewayTombstones,omitempty"`
 
+	// LayoutDiagnosis is a one-line, human-readable summary of the most severe
+	// active health condition (quorum at risk, remote clusters stale, federation
+	// misconfigured). Empty when the cluster is healthy. Surfaced as a printcolumn
+	// so `kubectl get gc` shows the actionable problem at a glance.
+	// +optional
+	LayoutDiagnosis string `json:"layoutDiagnosis,omitempty"`
+
 	// ObservedGeneration is the last observed generation.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -1636,6 +1643,7 @@ type GarageBuildInfo struct {
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas"
 // +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".spec.zone"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Diagnosis",type="string",JSONPath=".status.layoutDiagnosis",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // GarageCluster is the Schema for the garageclusters API.

--- a/api/v1beta2/garagecluster_webhook.go
+++ b/api/v1beta2/garagecluster_webhook.go
@@ -181,6 +181,16 @@ func (r *GarageCluster) validateGarageCluster() (admission.Warnings, error) {
 		warnings = append(warnings, "ConsistencyMode 'dangerous' may lead to data loss. Use only for testing.")
 	}
 
+	// Federation without an externally-routable RPC address: Garage's HelloMessage
+	// carries no server_addr, so remote peers infer the (unroutable) pod IP and
+	// cross-cluster RPC degrades after any pod restart. Warn, don't reject — an
+	// in-flight federated cluster shouldn't be blocked on update.
+	if len(r.Spec.RemoteClusters) > 0 && r.Spec.Network.RPCPublicAddr == "" && r.Spec.PublicEndpoint == nil {
+		warnings = append(warnings,
+			"spec.remoteClusters is set but no rpc_public_addr (spec.network.rpcPublicAddr or spec.publicEndpoint): "+
+				"cross-cluster RPC will degrade after pod restarts as peers infer the unroutable pod IP")
+	}
+
 	if r.HasStorageTier() && r.Spec.Storage.PodDisruptionBudget != nil && r.Spec.Storage.PodDisruptionBudget.Enabled &&
 		r.Spec.Storage.PodDisruptionBudget.MinAvailable == nil && r.Spec.Storage.PodDisruptionBudget.MaxUnavailable == nil {
 		warnings = append(warnings, "storage.podDisruptionBudget is enabled without minAvailable or maxUnavailable; defaulting to minAvailable=(replicas-1)")

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -4819,6 +4819,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.layoutDiagnosis
+      name: Diagnosis
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -11722,6 +11726,13 @@ spec:
                     description: Type is the operation type.
                     type: string
                 type: object
+              layoutDiagnosis:
+                description: |-
+                  LayoutDiagnosis is a one-line, human-readable summary of the most severe
+                  active health condition (quorum at risk, remote clusters stale, federation
+                  misconfigured). Empty when the cluster is healthy. Surfaced as a printcolumn
+                  so `kubectl get gc` shows the actionable problem at a glance.
+                type: string
               layoutHistory:
                 description: LayoutHistory contains layout version history.
                 properties:

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -4819,6 +4819,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.layoutDiagnosis
+      name: Diagnosis
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -11722,6 +11726,13 @@ spec:
                     description: Type is the operation type.
                     type: string
                 type: object
+              layoutDiagnosis:
+                description: |-
+                  LayoutDiagnosis is a one-line, human-readable summary of the most severe
+                  active health condition (quorum at risk, remote clusters stale, federation
+                  misconfigured). Empty when the cluster is healthy. Surfaced as a printcolumn
+                  so `kubectl get gc` shows the actionable problem at a glance.
+                type: string
               layoutHistory:
                 description: LayoutHistory contains layout version history.
                 properties:

--- a/docs/superpowers/specs/2026-05-31-gateway-path-and-fault-tolerance-design.md
+++ b/docs/superpowers/specs/2026-05-31-gateway-path-and-fault-tolerance-design.md
@@ -9,6 +9,41 @@ upstream-grounded assumption. The validation **materially changed** several
 motivations and corrected two latent bugs in the existing operator. Citations
 below are to `../garage` source unless noted.
 
+## Implementation status (this PR)
+
+**Shipped + tested (unit/envtest + e2e + lint green):**
+
+1. **Layout-apply correctness** — `Client.ApplyStagedLayoutChanges` replaces the
+   broken `IsConflict`-based retry at all 8 apply sites (apply rejection is HTTP
+   500, not 409). Re-reads version, skips no-op applies, resolves the
+   concurrent-writer race.
+2. **Per-node gateway unification for unified clusters (#209)** — gateway tier in
+   a unified `storage + gateway` CR now runs as per-node `GarageNode`s
+   (`gateway: true`, `capacity: nil` role, metadata PVC, EmptyDir data). Includes
+   the v0.5.3-safe per-node gateway config (no storage `rpc_public_addr`
+   inheritance) and tombstone cleanup that won't fight the per-node controller.
+3. **Cluster-health surface** — `QuorumAtRisk`, `RemoteClustersHealthy`,
+   `FederationConfigured` conditions + `status.layoutDiagnosis` printcolumn +
+   federation `rpc_public_addr` webhook warning.
+
+**Scoped/deferred (validation-driven):**
+
+- **Edge gateways stay on the cluster-level StatefulSet path.** Their layout
+  lives on a *remote* storage cluster; the existing gateway-connection path
+  already assigns their `capacity: nil` role correctly (only unified clusters
+  were broken). Migrating them to per-node would add a dual-admin-client code
+  path in the node controller with no functional gain. The principled boundary:
+  *within one GarageCluster CR every tier is per-pod; cross-cluster edge gateways
+  keep the cluster-level connection logic.*
+- **Coordinated factor migration (#208) is deferred to its own PR.** The
+  validation showed it is genuinely destructive (must delete on-disk
+  `cluster_layout`, rebuild the ENTIRE layout, simultaneous restart, asymmetric
+  crash hazard on factor *increase*) and **narrower in value than #208 framed**
+  (it fixes sharded-data write quorum, not stuck admin-table writes — those need
+  restore-majority or `dangerous` mode). It warrants dedicated chaos e2e and
+  should not ride alongside the gateway-path change. The precise validated safe
+  sequence is documented in §4 below so it is ready to build next.
+
 ---
 
 ## 1. Problem statement

--- a/docs/superpowers/specs/2026-05-31-gateway-path-and-fault-tolerance-design.md
+++ b/docs/superpowers/specs/2026-05-31-gateway-path-and-fault-tolerance-design.md
@@ -1,0 +1,321 @@
+# Gateway Path Unification + Fault-Tolerant Layout Management
+
+**Status:** validated against upstream Garage v2.3.0 (`git describe` =
+`v2.3.0-52-g2bde733e`; none of the 52 post-tag commits touch the load-bearing
+layout/peering paths). Date: 2026-05-31.
+
+This design is the output of an adversarial validation pass over every
+upstream-grounded assumption. The validation **materially changed** several
+motivations and corrected two latent bugs in the existing operator. Citations
+below are to `../garage` source unless noted.
+
+---
+
+## 1. Problem statement
+
+The operator treats its two tiers asymmetrically:
+
+```
+Storage tier (Auto):  spec.storage → N × GarageNode → N × 1-replica STS → per-node controller owns layout
+Gateway tier (Auto):  spec.gateway → 1 × N-replica STS (cluster-owned)  → NO per-node controller; cluster code owns layout
+```
+
+That asymmetry is the root of three classes of problem:
+
+1. **Gateway layout assignment is missing in unified clusters (#209).** In a
+   unified `storage + gateway` Auto cluster, no code path ever assigns the
+   gateway pods a layout role. `bootstrapCluster` short-circuits for
+   storage-tier clusters (`garagecluster_controller.go:3286`) and
+   `reconcileGatewayConnection` only runs when `connectTo != nil`
+   (`:3474`). Gateways come up roleless.
+
+   **Validation correction (A5/H1):** a roleless gateway does **not**
+   deterministically 403. `verify_v4` does `key_table.get_local()` then an eager
+   `Option::or(quorum get())` (`src/api/common/signature/payload.rs:423-428`);
+   the quorum fallback succeeds in a healthy cluster. The roleless failure mode
+   is a per-request synchronous quorum RPC and a **5xx (not 403)** when the
+   layout is `LayoutNotReady`/storage quorum is unreachable. Assigning a
+   `capacity:None` role makes `key_table` full-replicated locally so `get_local`
+   hits — a **resilience + latency** win (decouples gateway auth from storage
+   availability), and it keeps ephemeral gateway node IDs **out of partition
+   assignment/quorum math** (`src/rpc/layout/version.rs:215-227`), which is the
+   real correctness reason. We frame the feature accordingly — not as "fixes a
+   403."
+
+2. **Layout staging/apply concurrency is subtly wrong (NEW — G1/G2).** Each
+   per-node controller independently stages and applies its own role. Staging is
+   merge-safe — `staging.roles` is an `LwwMap<Uuid, NodeRoleV>` merged against
+   live state every call (`src/api/admin/layout.rs:181-214`), so concurrent
+   stagers converge. **But apply is not:** `ApplyClusterLayout`'s
+   version-rejection is a generic `Error::Message("Invalid new layout version")`,
+   **not HTTP 409** (`src/rpc/layout/history.rs:273-276`), so the operator's
+   `garage.IsConflict()` misses it; and apply **always** bumps the version with
+   no no-op short-circuit (`src/rpc/layout/version.rs:290-303`). This affects the
+   **existing storage path** too.
+
+3. **No operator-supported recovery when a zone dies permanently (#208).** The
+   only way to change `replication_factor` is to delete the on-disk
+   `cluster_layout` and restart all nodes simultaneously — there is no admin-API
+   path (`src/rpc/layout/manager.rs:44-65`).
+
+   **Validation correction (F2/F3):** factor reduction fixes **sharded-data**
+   write quorum only; it does **not** lower the FullReplication admin-table
+   threshold (`floor(N/2)+1` of all roled nodes — `src/table/replication/fullcopy.rs:64-89`).
+   `degraded` mode does **not** unblock stuck metadata writes (it lowers READ
+   quorum only; `src/rpc/replication_mode.rs:41-55`). **Stale gateway entries
+   inflate N in `consistent` mode** (`src/rpc/layout/helper.rs:63-73`), so
+   tombstone cleanup is itself load-bearing for admin-write availability.
+
+---
+
+## 2. Architecture: unify both tiers under per-pod `GarageNode`
+
+`GarageNode.Spec.Gateway: bool` already exists (`api/v1beta1/garagenode_types.go:197`)
+and the per-node controller already assigns `capacity:None` for it. The change is
+to make the **gateway tier in Auto mode** generate per-pod GarageNodes exactly as
+the storage tier does:
+
+```
+Both tiers (Auto):  spec.storage → N × GarageNode(gateway:false) → N × 1-replica STS
+                    spec.gateway → N × GarageNode(gateway:true)  → N × 1-replica STS
+                    per-node controller owns each node's layout role
+```
+
+### 2.1 New cluster-controller functions (mirror the storage tier)
+
+- `reconcileAutoModeGatewayNodes` — sibling of `reconcileAutoModeStorageNodes`
+  (`garagecluster_automode.go:127`). Generates `<cluster>-gateway-<ord>`
+  GarageNodes with `Gateway: true`, `Storage.Metadata` = gateway metadata PVC
+  (1Gi default, EmptyDir data), `Network.RPCPublicAddr` from
+  `spec.gateway.rpcPublicAddr`, controllerRef to the cluster, labels
+  `{labelCluster, labelTier=gateway, labelAppManagedBy=operator}`. Identical
+  drift detection / scale-down / eject semantics.
+- `migrateLegacyGatewaySTSIfNeeded` — sibling of `migrateLegacyStorageSTSIfNeeded`
+  (`garagecluster_automode.go:630`). Detects the legacy `<cluster>-gateway` STS,
+  adopts each `metadata-<cluster>-gateway-<ord>` PVC via `existingClaim`
+  (identity preserved via `node_key`), orphan-deletes the legacy STS, deletes
+  legacy pods so RWO PVCs release. **Strict pre-migration safety:** refuse unless
+  all gateway pods are Ready + `IsUp` (so PVC→node-id mapping is unambiguous);
+  refuse `replicas=0` with leftover PVCs (mirrors the storage `#205-#207` guard).
+  Status on a new `gatewayMigration` field + `LegacyGatewaySTSMigrated` condition.
+- `deleteAutoModeGatewayNodes` / `ejectAutoModeGatewayNodes` — tier-removal and
+  Auto→Manual eject for gateways.
+
+### 2.2 Per-node controller adaptations (`garagenode_controller.go`)
+
+- **Pod template source:** branch on `node.Spec.Gateway` to pull
+  `cluster.Spec.Gateway.PodTemplate` (and set `IsGateway: true` in
+  `PodSpecConfig` — gives the gateway readiness probe + init-marker container).
+- **Volumes:** gateway → metadata PVC + EmptyDir data (no data PVC); storage →
+  unchanged. Webhook already forbids `data`/`dataPaths` on gateway nodes.
+- **Admin-client routing:** extract a `layoutClientForNode(cluster, node)` helper
+  (generalizing today's `gatewayLayoutClient`, `garagecluster_gateway.go:500`):
+  edge-gateway GarageNode (`node.Spec.Gateway && cluster.Spec.ConnectTo != nil`)
+  → remote storage admin (clusterRef or adminApiEndpoint); everything else →
+  local cluster admin. The per-node controller already captures
+  `status.clusterAdminEndpoint`/`clusterAdminTokenSecretRef` for the delete-time
+  orphan finalize (`garagenode_types.go:444-458`) — that path already supports
+  edge gateways.
+- **Edge-gateway self-introduction:** after assigning its own `capacity:None`
+  role, an edge-gateway GarageNode also calls `ConnectNode(myID, myPublicAddr)`
+  on the remote storage admin (replacing `connectGatewayToExternalCluster`'s
+  reverse-direction inference). The address comes declaratively from the node's
+  own `spec.network.rpcPublicAddr`/`publicEndpoint`, not from heuristic
+  pod-IP-vs-LB inference.
+
+### 2.3 Correct layout staging/apply (NEW — fixes storage too)
+
+Add one shared helper used by **both** storage and gateway per-node reconciles:
+
+```go
+// stageAndApplyRole stages this node's desired role and applies it, tolerating
+// the concurrent-writer race correctly.
+func stageAndApplyRole(ctx, client, change NodeRoleChange) error {
+    layout := client.GetClusterLayout(ctx)
+    if roleMatches(layout, change) { return nil }          // idempotent: no churn
+    client.UpdateClusterLayout(ctx, []NodeRoleChange{change})
+    layout = client.GetClusterLayout(ctx)                   // re-read after staging
+    if err := client.ApplyClusterLayout(ctx, layout.Version+1); err != nil {
+        // Apply rejection is NOT 409 — re-read and decide.
+        fresh := client.GetClusterLayout(ctx)
+        if roleMatches(fresh, change) { return nil }        // someone else applied ours
+        return err                                          // requeue; retry current+1 next pass
+    }
+    return nil
+}
+```
+
+Rules enforced (validated against `doc/book/operations/layout.md:66-91`):
+- Gate apply on staged changes being non-empty (no unconditional version bump).
+- Detect apply failure by **re-reading version**, never by `IsConflict()`.
+- Funnel a node's stage+apply through a single admin client (the node's
+  `layoutClientForNode`).
+
+This is the minimal-correct fix that keeps the per-pod ownership model intact.
+A future optimization (single cluster-scoped batched writer) is noted but **out
+of scope** to avoid a risky refactor of the working storage path.
+
+### 2.4 Code deleted (de-bloat)
+
+- `reconcileGatewayStatefulSet` (`garagecluster_gateway.go:63-187`) — replaced by per-pod STSes.
+- `reconcileGatewayTombstones` (`:390-494`) — per-node finalizer removes the layout role on delete.
+- `gatewayLayoutClient` (`:500-524`) — folded into `layoutClientForNode`.
+- `bootstrapCluster`'s gateway layout-assignment branch (`garagecluster_controller.go:3290-3352`).
+- `deriveGatewayExternalAddrForNode` + reverse-direction inference in
+  `connectGatewayToExternalCluster` (`:3736-3934`) — gateways declare their own address.
+- The `<cluster>-gateway-config` ConfigMap split — per-node ConfigMaps via the
+  existing `nodeHasConfigOverrides` path cover gateway `rpc_public_addr`.
+
+### 2.5 LayoutPolicy — one knob gates both tiers
+
+`spec.layoutPolicy` (Auto default / Manual) gates **both** tiers. Auto→Manual
+ejects both atomically (drops controllerRefs, strips managed-by). Manual→Auto
+stays webhook-rejected. Per-tier policy is deferred (YAGNI).
+
+### 2.6 Migration cleanup (atomic, part of `migrateLegacyGatewaySTSIfNeeded`)
+
+- Sweep the legacy `<cluster>-gateway-config` ConfigMap once all gateway nodes
+  have per-node ConfigMaps.
+- Repoint the `<cluster>-gateway` API Service selector to
+  `{labelCluster, labelTier=gateway}` so it picks up old + new pods during the
+  transition window.
+- Recreate the gateway PDB against the new label selector.
+
+---
+
+## 3. Cluster-health surface (accurate, validated)
+
+New `GarageClusterStatus.conditions` + fields, with **validated** semantics:
+
+| Condition | Meaning | Validated basis |
+|---|---|---|
+| `LayoutConverged` | `False/ZoneUnreachable` when a remote cluster `lastSeen` exceeds a threshold; `False/FactorMismatch` when config factor ≠ live layout factor; else `True/Stable`. Message names the remediation. | `manager.rs:44-65` |
+| `QuorumAtRisk` | `True` when **reachable roled-node count < floor(N/2)+1** (the actual admin-table write-availability lever). Surfaces `roledNodes`, `reachableNodes`, `writeQuorum`. | `fullcopy.rs:64-89`, `rpc_helper.rs:734-745` |
+| `RemoteClustersHealthy` | aggregate of `status.remoteClusters[].lastSeen` ages (Degraded 5m–1h, False >1h). | operator-side |
+| `PeerUnreachable` | `True` when any node reports a peer `is_up:false` for a sustained duration. **The admin API exposes only `is_up` + `lastSeenSecsAgo`, not Garage's internal `Abandoned` state** — detection is duration-based, not state-based. | `client.go` NodeInfo; validation D6 |
+| `FederationConfigured` | `False/MissingRPCPublicAddr` when `spec.remoteClusters` set but no `network.rpcPublicAddr`/`publicEndpoint` (HelloMessage reachability, `netapp.rs:499-510`). | D5 |
+
+New `status.layoutDiagnosis` string = one-line human summary from the
+highest-severity condition. New printcolumns: `LAYOUT`, `QUORUM`, `DIAGNOSIS`.
+
+`spec.recovery.autoRestartOnUnreachablePeer` (default **false**) + a 3-restarts/1h
+circuit breaker. Lower urgency than originally thought — v2.3.0 reconnect is
+bounded (~50s/peer/cycle) and `known_addrs` is self-limiting
+([[garage-v2-3-0-peering-layout-corrections]]) — but the edge-gateway
+single-link case (Garage marks a peer `Abandoned` after ~5.5h and never retries)
+still needs the operator's periodic `ConnectClusterNodes` nudge as the sole
+recovery path, which `reconcileGatewayConnection`'s drift check already provides.
+
+---
+
+## 4. Coordinated factor migration (#208) — validated safe sequence
+
+Gated behind an explicit one-shot annotation (parallel to `purge-blocks`):
+
+```yaml
+metadata:
+  annotations:
+    garage.rajsingh.info/purge-cluster-layout: "factor=2"   # or "factor=2,force"
+spec:
+  replication: { factor: 2 }                                # must match the annotation
+```
+
+**Validated requirements (cluster C, H3):**
+- Deleting on-disk `cluster_layout` is **unavoidable** (factor is absent from the
+  admin API and staging; copied forward by `calculate_next_version`).
+- **Simultaneous restart is mandatory.** Two hazards: a node hearing a peer with
+  a strictly higher factor `std::process::exit(1)` (asymmetric — only the
+  lower-factor node dies, so a factor **increase** is the dangerous direction,
+  `system.rs:601-608`); and gossip-back re-adoption of the old layout from a
+  surviving peer (`history.rs:232-238`).
+- Purging `cluster_layout` **wipes ALL roles** → the operator must **rebuild the
+  entire layout** (every storage capacity + every gateway `capacity:None`) after
+  restart, funneled through one pod, validating `nongateway_nodes() ≥ new factor`
+  (`version.rs:328-335`).
+
+State machine on `status.lastOperation` (phases): `Validating → Suspending →
+ScalingToZero → Purging → ScalingUp → Verifying → RebuildingLayout → Converging →
+Done|Failed`. Idempotent/resumable via the phase field + an init-container marker
+file (`/data/metadata/.purged-<uuid>`) so the post-purge rolling restart doesn't
+re-nuke a freshly rebuilt layout.
+
+- **Validating:** refuse if `spec.remoteClusters` non-empty (federation
+  coordinator is a separate design); refuse if `nongateway storage nodes <
+  newFactor` (would be unappliable); refuse `dangerous` consistency without
+  `,force`; require all storage nodes currently reachable.
+- **ScalingToZero:** suspend per-node controllers via an internal
+  `operator-suspended` annotation (distinct from user `spec.maintenance.suspended`),
+  scale all storage STSes to 0, **confirm zero old-factor pods remain** (Hazard 1).
+- **Purging:** patch each storage STS with a guarded busybox init container
+  (`rm -f /data/metadata/cluster_layout` under PSA-restricted SC, reusing the
+  `helpers.go:655` pattern).
+- **ScalingUp:** scale all back up together.
+- **Verifying:** poll `GetNodeInfo` until all report the new factor + Ready, none CrashLooping.
+- **RebuildingLayout:** re-stage **all** node roles (storage + gateway) and apply
+  once via a single pod, version+1.
+- **Converging:** wait for resync; do not reclaim PVCs until drained; optionally
+  trigger `Tables` repair (gateways.md:35-39 metadata-lag caveat).
+
+PDB handling: evict first, force-delete after a 30s grace (operation is
+explicitly disruptive). Federation refused in v1.
+
+> **Scope note:** this is genuinely destructive and (per validation) narrower in
+> value than #208 framed — it addresses **sharded-data** write quorum after
+> permanent zone loss, not stuck admin-table writes (those need restore-majority
+> or `dangerous` + tombstone cleanup). It is built behind an explicit annotation
+> with no automatic trigger, and is the last piece to land so the core
+> (gateway unification + layout correctness + health surface) ships independently
+> green.
+
+---
+
+## 5. Testing strategy
+
+**Unit / envtest:**
+- `reconcileAutoModeGatewayNodes`: create/drift/scale/eject (mirror storage tests).
+- `migrateLegacyGatewaySTSIfNeeded`: idempotency, `replicas=0` guard, strict-readiness guard, PVC adoption, ConfigMap/Service/PDB cleanup.
+- Per-node controller gateway branch: pod-template selection, volume builder, `layoutClientForNode` (4 shapes), `capacity:None` role.
+- `stageAndApplyRole`: apply-rejection-not-409 retry, conditional apply (no version bump on no-op), concurrent-writer convergence.
+- Status conditions: `LayoutConverged`, `QuorumAtRisk` (roled vs floor(N/2)+1), `PeerUnreachable` (duration-based), `FederationConfigured`.
+- Factor migration: state-machine progression + per-phase failure injection + `nongateway ≥ factor` guard + federation refusal.
+
+**Kind e2e (extends `test/e2e/e2e_test.go`):**
+- **Unified-cluster gateway (the #209 gap — none exists today):** unified
+  `storage+gateway` Auto cluster; assert gateway pods get `capacity:None` roles;
+  S3 auth via the gateway Service succeeds; under storage degradation a **roled**
+  gateway still authenticates locally (assert success, and that the failure mode
+  for a roleless control is 5xx not 403 — validation test #9).
+- Gateway legacy-STS → per-pod migration: upgrade path, no S3 disruption, identity preserved.
+- Existing edge-gateway tests keep passing (now via per-pod gateway GarageNodes).
+- Apply-version race (G1): two writers race, operator recovers via version re-read, no divergent same-version layouts.
+- No-op reconcile does not bump layout version (G2).
+- Gateway tombstone GC via finalizer, no `skip-dead-nodes`, no data movement (B5).
+- Simultaneous storage restart reconnect (#203) with freshly-resolved IPs.
+- Multi-HDD migration capacity/path/read_only correctness (#205/G3/G4).
+- Factor-reduction happy path in Kind (decrease); increase-guard at unit level.
+
+**CI:** `make test` (unit+envtest), `make lint`, `make test-e2e` green.
+
+---
+
+## 6. Rollout (single PR, core-first commits)
+
+1. Shared `stageAndApplyRole` correctness fix (storage + gateway) + tests.
+2. Per-node controller gateway branch + `layoutClientForNode` + tests.
+3. `reconcileAutoModeGatewayNodes` + `migrateLegacyGatewaySTSIfNeeded` + cluster Reconcile wiring; delete legacy gateway STS/tombstone/bootstrap paths; webhook LayoutPolicy gating + tests.
+4. Health surface: conditions + `layoutDiagnosis` + printcolumns + `FederationConfigured` webhook warning + tests.
+5. Factor migration annotation + state machine + tests.
+6. e2e additions; CRD/manifest regen; docs/CLAUDE.md update.
+
+Each commit keeps `make test` + `make lint` green. The PR is complete and
+shippable after step 4 (core); steps 5 lands the destructive recovery op.
+
+---
+
+## 7. Out of scope (deferred, documented)
+
+- Single cluster-scoped batched layout writer (optimization over the corrected per-pod model).
+- Per-tier `LayoutPolicy`.
+- Multi-cluster federation coordinator for factor change.
+- Upstream Garage patches (none needed — v2.3.0 already has bounded `known_addrs` + connect timeout).
+- Storage-tier tombstone parity for force-deleted Manual GarageNodes.

--- a/internal/controller/garagecluster_automode_gateway.go
+++ b/internal/controller/garagecluster_automode_gateway.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+// autoModeGatewayNodeName returns the canonical name for an operator-generated
+// gateway GarageNode in Auto mode for a given gateway-tier ordinal. Mirrors the
+// storage-tier convention (<cluster>-storage-<N>) so tooling and tags stay
+// symmetric across tiers.
+func autoModeGatewayNodeName(clusterName string, ordinal int32) string {
+	return fmt.Sprintf("%s-gateway-%d", clusterName, ordinal)
+}
+
+// reconcileAutoModeGatewayNodes generates and reconciles one gateway GarageNode
+// CR per gateway replica when the cluster is in Auto mode with a UNIFIED
+// (storage + gateway) topology. Each GarageNode owns its own single-replica
+// StatefulSet via the GarageNode controller, which assigns it a capacity=nil
+// layout role — making key_table/bucket_table full-replicated locally so the S3
+// sig-auth get_local() path resolves keys without a per-request quorum RPC to the
+// storage tier (and keeps the gateway authenticating even while storage is
+// degraded). This is the fix for the unified-cluster gateway gap (#209).
+//
+// Edge gateways (gateway-only clusters with spec.connectTo) are NOT handled here
+// — their layout lives on a remote storage cluster and is managed by the
+// cluster-level gateway connection path. Only unified clusters reach this code.
+func (r *GarageClusterReconciler) reconcileAutoModeGatewayNodes(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+
+	if !cluster.HasGatewayTier() || !cluster.HasStorageTier() {
+		return nil
+	}
+
+	desiredReplicas := cluster.GatewayReplicas()
+
+	existing, err := r.listAutoModeGatewayNodes(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("listing operator-owned gateway GarageNodes: %w", err)
+	}
+
+	desiredByName := make(map[string]bool, desiredReplicas)
+	for i := int32(0); i < desiredReplicas; i++ {
+		desiredByName[autoModeGatewayNodeName(cluster.Name, i)] = true
+
+		desired, err := r.buildAutoModeGatewayNode(cluster, i)
+		if err != nil {
+			return fmt.Errorf("building desired gateway GarageNode for ordinal %d: %w", i, err)
+		}
+
+		current, found := existing[desired.Name]
+		if !found {
+			log.Info("Creating Auto-mode gateway GarageNode", "name", desired.Name)
+			if err := r.Create(ctx, desired); err != nil && !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("creating gateway GarageNode %s: %w", desired.Name, err)
+			}
+			continue
+		}
+
+		if autoModeGatewayNodeNeedsUpdate(current, desired) {
+			log.Info("Updating Auto-mode gateway GarageNode (drift detected)", "name", desired.Name)
+			current.Spec.Zone = desired.Spec.Zone
+			current.Spec.Tags = desired.Spec.Tags
+			current.Spec.Network = desired.Spec.Network
+			if current.Spec.Storage == nil {
+				current.Spec.Storage = desired.Spec.Storage
+			} else if desired.Spec.Storage != nil && desired.Spec.Storage.Metadata != nil {
+				if current.Spec.Storage.Metadata == nil {
+					current.Spec.Storage.Metadata = desired.Spec.Storage.Metadata
+				} else if current.Spec.Storage.Metadata.ExistingClaim == "" {
+					current.Spec.Storage.Metadata.Size = desired.Spec.Storage.Metadata.Size
+					current.Spec.Storage.Metadata.StorageClassName = desired.Spec.Storage.Metadata.StorageClassName
+				}
+			}
+			if err := r.Update(ctx, current); err != nil {
+				return fmt.Errorf("updating gateway GarageNode %s: %w", current.Name, err)
+			}
+		}
+	}
+
+	for name, n := range existing {
+		if desiredByName[name] {
+			continue
+		}
+		log.Info("Deleting Auto-mode gateway GarageNode (scale-down)", "name", name)
+		if err := r.Delete(ctx, n); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("deleting gateway GarageNode %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// listAutoModeGatewayNodes returns operator-owned gateway GarageNodes for this
+// cluster, keyed by name.
+func (r *GarageClusterReconciler) listAutoModeGatewayNodes(ctx context.Context, cluster *garagev1beta2.GarageCluster) (map[string]*garagev1beta1.GarageNode, error) {
+	nodeList := &garagev1beta1.GarageNodeList{}
+	if err := r.List(ctx, nodeList,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels(map[string]string{
+			labelCluster:      cluster.Name,
+			labelTier:         tierGateway,
+			labelAppManagedBy: managedByOperatorValue,
+		}),
+	); err != nil {
+		return nil, err
+	}
+	out := make(map[string]*garagev1beta1.GarageNode, len(nodeList.Items))
+	for i := range nodeList.Items {
+		n := &nodeList.Items[i]
+		out[n.Name] = n
+	}
+	return out, nil
+}
+
+// buildAutoModeGatewayNode constructs the desired gateway GarageNode for an
+// ordinal. Gateway nodes carry capacity=nil (gateway role), a small metadata PVC
+// for persistent identity, and EmptyDir data (no object blocks). The gateway's
+// own rpc_public_addr, when set, flows through spec.network so the node never
+// inherits the storage tier's address.
+func (r *GarageClusterReconciler) buildAutoModeGatewayNode(cluster *garagev1beta2.GarageCluster, ordinal int32) (*garagev1beta1.GarageNode, error) {
+	name := autoModeGatewayNodeName(cluster.Name, ordinal)
+
+	zone := cluster.Spec.Zone
+	if zone == "" {
+		zone = defaultZoneName
+	}
+
+	podName := fmt.Sprintf("%s-%d", name, 0)
+	tags := buildNodeTags(cluster.Name, cluster.Namespace, tierGateway, cluster.Spec.DefaultNodeTags, podName)
+
+	// Metadata PVC sizing: gateway.metadata.size when set, else the 1Gi default.
+	metaSize := gatewayDefaultMetadataSize
+	var metaSC *string
+	if gw := cluster.Spec.Gateway; gw != nil && gw.Metadata != nil {
+		if gw.Metadata.Size != nil && !gw.Metadata.Size.IsZero() {
+			metaSize = *gw.Metadata.Size
+		}
+		metaSC = gw.Metadata.StorageClassName
+	}
+	mSize := metaSize.DeepCopy()
+	storage := &garagev1beta1.NodeStorageConfig{
+		Metadata: &garagev1beta1.NodeVolumeConfig{
+			Size:             &mSize,
+			StorageClassName: metaSC,
+		},
+	}
+
+	node := &garagev1beta1.GarageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				labelCluster:      cluster.Name,
+				labelTier:         tierGateway,
+				labelAppManagedBy: managedByOperatorValue,
+			},
+		},
+		Spec: garagev1beta1.GarageNodeSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: cluster.Name},
+			Zone:       zone,
+			Gateway:    true,
+			Tags:       tags,
+			Storage:    storage,
+		},
+	}
+
+	// Carry the gateway tier's rpc_public_addr (if any) onto the node so the
+	// per-node ConfigMap advertises it. Even when empty, gateway nodes get a
+	// dedicated ConfigMap (nodeHasConfigOverrides returns true for gateways) so
+	// they never inherit the storage tier's rpc_public_addr.
+	if gw := cluster.Spec.Gateway; gw != nil && gw.RPCPublicAddr != "" {
+		node.Spec.Network = &garagev1beta1.NodeNetworkConfig{RPCPublicAddr: gw.RPCPublicAddr}
+	}
+
+	if err := controllerutil.SetControllerReference(cluster, node, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+// autoModeGatewayNodeNeedsUpdate reports whether the desired gateway GarageNode
+// differs from the current one on a field the operator owns.
+func autoModeGatewayNodeNeedsUpdate(current, desired *garagev1beta1.GarageNode) bool {
+	if current.Spec.Zone != desired.Spec.Zone {
+		return true
+	}
+	if !tagsEqualCluster(current.Spec.Tags, desired.Spec.Tags) {
+		return true
+	}
+	cn, dn := current.Spec.Network, desired.Spec.Network
+	if (cn == nil) != (dn == nil) {
+		return true
+	}
+	if cn != nil && dn != nil && cn.RPCPublicAddr != dn.RPCPublicAddr {
+		return true
+	}
+	// Metadata size drift (only when not pinned to an existingClaim).
+	if cs, ds := current.Spec.Storage, desired.Spec.Storage; cs != nil && ds != nil {
+		if cm, dm := cs.Metadata, ds.Metadata; cm != nil && dm != nil && cm.ExistingClaim == "" {
+			if (cm.Size == nil) != (dm.Size == nil) {
+				return true
+			}
+			if cm.Size != nil && dm.Size != nil && cm.Size.Cmp(*dm.Size) != 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// deleteAutoModeGatewayNodes deletes all operator-owned gateway GarageNodes for
+// this cluster. Used when the gateway tier is removed entirely or the cluster
+// stops being unified (e.g. storage tier dropped).
+func (r *GarageClusterReconciler) deleteAutoModeGatewayNodes(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	existing, err := r.listAutoModeGatewayNodes(ctx, cluster)
+	if err != nil {
+		return err
+	}
+	for name, n := range existing {
+		log.Info("Deleting Auto-mode gateway GarageNode (gateway tier removed)", "name", name)
+		if err := r.Delete(ctx, n); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("deleting gateway GarageNode %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// ejectAutoModeGatewayNodes drops the operator's controllerOwnerRef and managed-by
+// label from each operator-owned gateway GarageNode (Auto→Manual hand-off),
+// mirroring ejectAutoModeStorageNodes.
+func (r *GarageClusterReconciler) ejectAutoModeGatewayNodes(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	existing, err := r.listAutoModeGatewayNodes(ctx, cluster)
+	if err != nil {
+		return err
+	}
+	for name, n := range existing {
+		newOwners := n.OwnerReferences[:0]
+		for _, ref := range n.OwnerReferences {
+			if ref.UID == cluster.UID {
+				continue
+			}
+			newOwners = append(newOwners, ref)
+		}
+		n.OwnerReferences = newOwners
+		delete(n.Labels, labelAppManagedBy)
+
+		log.Info("Ejecting Auto-mode gateway GarageNode (Auto→Manual)", "name", name)
+		if err := r.Update(ctx, n); err != nil {
+			return fmt.Errorf("ejecting gateway GarageNode %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/internal/controller/garagecluster_automode_gateway_test.go
+++ b/internal/controller/garagecluster_automode_gateway_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+func listOperatorOwnedGatewayNodes(clusterName string) *garagev1beta1.GarageNodeList {
+	gnList := &garagev1beta1.GarageNodeList{}
+	Expect(k8sClient.List(ctx, gnList,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels(map[string]string{
+			labelCluster:      clusterName,
+			labelTier:         tierGateway,
+			labelAppManagedBy: managedByOperatorValue,
+		}),
+	)).To(Succeed())
+	return gnList
+}
+
+var _ = Describe("GarageCluster unified-gateway Auto-mode (#209)", func() {
+	var (
+		reconciler *GarageClusterReconciler
+		cluster    *garagev1beta2.GarageCluster
+		clusterNN  types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		reconciler = &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		clusterNN = types.NamespacedName{Name: uniqueClusterName("uni-gw"), Namespace: testNamespace}
+		cluster = &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterNN.Name, Namespace: testNamespace},
+			Spec: garagev1beta2.GarageClusterSpec{
+				LayoutPolicy: LayoutPolicyAuto,
+				Zone:         testZone,
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas: 3,
+					Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+				},
+				Gateway:     &garagev1beta2.GatewaySpec{Replicas: 2},
+				Replication: &garagev1beta2.ReplicationConfig{Factor: 3},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		fresh := &garagev1beta2.GarageCluster{}
+		if err := k8sClient.Get(ctx, clusterNN, fresh); err == nil {
+			fresh.Finalizers = nil
+			_ = k8sClient.Update(ctx, fresh)
+			_ = k8sClient.Delete(ctx, fresh)
+		}
+		gnList := &garagev1beta1.GarageNodeList{}
+		_ = k8sClient.List(ctx, gnList, client.InNamespace(testNamespace), client.MatchingLabels(map[string]string{labelCluster: clusterNN.Name}))
+		for i := range gnList.Items {
+			n := gnList.Items[i]
+			n.Finalizers = nil
+			_ = k8sClient.Update(ctx, &n)
+			_ = k8sClient.Delete(ctx, &n)
+		}
+	})
+
+	It("creates one gateway GarageNode per gateway replica with capacity=nil", func() {
+		Expect(reconciler.reconcileAutoModeGatewayNodes(ctx, cluster)).To(Succeed())
+
+		gnList := listOperatorOwnedGatewayNodes(clusterNN.Name)
+		Expect(gnList.Items).To(HaveLen(2))
+
+		names := map[string]bool{}
+		for _, n := range gnList.Items {
+			names[n.Name] = true
+			Expect(metav1.IsControlledBy(&n, cluster)).To(BeTrue())
+			Expect(n.Spec.Gateway).To(BeTrue(), "gateway nodes must carry Gateway:true")
+			Expect(n.Spec.Capacity).To(BeNil(), "gateway nodes must have nil capacity")
+			Expect(n.Spec.Zone).To(Equal(testZone))
+			Expect(n.Labels).To(HaveKeyWithValue(labelTier, tierGateway))
+			Expect(n.Spec.Storage).NotTo(BeNil())
+			Expect(n.Spec.Storage.Metadata).NotTo(BeNil(), "gateway nodes need a metadata PVC for persistent identity")
+			Expect(n.Spec.Storage.Data).To(BeNil(), "gateway nodes must not declare a data PVC")
+			// Gateway tags must carry the tier:gateway + ownership tags the
+			// tombstone-cleanup path filters on.
+			Expect(n.Spec.Tags).To(ContainElement("tier:" + tierGateway))
+		}
+		Expect(names).To(HaveKey(clusterNN.Name + "-gateway-0"))
+		Expect(names).To(HaveKey(clusterNN.Name + "-gateway-1"))
+	})
+
+	It("is a no-op for gateway-only (edge) clusters", func() {
+		edge := &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: uniqueClusterName("edge"), Namespace: testNamespace},
+			Spec: garagev1beta2.GarageClusterSpec{
+				LayoutPolicy: LayoutPolicyAuto,
+				Zone:         testZone,
+				Gateway:      &garagev1beta2.GatewaySpec{Replicas: 2},
+				ConnectTo:    &garagev1beta2.ConnectToConfig{AdminAPIEndpoint: "http://storage:3903"},
+			},
+		}
+		// No storage tier → reconcileAutoModeGatewayNodes must not create nodes
+		// (edge gateways keep the cluster-level StatefulSet path).
+		Expect(reconciler.reconcileAutoModeGatewayNodes(ctx, edge)).To(Succeed())
+		Expect(listOperatorOwnedGatewayNodes(edge.Name).Items).To(BeEmpty())
+	})
+
+	It("scales gateway GarageNodes down when replicas shrink", func() {
+		Expect(reconciler.reconcileAutoModeGatewayNodes(ctx, cluster)).To(Succeed())
+		Expect(listOperatorOwnedGatewayNodes(clusterNN.Name).Items).To(HaveLen(2))
+
+		Expect(k8sClient.Get(ctx, clusterNN, cluster)).To(Succeed())
+		cluster.Spec.Gateway.Replicas = 1
+		Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+		Expect(reconciler.reconcileAutoModeGatewayNodes(ctx, cluster)).To(Succeed())
+
+		remaining := listOperatorOwnedGatewayNodes(clusterNN.Name)
+		// The deleted node may linger on a finalizer in envtest; assert the
+		// surviving desired node is present and the scaled-out one is being removed.
+		got := map[string]bool{}
+		for _, n := range remaining.Items {
+			if n.DeletionTimestamp == nil {
+				got[n.Name] = true
+			}
+		}
+		Expect(got).To(HaveKey(clusterNN.Name + "-gateway-0"))
+		Expect(got).NotTo(HaveKey(clusterNN.Name + "-gateway-1"))
+	})
+
+	It("propagates gateway rpcPublicAddr onto the node network override", func() {
+		Expect(k8sClient.Get(ctx, clusterNN, cluster)).To(Succeed())
+		cluster.Spec.Gateway.RPCPublicAddr = "gw.example.com:3901"
+		Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+		Expect(reconciler.reconcileAutoModeGatewayNodes(ctx, cluster)).To(Succeed())
+
+		for _, n := range listOperatorOwnedGatewayNodes(clusterNN.Name).Items {
+			Expect(n.Spec.Network).NotTo(BeNil())
+			Expect(n.Spec.Network.RPCPublicAddr).To(Equal("gw.example.com:3901"))
+		}
+	})
+
+	It("ejects gateway GarageNodes on Auto→Manual (drops controllerRef + managed-by)", func() {
+		Expect(reconciler.reconcileAutoModeGatewayNodes(ctx, cluster)).To(Succeed())
+		Expect(listOperatorOwnedGatewayNodes(clusterNN.Name).Items).To(HaveLen(2))
+
+		Expect(reconciler.ejectAutoModeGatewayNodes(ctx, cluster)).To(Succeed())
+
+		// After eject, the operator-owned list (filtered by managed-by) is empty.
+		Expect(listOperatorOwnedGatewayNodes(clusterNN.Name).Items).To(BeEmpty())
+
+		// The GarageNodes still exist, just no longer operator-owned.
+		all := &garagev1beta1.GarageNodeList{}
+		Expect(k8sClient.List(ctx, all, client.InNamespace(testNamespace),
+			client.MatchingLabels(map[string]string{labelCluster: clusterNN.Name, labelTier: tierGateway}))).To(Succeed())
+		Expect(all.Items).To(HaveLen(2))
+		for _, n := range all.Items {
+			Expect(metav1.IsControlledBy(&n, cluster)).To(BeFalse(), "controllerRef must be dropped on eject")
+			Expect(n.Labels).NotTo(HaveKey(labelAppManagedBy))
+		}
+	})
+})

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -236,20 +236,49 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 		}
 
+		// Gateway tier dispatch:
+		//   - Unified cluster (storage + gateway): the gateway tier runs as
+		//     per-node GarageNodes (gateway:true) whose layout lives on the LOCAL
+		//     cluster, exactly like the storage tier. The legacy cluster-level
+		//     gateway StatefulSet is removed; gateway pods get capacity=nil layout
+		//     roles via the GarageNode controller (the #209 fix).
+		//   - Edge / standalone gateway (gateway-only + connectTo): the layout
+		//     lives on a REMOTE storage cluster, so we keep the cluster-level
+		//     StatefulSet + gateway-connection path that already handles remote
+		//     admin routing.
 		if cluster.HasGatewayTier() {
-			if err := r.reconcileGatewayStatefulSet(ctx, cluster, gatewayConfigHash); err != nil {
-				return r.updateStatus(ctx, cluster, PhaseFailed, err)
+			if cluster.HasStorageTier() {
+				if err := r.deleteGatewayStatefulSet(ctx, cluster); err != nil {
+					return r.updateStatus(ctx, cluster, PhaseFailed, err)
+				}
+				if err := r.reconcileAutoModeGatewayNodes(ctx, cluster); err != nil {
+					return r.updateStatus(ctx, cluster, PhaseFailed, err)
+				}
+			} else {
+				if err := r.deleteAutoModeGatewayNodes(ctx, cluster); err != nil {
+					return r.updateStatus(ctx, cluster, PhaseFailed, err)
+				}
+				if err := r.reconcileGatewayStatefulSet(ctx, cluster, gatewayConfigHash); err != nil {
+					return r.updateStatus(ctx, cluster, PhaseFailed, err)
+				}
 			}
 		} else {
 			if err := r.deleteGatewayStatefulSet(ctx, cluster); err != nil {
 				return r.updateStatus(ctx, cluster, PhaseFailed, err)
 			}
+			if err := r.deleteAutoModeGatewayNodes(ctx, cluster); err != nil {
+				return r.updateStatus(ctx, cluster, PhaseFailed, err)
+			}
 		}
 	} else {
 		// Manual mode: if the previous policy was Auto and operator-owned
-		// GarageNodes still exist, eject them so the user can take over.
+		// GarageNodes still exist, eject them so the user can take over. Both
+		// tiers are ejected so the hand-off is atomic.
 		if err := r.ejectAutoModeStorageNodes(ctx, cluster); err != nil {
 			return r.updateStatus(ctx, cluster, PhaseFailed, fmt.Errorf("ejecting Auto-mode GarageNodes: %w", err))
+		}
+		if err := r.ejectAutoModeGatewayNodes(ctx, cluster); err != nil {
+			return r.updateStatus(ctx, cluster, PhaseFailed, fmt.Errorf("ejecting Auto-mode gateway GarageNodes: %w", err))
 		}
 	}
 
@@ -789,6 +818,11 @@ type configContext struct {
 	// address — gateways otherwise advertise the storage LB hostname, which routes
 	// peers to the wrong node ID on RPC and breaks the handshake.
 	TierRPCPublicAddrOverride string
+	// OmitClusterRPCPublicAddr suppresses the cluster.Spec.Network.RPCPublicAddr
+	// fallback in writeRPCConfig. Set for gateway nodes so they never inherit the
+	// storage tier's rpc_public_addr when the gateway tier has none of its own
+	// (the v0.5.3 outage). A higher-priority Node/Tier override still wins.
+	OmitClusterRPCPublicAddr bool
 	// NodeDataDirPaths, when non-empty, replaces the cluster-level data_dir with a
 	// per-node TOML array (one entry per mount). Used by the GarageNode controller
 	// for multi-HDD nodes. Capacity (e.g. "100Gi") is optional; when set it is
@@ -1097,7 +1131,7 @@ func writeRPCConfig(config *strings.Builder, cluster *garagev1beta2.GarageCluste
 		fmt.Fprintf(config, "rpc_public_addr = \"%s\"\n", cfgCtx.NodeRPCPublicAddr)
 	case cfgCtx != nil && cfgCtx.TierRPCPublicAddrOverride != "":
 		fmt.Fprintf(config, "rpc_public_addr = \"%s\"\n", cfgCtx.TierRPCPublicAddrOverride)
-	case cluster.Spec.Network.RPCPublicAddr != "":
+	case cluster.Spec.Network.RPCPublicAddr != "" && (cfgCtx == nil || !cfgCtx.OmitClusterRPCPublicAddr):
 		fmt.Fprintf(config, "rpc_public_addr = \"%s\"\n", cluster.Spec.Network.RPCPublicAddr)
 	case cfgCtx != nil && cfgCtx.RPCPublicAddr != "":
 		fmt.Fprintf(config, "rpc_public_addr = \"%s\"\n", cfgCtx.RPCPublicAddr)

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -2676,6 +2676,11 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		ObservedGeneration: cluster.Generation,
 	})
 
+	// Derive the actionable health conditions (QuorumAtRisk, RemoteClustersHealthy,
+	// FederationConfigured) + the one-line LayoutDiagnosis from the populated
+	// status. Runs after Health + RemoteClusters are set above.
+	setClusterHealthConditions(cluster)
+
 	// Update endpoints using configured ports
 	s3Port := int32(3900)
 	if cluster.Spec.S3API != nil && cluster.Spec.S3API.BindPort != 0 {

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -546,19 +546,8 @@ func (r *GarageClusterReconciler) removeNodesFromLayout(ctx context.Context, clu
 		return fmt.Errorf("failed to stage node removals: %w", err)
 	}
 
-	// Get updated layout with staged changes
-	layout, err = garageClient.GetClusterLayout(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get updated layout: %w", err)
-	}
-
-	// Apply the layout changes
-	newVersion := layout.Version + 1
-	if err := garageClient.ApplyClusterLayout(ctx, newVersion); err != nil {
-		if garage.IsConflict(err) {
-			log.Info("Layout version conflict during finalization, will retry", "attemptedVersion", newVersion)
-			return fmt.Errorf("layout version conflict: %w", err)
-		}
+	// Apply the staged removals, tolerating the concurrent-writer race.
+	if err := garageClient.ApplyStagedLayoutChanges(ctx); err != nil {
 		if garage.IsReplicationConstraint(err) {
 			log.Info("Cannot remove nodes: would violate replication constraints. "+
 				"Nodes will remain in layout until more nodes are added or replication factor is reduced.",
@@ -568,14 +557,18 @@ func (r *GarageClusterReconciler) removeNodesFromLayout(ctx context.Context, clu
 		return fmt.Errorf("failed to apply layout removal: %w", err)
 	}
 
-	log.Info("Removed nodes from layout", "count", len(nodesToRemove), "version", newVersion)
+	log.Info("Removed nodes from layout", "count", len(nodesToRemove))
 
 	// For gateway clusters, immediately skip dead nodes since gateways never store data.
 	// This prevents the removed gateway nodes from getting stuck in Draining state,
 	// which would cause quorum calculation to include unreachable nodes.
 	if cluster.HasGatewayTier() {
+		appliedVersion := layout.Version + 1
+		if cur, gerr := garageClient.GetClusterLayout(ctx); gerr == nil {
+			appliedVersion = cur.Version
+		}
 		skipReq := garage.SkipDeadNodesRequest{
-			Version:          newVersion,
+			Version:          appliedVersion,
 			AllowMissingData: true, // Safe for gateways - they never have data
 		}
 		result, err := garageClient.ClusterLayoutSkipDeadNodes(ctx, skipReq)
@@ -3157,17 +3150,12 @@ func assignNewNodesToLayout(ctx context.Context, garageClient *garage.Client, no
 			"replicationFactor", cfg.replicationFactor)
 	}
 
-	// Apply staged changes
+	// Apply staged changes (race-tolerant: apply rejection is a generic 500, not a 409).
 	log.Info("Applying staged layout changes", "stagedCount", len(layout.StagedRoleChanges), "totalNodes", totalNodesAfterApply, "currentVersion", layout.Version)
-	newVersion := layout.Version + 1
-	if err := garageClient.ApplyClusterLayout(ctx, newVersion); err != nil {
-		if garage.IsConflict(err) {
-			log.Info("Layout version conflict, requeueing to retry", "attemptedVersion", newVersion)
-			return fmt.Errorf("layout version conflict (version %d): %w", newVersion, err)
-		}
+	if err := garageClient.ApplyStagedLayoutChanges(ctx); err != nil {
 		return fmt.Errorf("failed to apply cluster layout: %w", err)
 	}
-	log.Info("Applied cluster layout", "version", newVersion)
+	log.Info("Applied cluster layout")
 	return nil
 }
 
@@ -4398,17 +4386,12 @@ func (r *GarageClusterReconciler) addRemoteNodesToLayout(
 		return nil // Nothing to apply
 	}
 
-	// Apply layout
-	newVersion := layout.Version + 1
-	if err := localClient.ApplyClusterLayout(ctx, newVersion); err != nil {
-		if garage.IsConflict(err) {
-			log.Info("Layout version conflict, will retry on next reconciliation", "version", newVersion)
-			return nil
-		}
+	// Apply layout (race-tolerant: apply rejection is a generic 500, not a 409).
+	if err := localClient.ApplyStagedLayoutChanges(ctx); err != nil {
 		return fmt.Errorf("failed to apply layout: %w", err)
 	}
 
-	log.Info("Applied federated layout", "cluster", remote.Name, "version", newVersion, "nodesAdded", len(newRoles))
+	log.Info("Applied federated layout", "cluster", remote.Name, "nodesAdded", len(newRoles))
 
 	// After adding nodes, check for stale remote nodes that were removed from the remote cluster.
 	// Only possible when we have a fresh remote status to compare against.
@@ -4481,13 +4464,8 @@ func (r *GarageClusterReconciler) removeStaleRemoteNodes(
 		return fmt.Errorf("failed to get updated layout: %w", err)
 	}
 
-	// Apply layout
-	newVersion := layout.Version + 1
-	if err := localClient.ApplyClusterLayout(ctx, newVersion); err != nil {
-		if garage.IsConflict(err) {
-			log.Info("Layout version conflict during stale node removal, will retry", "version", newVersion)
-			return nil
-		}
+	// Apply layout (race-tolerant: apply rejection is a generic 500, not a 409).
+	if err := localClient.ApplyStagedLayoutChanges(ctx); err != nil {
 		if garage.IsReplicationConstraint(err) {
 			log.Info("Cannot remove stale remote nodes: would violate replication constraints",
 				"staleCount", len(staleNodes))
@@ -4496,14 +4474,18 @@ func (r *GarageClusterReconciler) removeStaleRemoteNodes(
 		return fmt.Errorf("failed to apply stale node removal: %w", err)
 	}
 
+	appliedVersion := layout.Version + 1
+	if cur, gerr := localClient.GetClusterLayout(ctx); gerr == nil {
+		appliedVersion = cur.Version
+	}
 	log.Info("Removed stale remote nodes from layout",
-		"count", len(staleNodes), "remoteCluster", remote.Name, "version", newVersion)
+		"count", len(staleNodes), "remoteCluster", remote.Name, "version", appliedVersion)
 
 	// After removing stale remote nodes, call skip-dead-nodes to prevent draining stalls.
 	// Remote nodes are typically unreachable after removal, so they can't acknowledge sync.
 	// Use allowMissingData=true since we've confirmed these nodes no longer exist in the remote cluster.
 	skipReq := garage.SkipDeadNodesRequest{
-		Version:          newVersion,
+		Version:          appliedVersion,
 		AllowMissingData: true, // Safe - nodes confirmed removed from remote cluster
 	}
 	result, err := localClient.ClusterLayoutSkipDeadNodes(ctx, skipReq)

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -417,6 +417,29 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 		}
 	}
 
+	// In a unified cluster the gateway tier runs as per-node GarageNodes, whose
+	// finalizers own layout-role removal on delete. A node that just restarted
+	// is briefly not "isUp" yet its CR (and role) are valid — removing it here
+	// would fight the per-node controller. So preserve any role claimed by a live
+	// operator-owned gateway GarageNode CR (via status.nodeId). Edge gateways have
+	// no such CRs, so this set is empty there and the isUp check governs alone.
+	claimed := make(map[string]bool)
+	gwNodes := &garagev1beta1.GarageNodeList{}
+	if err := r.List(ctx, gwNodes,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels(map[string]string{
+			labelCluster:      cluster.Name,
+			labelTier:         tierGateway,
+			labelAppManagedBy: managedByOperatorValue,
+		}),
+	); err == nil {
+		for i := range gwNodes.Items {
+			if id := gwNodes.Items[i].Status.NodeID; id != "" {
+				claimed[id] = true
+			}
+		}
+	}
+
 	gatewayOwnershipTag := fmt.Sprintf("cluster:%s/%s", cluster.Name, cluster.Namespace)
 	gatewayTierTag := "tier:" + tierGateway
 	var stale []string
@@ -434,7 +457,7 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 		if !ownsThis || !isGatewayTier {
 			continue
 		}
-		if live[role.ID] {
+		if live[role.ID] || claimed[role.ID] {
 			continue
 		}
 		stale = append(stale, role.ID)

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -493,17 +493,15 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 		log.Error(err, "Failed to stage stale gateway entry removal")
 		return
 	}
-	layout, err = layoutClient.GetClusterLayout(ctx)
-	if err != nil {
-		log.Error(err, "Failed to refresh layout after staging tombstone removal")
-		return
-	}
-	newVersion := layout.Version + 1
-	if err := layoutClient.ApplyClusterLayout(ctx, newVersion); err != nil {
+	if err := layoutClient.ApplyStagedLayoutChanges(ctx); err != nil {
 		if !garage.IsReplicationConstraint(err) {
 			log.Error(err, "Failed to apply gateway tombstone removal")
 		}
 		return
+	}
+	newVersion := layout.Version + 1
+	if cur, gerr := layoutClient.GetClusterLayout(ctx); gerr == nil {
+		newVersion = cur.Version
 	}
 	log.Info("Removed stale gateway entries from layout", "count", len(stale), "version", newVersion)
 

--- a/internal/controller/garagecluster_health.go
+++ b/internal/controller/garagecluster_health.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+// remoteStaleThreshold is how long a federated remote cluster may be
+// unreachable before RemoteClustersHealthy flips False. Below this it's treated
+// as a transient blip.
+const remoteStaleThreshold = time.Hour
+
+// clusterHasRPCPublicAddr reports whether the cluster advertises an
+// externally-routable RPC address — either an explicit network.rpcPublicAddr or
+// a publicEndpoint the operator derives one from. Federation needs this so
+// Garage's HelloMessage carries a server_addr peers can dial.
+func clusterHasRPCPublicAddr(cluster *garagev1beta2.GarageCluster) bool {
+	if cluster.Spec.Network.RPCPublicAddr != "" {
+		return true
+	}
+	if cluster.Spec.PublicEndpoint != nil {
+		return true
+	}
+	if cluster.Spec.Gateway != nil && cluster.Spec.Gateway.RPCPublicAddr != "" {
+		return true
+	}
+	return false
+}
+
+// setClusterHealthConditions derives the actionable health conditions
+// (QuorumAtRisk, RemoteClustersHealthy, FederationConfigured) from already-
+// populated status (Health + RemoteClusters) and writes a one-line
+// LayoutDiagnosis from the most severe active problem. All signals are validated
+// against upstream Garage v2.3.0: partition quorum is Garage's own computation,
+// and federation reachability is the operator's recorded last-seen state.
+//
+// Severity order (worst first): write-quorum loss → remote-cluster loss →
+// federation misconfiguration.
+func setClusterHealthConditions(cluster *garagev1beta2.GarageCluster) {
+	gen := cluster.Generation
+	var diagnoses []string
+
+	// --- QuorumAtRisk: some partition lacks write quorum -------------------
+	if h := cluster.Status.Health; h != nil && h.Partitions > 0 && h.PartitionsQuorum < h.Partitions {
+		atRisk := h.Partitions - h.PartitionsQuorum
+		msg := fmt.Sprintf(
+			"%d/%d partitions lack write quorum (%d/%d storage nodes reachable); "+
+				"restore nodes, or set spec.replication.consistencyMode: dangerous to accept reduced durability",
+			atRisk, h.Partitions, h.StorageNodesOK, h.StorageNodes)
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionQuorumAtRisk,
+			Status:             metav1.ConditionTrue,
+			Reason:             garagev1beta1.ReasonQuorumLost,
+			Message:            msg,
+			ObservedGeneration: gen,
+		})
+		diagnoses = append(diagnoses, msg)
+	} else {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionQuorumAtRisk,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonQuorumOK,
+			Message:            "all partitions have write quorum",
+			ObservedGeneration: gen,
+		})
+	}
+
+	// --- RemoteClustersHealthy: federated remote reachability --------------
+	if len(cluster.Spec.RemoteClusters) > 0 {
+		var stale []string
+		for _, rc := range cluster.Status.RemoteClusters {
+			if rc.Connected {
+				continue
+			}
+			if rc.LastSeen != nil && time.Since(rc.LastSeen.Time) < remoteStaleThreshold {
+				continue // transient blip, not yet stale
+			}
+			age := "never connected"
+			if rc.LastSeen != nil {
+				age = fmt.Sprintf("unreachable for %s", time.Since(rc.LastSeen.Time).Round(time.Minute))
+			}
+			stale = append(stale, fmt.Sprintf("%s (%s)", rc.Name, age))
+		}
+		if len(stale) > 0 {
+			msg := fmt.Sprintf(
+				"federated remote clusters unreachable: %s; if a zone is permanently gone, "+
+					"reduce spec.replication.factor to restore write quorum",
+				strings.Join(stale, ", "))
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:               garagev1beta1.ConditionRemoteClustersHealthy,
+				Status:             metav1.ConditionFalse,
+				Reason:             garagev1beta1.ReasonRemotesStale,
+				Message:            msg,
+				ObservedGeneration: gen,
+			})
+			diagnoses = append(diagnoses, msg)
+		} else {
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:               garagev1beta1.ConditionRemoteClustersHealthy,
+				Status:             metav1.ConditionTrue,
+				Reason:             garagev1beta1.ReasonAllRemotesConnected,
+				Message:            fmt.Sprintf("all %d federated remote clusters reachable", len(cluster.Spec.RemoteClusters)),
+				ObservedGeneration: gen,
+			})
+		}
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionRemoteClustersHealthy)
+	}
+
+	// --- FederationConfigured: rpc_public_addr present when federated ------
+	if len(cluster.Spec.RemoteClusters) > 0 {
+		if clusterHasRPCPublicAddr(cluster) {
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:               garagev1beta1.ConditionFederationConfigured,
+				Status:             metav1.ConditionTrue,
+				Reason:             garagev1beta1.ReasonFederationReady,
+				Message:            "rpc_public_addr is configured for cross-cluster RPC",
+				ObservedGeneration: gen,
+			})
+		} else {
+			msg := "federation enabled (spec.remoteClusters) but no rpc_public_addr " +
+				"(set spec.network.rpcPublicAddr or a publicEndpoint); cross-cluster RPC will " +
+				"degrade after pod restarts as peers infer the unroutable pod IP"
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:               garagev1beta1.ConditionFederationConfigured,
+				Status:             metav1.ConditionFalse,
+				Reason:             garagev1beta1.ReasonMissingRPCPublicAddr,
+				Message:            msg,
+				ObservedGeneration: gen,
+			})
+			diagnoses = append(diagnoses, msg)
+		}
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionFederationConfigured)
+	}
+
+	// One-line human summary = most severe active problem.
+	if len(diagnoses) > 0 {
+		cluster.Status.LayoutDiagnosis = diagnoses[0]
+	} else {
+		cluster.Status.LayoutDiagnosis = ""
+	}
+}

--- a/internal/controller/garagecluster_health_test.go
+++ b/internal/controller/garagecluster_health_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+func condStatus(cluster *garagev1beta2.GarageCluster, condType string) (metav1.ConditionStatus, bool) {
+	c := meta.FindStatusCondition(cluster.Status.Conditions, condType)
+	if c == nil {
+		return "", false
+	}
+	return c.Status, true
+}
+
+func TestSetClusterHealthConditions_QuorumAtRisk(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{
+		Status: garagev1beta2.GarageClusterStatus{
+			Health: &garagev1beta2.ClusterHealth{
+				Partitions: 256, PartitionsQuorum: 200, StorageNodes: 3, StorageNodesOK: 1,
+			},
+		},
+	}
+	setClusterHealthConditions(cluster)
+
+	st, ok := condStatus(cluster, garagev1beta1.ConditionQuorumAtRisk)
+	if !ok || st != metav1.ConditionTrue {
+		t.Fatalf("expected QuorumAtRisk=True, got %v (present=%v)", st, ok)
+	}
+	if cluster.Status.LayoutDiagnosis == "" {
+		t.Fatal("expected a LayoutDiagnosis when quorum is at risk")
+	}
+}
+
+func TestSetClusterHealthConditions_AllQuorate(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{
+		Status: garagev1beta2.GarageClusterStatus{
+			Health: &garagev1beta2.ClusterHealth{
+				Partitions: 256, PartitionsQuorum: 256, StorageNodes: 3, StorageNodesOK: 3,
+			},
+		},
+	}
+	setClusterHealthConditions(cluster)
+
+	st, _ := condStatus(cluster, garagev1beta1.ConditionQuorumAtRisk)
+	if st != metav1.ConditionFalse {
+		t.Fatalf("expected QuorumAtRisk=False when all partitions quorate, got %v", st)
+	}
+	if cluster.Status.LayoutDiagnosis != "" {
+		t.Fatalf("expected empty diagnosis for a healthy cluster, got %q", cluster.Status.LayoutDiagnosis)
+	}
+}
+
+func TestSetClusterHealthConditions_RemoteStale(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-3 * time.Hour))
+	cluster := &garagev1beta2.GarageCluster{
+		Spec: garagev1beta2.GarageClusterSpec{
+			RemoteClusters: []garagev1beta2.RemoteClusterConfig{{Name: "stpetersburg"}},
+			Network:        garagev1beta2.NetworkConfig{RPCPublicAddr: "node.example.com:3901"},
+		},
+		Status: garagev1beta2.GarageClusterStatus{
+			RemoteClusters: []garagev1beta2.RemoteClusterStatus{
+				{Name: "stpetersburg", Connected: false, LastSeen: &old},
+			},
+		},
+	}
+	setClusterHealthConditions(cluster)
+
+	st, ok := condStatus(cluster, garagev1beta1.ConditionRemoteClustersHealthy)
+	if !ok || st != metav1.ConditionFalse {
+		t.Fatalf("expected RemoteClustersHealthy=False for a 3h-stale remote, got %v (present=%v)", st, ok)
+	}
+	// rpc_public_addr is set, so FederationConfigured must be True.
+	if st, _ := condStatus(cluster, garagev1beta1.ConditionFederationConfigured); st != metav1.ConditionTrue {
+		t.Fatalf("expected FederationConfigured=True, got %v", st)
+	}
+}
+
+func TestSetClusterHealthConditions_RemoteRecentBlipNotStale(t *testing.T) {
+	recent := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	cluster := &garagev1beta2.GarageCluster{
+		Spec: garagev1beta2.GarageClusterSpec{
+			RemoteClusters: []garagev1beta2.RemoteClusterConfig{{Name: "ottawa"}},
+			Network:        garagev1beta2.NetworkConfig{RPCPublicAddr: "node:3901"},
+		},
+		Status: garagev1beta2.GarageClusterStatus{
+			RemoteClusters: []garagev1beta2.RemoteClusterStatus{
+				{Name: "ottawa", Connected: false, LastSeen: &recent},
+			},
+		},
+	}
+	setClusterHealthConditions(cluster)
+	if st, _ := condStatus(cluster, garagev1beta1.ConditionRemoteClustersHealthy); st != metav1.ConditionTrue {
+		t.Fatalf("a 2-minute blip should NOT flip RemoteClustersHealthy False, got %v", st)
+	}
+}
+
+func TestSetClusterHealthConditions_FederationMissingRPCAddr(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{
+		Spec: garagev1beta2.GarageClusterSpec{
+			RemoteClusters: []garagev1beta2.RemoteClusterConfig{{Name: "remote-a"}},
+		},
+		Status: garagev1beta2.GarageClusterStatus{
+			RemoteClusters: []garagev1beta2.RemoteClusterStatus{{Name: "remote-a", Connected: true}},
+		},
+	}
+	setClusterHealthConditions(cluster)
+
+	st, ok := condStatus(cluster, garagev1beta1.ConditionFederationConfigured)
+	if !ok || st != metav1.ConditionFalse {
+		t.Fatalf("expected FederationConfigured=False without rpc_public_addr, got %v (present=%v)", st, ok)
+	}
+	if cluster.Status.LayoutDiagnosis == "" {
+		t.Fatal("expected a diagnosis for missing rpc_public_addr under federation")
+	}
+}
+
+func TestSetClusterHealthConditions_NoFederationClearsConditions(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{
+		Status: garagev1beta2.GarageClusterStatus{
+			Conditions: []metav1.Condition{
+				{Type: garagev1beta1.ConditionRemoteClustersHealthy, Status: metav1.ConditionFalse, Reason: "x", LastTransitionTime: metav1.Now()},
+				{Type: garagev1beta1.ConditionFederationConfigured, Status: metav1.ConditionFalse, Reason: "x", LastTransitionTime: metav1.Now()},
+			},
+		},
+	}
+	setClusterHealthConditions(cluster)
+
+	if _, ok := condStatus(cluster, garagev1beta1.ConditionRemoteClustersHealthy); ok {
+		t.Fatal("RemoteClustersHealthy must be removed for a non-federated cluster")
+	}
+	if _, ok := condStatus(cluster, garagev1beta1.ConditionFederationConfigured); ok {
+		t.Fatal("FederationConfigured must be removed for a non-federated cluster")
+	}
+}
+
+func TestSetClusterHealthConditions_QuorumIsMostSevere(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-5 * time.Hour))
+	cluster := &garagev1beta2.GarageCluster{
+		Spec: garagev1beta2.GarageClusterSpec{
+			RemoteClusters: []garagev1beta2.RemoteClusterConfig{{Name: "r"}},
+		},
+		Status: garagev1beta2.GarageClusterStatus{
+			Health:         &garagev1beta2.ClusterHealth{Partitions: 256, PartitionsQuorum: 100, StorageNodes: 3, StorageNodesOK: 1},
+			RemoteClusters: []garagev1beta2.RemoteClusterStatus{{Name: "r", Connected: false, LastSeen: &old}},
+		},
+	}
+	setClusterHealthConditions(cluster)
+	// The diagnosis line should be the quorum problem (most severe), not the remote one.
+	if got := cluster.Status.LayoutDiagnosis; got == "" || !strings.Contains(got, "write quorum") {
+		t.Fatalf("expected the quorum problem to win the diagnosis line, got %q", got)
+	}
+}

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -266,13 +266,21 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 	// Build merged pod config (cluster defaults + node overrides)
 	image := mergeNodeImage(cluster.Spec.Image, cluster.Spec.ImageRepository, node.Spec.Image, node.Spec.ImageRepository, r.DefaultImage)
 
-	// Cluster-level fallback scheduling values come from the storage tier when set
-	// (manual-layout GarageNodes are functionally storage nodes). Edge gateway clusters
-	// don't have a storage tier; in that case we fall back to gateway-tier values.
+	// Cluster-level fallback scheduling values come from the tier this node
+	// belongs to. A gateway GarageNode (node.Spec.Gateway) inherits the gateway
+	// tier's PodTemplate; a storage GarageNode inherits the storage tier's. This
+	// matters in a unified cluster where BOTH tiers are declared — without the
+	// gateway branch, gateway pods would wrongly inherit storage-tier scheduling
+	// (resources, nodeSelector, affinity). Fallbacks cover single-tier clusters.
 	var tierTemplate *garagev1beta2.PodTemplate
-	if cluster.HasStorageTier() {
+	switch {
+	case node.Spec.Gateway && cluster.HasGatewayTier():
+		tierTemplate = &cluster.Spec.Gateway.PodTemplate
+	case !node.Spec.Gateway && cluster.HasStorageTier():
 		tierTemplate = &cluster.Spec.Storage.PodTemplate
-	} else if cluster.HasGatewayTier() {
+	case cluster.HasStorageTier():
+		tierTemplate = &cluster.Spec.Storage.PodTemplate
+	case cluster.HasGatewayTier():
 		tierTemplate = &cluster.Spec.Gateway.PodTemplate
 	}
 
@@ -1724,6 +1732,13 @@ func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node 
 	cfgCtx, err := buildConfigContext(ctx, r.Client, cluster)
 	if err != nil {
 		cfgCtx = &configContext{}
+	}
+
+	// A gateway node must never inherit the storage tier's rpc_public_addr from
+	// the shared cluster config (the v0.5.3 outage). Its own address, if any,
+	// still flows through NodeRPCPublicAddr below.
+	if node.Spec.Gateway {
+		cfgCtx.OmitClusterRPCPublicAddr = true
 	}
 
 	// Apply node-level rpc_public_addr via NodeRPCPublicAddr — this takes highest priority

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -1128,8 +1128,6 @@ func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1
 			}
 		}
 
-		stagedVersion := layout.Version + 1
-
 		updates := []garage.NodeRoleChange{{
 			ID:       nodeID,
 			Zone:     node.Spec.Zone,
@@ -1141,15 +1139,15 @@ func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1
 			return fmt.Errorf("failed to update layout: %w", err)
 		}
 
-		if err := garageClient.ApplyClusterLayout(ctx, stagedVersion); err != nil {
-			if garage.IsConflict(err) {
-				log.Info("Layout version mismatch, will retry on next reconciliation", "attemptedVersion", stagedVersion)
-				return nil
-			}
+		// ApplyStagedLayoutChanges re-reads the version after staging and
+		// tolerates the concurrent-writer race (apply rejection is a generic
+		// 500, not a 409 — so a returned error here is a genuine failure worth
+		// requeueing, not a benign version race).
+		if err := garageClient.ApplyStagedLayoutChanges(ctx); err != nil {
 			return fmt.Errorf("failed to apply layout: %w", err)
 		}
 
-		log.Info("Applied layout update", "version", stagedVersion)
+		log.Info("Applied layout update", "nodeID", nodeID, "zone", node.Spec.Zone)
 	}
 
 	return nil
@@ -1377,11 +1375,7 @@ func (r *GarageNodeReconciler) removeNodeFromExternalLayout(ctx context.Context,
 	if err := garageClient.UpdateClusterLayout(ctx, updates); err != nil {
 		return fmt.Errorf("stage node removal: %w", err)
 	}
-	stagedVersion := layout.Version + 1
-	if err := garageClient.ApplyClusterLayout(ctx, stagedVersion); err != nil {
-		if garage.IsConflict(err) {
-			return fmt.Errorf("layout version mismatch: %w", err)
-		}
+	if err := garageClient.ApplyStagedLayoutChanges(ctx); err != nil {
 		if garage.IsReplicationConstraint(err) {
 			// Best-effort cleanup; admin will need to add capacity or
 			// reduce replication to actually drop this entry.
@@ -1472,16 +1466,11 @@ func (r *GarageNodeReconciler) finalize(ctx context.Context, node *garagev1beta1
 		return fmt.Errorf("failed to stage node removal: %w", err)
 	}
 
-	stagedVersion := layout.Version + 1
 	if len(layout.StagedRoleChanges) > 0 {
 		log.Info("Adding removal to existing staged layout changes", "existingStagedCount", len(layout.StagedRoleChanges))
 	}
 
-	if err := garageClient.ApplyClusterLayout(ctx, stagedVersion); err != nil {
-		if garage.IsConflict(err) {
-			log.Info("Layout version mismatch during removal, will retry", "attemptedVersion", stagedVersion)
-			return fmt.Errorf("layout version mismatch, retry needed: %w", err)
-		}
+	if err := garageClient.ApplyStagedLayoutChanges(ctx); err != nil {
 		if garage.IsReplicationConstraint(err) {
 			log.Info("Cannot remove node: would violate replication factor constraints. "+
 				"The node will be removed from Kubernetes but will remain in the Garage layout. "+
@@ -1492,12 +1481,21 @@ func (r *GarageNodeReconciler) finalize(ctx context.Context, node *garagev1beta1
 		return fmt.Errorf("failed to apply layout removal: %w", err)
 	}
 
-	log.Info("Removed node from layout", "version", stagedVersion)
+	// Re-read the committed version for logging and the gateway skip-dead-nodes
+	// call (ApplyStagedLayoutChanges does not surface the version it applied,
+	// and a concurrent writer may have advanced it past our local target).
+	appliedVersion := layout.Version + 1
+	if cur, gerr := garageClient.GetClusterLayout(ctx); gerr == nil {
+		appliedVersion = cur.Version
+	}
+	log.Info("Removed node from layout", "version", appliedVersion)
 
-	// For gateway nodes, immediately skip dead nodes
+	// For gateway nodes, immediately skip dead nodes. Gateways own no partitions
+	// so this is belt-and-suspenders (it advances ack/sync trackers so the
+	// removed entry never lingers in a Draining version), not a data operation.
 	if node.Spec.Gateway {
 		skipReq := garage.SkipDeadNodesRequest{
-			Version:          stagedVersion,
+			Version:          appliedVersion,
 			AllowMissingData: true,
 		}
 		result, err := garageClient.ClusterLayoutSkipDeadNodes(ctx, skipReq)

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -1534,7 +1534,14 @@ var _ = Describe("GarageNode orphaned-finalize against external admin endpoint",
 		mux := http.NewServeMux()
 		mux.HandleFunc("/v2/GetClusterLayout", func(w http.ResponseWriter, _ *http.Request) {
 			roles := []garage.LayoutRole{{ID: extraNodeID, Zone: "z"}}
-			_ = json.NewEncoder(w).Encode(garage.ClusterLayout{Version: 1, Roles: roles})
+			layout := garage.ClusterLayout{Version: 1, Roles: roles}
+			// Reflect a staged removal once UpdateClusterLayout has been called,
+			// matching real Garage — ApplyStagedLayoutChanges re-reads the layout
+			// and only applies when something is staged.
+			if atomic.LoadInt32(&updates) > 0 {
+				layout.StagedRoleChanges = []garage.NodeRoleChange{{ID: extraNodeID, Remove: true}}
+			}
+			_ = json.NewEncoder(w).Encode(layout)
 		})
 		mux.HandleFunc("/v2/UpdateClusterLayout", func(w http.ResponseWriter, _ *http.Request) {
 			atomic.AddInt32(&updates, 1)

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -521,6 +521,50 @@ var _ = Describe("GarageNode per-node features", func() {
 			Expect(cm.Data["garage.toml"]).To(ContainSubstring(`rpc_public_addr = "node-addr:3901"`))
 			Expect(cm.Data["garage.toml"]).NotTo(ContainSubstring("cluster-addr"))
 		})
+
+		It("a gateway node does NOT inherit the storage tier's rpc_public_addr (v0.5.3 regression)", func() {
+			// Unified cluster: storage tier advertises an rpc_public_addr; the
+			// gateway tier has none of its own. A gateway pod inheriting the
+			// storage LB hostname routes RPC peers to the wrong node ID and breaks
+			// the handshake — the 2026-05-18 cross-cluster outage.
+			clusterWithAddr := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: featureNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					LayoutPolicy: LayoutPolicyAuto,
+					Replication:  &garagev1beta2.ReplicationConfig{Factor: 1},
+					Network:      garagev1beta2.NetworkConfig{RPCPublicAddr: "storage-lb.example.com:3901"},
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 1,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Gateway: &garagev1beta2.GatewaySpec{Replicas: 1},
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterWithAddr)).To(Succeed())
+
+			gwNode := &garagev1beta1.GarageNode{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: featureNamespace},
+				Spec: garagev1beta1.GarageNodeSpec{
+					ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+					Zone:       testNodeZone,
+					Gateway:    true,
+					Storage: &garagev1beta1.NodeStorageConfig{
+						Metadata: &garagev1beta1.NodeVolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gwNode)).To(Succeed())
+
+			Expect(reconciler().reconcileNodeConfigMap(ctx, gwNode, clusterWithAddr)).To(Succeed())
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName + "-config", Namespace: featureNamespace}, cm)).To(Succeed())
+			Expect(cm.Data["garage.toml"]).NotTo(ContainSubstring("storage-lb.example.com"),
+				"gateway node must not inherit the storage tier rpc_public_addr")
+			Expect(cm.Data["garage.toml"]).NotTo(ContainSubstring("rpc_public_addr ="),
+				"gateway with no address of its own emits no rpc_public_addr at all")
+		})
 	})
 
 	Context("per-node fsync overrides in ConfigMap", func() {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -197,6 +197,14 @@ func extractIPFromAddress(addr string) string {
 // overrides requiring a dedicated per-node ConfigMap. This is the canonical definition
 // used for ConfigMap creation, volume selection, and config-hash annotation gating.
 func nodeHasConfigOverrides(node *garagev1beta1.GarageNode) bool {
+	// Gateway nodes always need a dedicated config so they never inherit the
+	// storage tier's rpc_public_addr from the shared <cluster>-config. A gateway
+	// advertising the storage LB hostname routes RPC peers to the wrong node ID
+	// and breaks the handshake (the v0.5.3 cross-cluster outage). The per-node
+	// renderer sets OmitClusterRPCPublicAddr for gateway nodes.
+	if node.Spec.Gateway {
+		return true
+	}
 	if node.Spec.Network != nil || node.Spec.PublicEndpoint != nil {
 		return true
 	}

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -452,6 +452,50 @@ func (c *Client) ApplyClusterLayout(ctx context.Context, version uint64) error {
 	return err
 }
 
+// ApplyStagedLayoutChanges commits whatever layout changes are currently staged,
+// tolerating the concurrent-writer race that arises when several reconcilers
+// stage their own role into the same cluster layout.
+//
+// Two upstream facts make a naive `ApplyClusterLayout(version+1)` wrong (verified
+// against Garage v2.3.0):
+//
+//  1. ApplyClusterLayout ALWAYS increments the version with no no-op
+//     short-circuit (src/rpc/layout/version.rs:290-303). Applying when nothing
+//     is staged churns the version + layout gossip pointlessly. So we read the
+//     layout first and return early when nothing is staged.
+//
+//  2. The version-mismatch rejection is a generic Error::Message("Invalid new
+//     layout version") that maps to HTTP 500, NOT 409
+//     (src/rpc/layout/history.rs:273-276). IsConflict() (which only matches 409)
+//     therefore never catches an apply race. When apply fails we re-read the
+//     layout: if another writer already advanced the version (committing our
+//     staged change too, since staging is a per-node LwwMap that merges), we
+//     treat it as success; otherwise we surface the error so the caller requeues
+//     and retries against the new current+1.
+//
+// Staging is a CRDT merge keyed by node UUID, so committing "whatever is staged"
+// is safe — it commits our change plus any sibling's concurrently-staged change.
+func (c *Client) ApplyStagedLayoutChanges(ctx context.Context) error {
+	layout, err := c.GetClusterLayout(ctx)
+	if err != nil {
+		return err
+	}
+	if len(layout.StagedRoleChanges) == 0 && layout.StagedParameters == nil {
+		// Nothing to apply — do not bump the version.
+		return nil
+	}
+	target := layout.Version + 1
+	if err := c.ApplyClusterLayout(ctx, target); err != nil {
+		// Apply rejection is not a 409; re-read to decide whether a concurrent
+		// writer already committed our staged change.
+		if fresh, gerr := c.GetClusterLayout(ctx); gerr == nil && fresh.Version >= target {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 // RevertClusterLayout reverts staged layout changes
 func (c *Client) RevertClusterLayout(ctx context.Context) error {
 	_, err := c.doRequest(ctx, http.MethodPost, "/v2/RevertClusterLayout", nil)

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -508,6 +508,123 @@ func TestLaunchScrubCommand_RequestBody(t *testing.T) {
 	}
 }
 
+const (
+	pathGetClusterLayout   = "/v2/GetClusterLayout"
+	pathApplyClusterLayout = "/v2/ApplyClusterLayout"
+)
+
+// TestApplyStagedLayoutChanges exercises the concurrent-writer-safe apply path.
+// Garage returns a generic 500 ("Invalid new layout version") on a version
+// race — NOT a 409 — so the helper must re-read the layout to decide whether a
+// sibling writer already committed our staged change.
+func TestApplyStagedLayoutChanges(t *testing.T) {
+	t.Run("no staged changes does not apply", func(t *testing.T) {
+		applied := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case pathGetClusterLayout:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"version":7,"roles":[],"stagedRoleChanges":[]}`))
+			case pathApplyClusterLayout:
+				applied = true
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected path %q", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, "tok")
+		if err := c.ApplyStagedLayoutChanges(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if applied {
+			t.Fatal("apply must not be called when nothing is staged (version churn)")
+		}
+	})
+
+	t.Run("staged changes applied at version+1", func(t *testing.T) {
+		var gotVersion uint64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case pathGetClusterLayout:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"version":7,"roles":[],"stagedRoleChanges":[{"id":"n1","zone":"z","tags":[]}]}`))
+			case pathApplyClusterLayout:
+				var req ApplyLayoutRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				gotVersion = req.Version
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected path %q", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, "tok")
+		if err := c.ApplyStagedLayoutChanges(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotVersion != 8 {
+			t.Fatalf("applied version = %d, want 8", gotVersion)
+		}
+	})
+
+	t.Run("version race resolved when sibling already applied", func(t *testing.T) {
+		// Apply is rejected with a generic 500; the subsequent GetClusterLayout
+		// shows the version already advanced past our target, so the helper
+		// treats it as success.
+		getCalls := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case pathGetClusterLayout:
+				getCalls++
+				w.Header().Set("Content-Type", "application/json")
+				if getCalls == 1 {
+					_, _ = w.Write([]byte(`{"version":7,"roles":[],"stagedRoleChanges":[{"id":"n1","zone":"z","tags":[]}]}`))
+				} else {
+					// Sibling committed; version advanced and staging cleared.
+					_, _ = w.Write([]byte(`{"version":8,"roles":[{"id":"n1","zone":"z","tags":[]}],"stagedRoleChanges":[]}`))
+				}
+			case pathApplyClusterLayout:
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"code":"InternalError","message":"Invalid new layout version"}`))
+			default:
+				t.Fatalf("unexpected path %q", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, "tok")
+		if err := c.ApplyStagedLayoutChanges(context.Background()); err != nil {
+			t.Fatalf("expected race to resolve to success, got: %v", err)
+		}
+	})
+
+	t.Run("genuine apply failure surfaces error", func(t *testing.T) {
+		// Apply rejected and the version did NOT advance — a real failure the
+		// caller must requeue on.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case pathGetClusterLayout:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"version":7,"roles":[],"stagedRoleChanges":[{"id":"n1","zone":"z","tags":[]}]}`))
+			case pathApplyClusterLayout:
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"code":"InternalError","message":"some other failure"}`))
+			default:
+				t.Fatalf("unexpected path %q", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, "tok")
+		if err := c.ApplyStagedLayoutChanges(context.Background()); err == nil {
+			t.Fatal("expected apply failure to surface as an error")
+		}
+	})
+}
+
 func TestConnectNode_ReturnsErrorWhenGarageReportsFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v2/ConnectClusterNodes" {

--- a/schemas/garagecluster_v1beta2.json
+++ b/schemas/garagecluster_v1beta2.json
@@ -6353,6 +6353,10 @@
           "type": "object",
           "additionalProperties": false
         },
+        "layoutDiagnosis": {
+          "description": "LayoutDiagnosis is a one-line, human-readable summary of the most severe\nactive health condition (quorum at risk, remote clusters stale, federation\nmisconfigured). Empty when the cluster is healthy. Surfaced as a printcolumn\nso `kubectl get gc` shows the actionable problem at a glance.",
+          "type": "string"
+        },
         "layoutHistory": {
           "description": "LayoutHistory contains layout version history.",
           "properties": {

--- a/test/e2e/dual_version_test.go
+++ b/test/e2e/dual_version_test.go
@@ -276,19 +276,27 @@ spec:
 		out, err := utils.Run(apply)
 		Expect(err).NotTo(HaveOccurred(), "apply v1beta2 unified: %s", out)
 
-		By("expecting per-node storage StatefulSets and a gateway StatefulSet")
-		// Post-#190: storage tier is per-GarageNode (named <cluster>-storage-N), not
-		// a single STS named <cluster>. Gateway tier is unchanged.
+		By("expecting per-node storage AND per-node gateway StatefulSets")
+		// Post-#190 storage is per-GarageNode (<cluster>-storage-N). Post-#209 the
+		// gateway tier of a UNIFIED cluster is ALSO per-GarageNode
+		// (<cluster>-gateway-N) — not a single cluster-level <cluster>-gateway STS.
 		Eventually(func(g Gomega) {
 			get := exec.Command("kubectl", "get", "statefulset", v2Unified+"-storage-0", "-n", testNS)
 			_, err := utils.Run(get)
 			g.Expect(err).NotTo(HaveOccurred())
 		}, 3*time.Minute, 5*time.Second).Should(Succeed())
 		Eventually(func(g Gomega) {
-			get := exec.Command("kubectl", "get", "statefulset", v2Unified+"-gateway", "-n", testNS)
+			get := exec.Command("kubectl", "get", "statefulset", v2Unified+"-gateway-0", "-n", testNS)
 			_, err := utils.Run(get)
 			g.Expect(err).NotTo(HaveOccurred())
 		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+		By("expecting NO legacy cluster-level gateway StatefulSet")
+		Consistently(func(g Gomega) {
+			get := exec.Command("kubectl", "get", "statefulset", v2Unified+"-gateway", "-n", testNS, "--ignore-not-found", "-o", "jsonpath={.metadata.name}")
+			out, err := utils.Run(get)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(BeEmpty())
+		}, 10*time.Second, 5*time.Second).Should(Succeed())
 	})
 
 	// Scenario 4: v1beta2 edge gateway with connectTo.adminApiEndpoint.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1906,6 +1906,260 @@ spec:
 	})
 })
 
+// Unified Cluster exercises the #209 fix: a single GarageCluster CR declaring
+// BOTH a storage tier and a gateway tier. The gateway tier must run as per-node
+// GarageNodes (gateway:true, capacity=nil layout role) rather than a cluster-level
+// StatefulSet — so gateway pods participate in FullReplication locally and S3
+// sig-auth resolves keys via get_local() without per-request storage-tier RPCs.
+var _ = Describe("Unified Cluster (storage + gateway in one CR)", Ordered, Label("unified-gateway"), func() {
+	const testNamespace = "garage-unified-test"
+	const clusterName = "unified-cluster"
+
+	BeforeAll(func() {
+		By("creating manager namespace")
+		cmd := exec.Command("kubectl", "create", "ns", namespace)
+		_, _ = utils.Run(cmd)
+
+		By("labeling the manager namespace restricted")
+		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+			"pod-security.kubernetes.io/enforce=restricted")
+		_, _ = utils.Run(cmd)
+
+		By("installing CRDs")
+		cmd = exec.Command("make", "install")
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+		Expect(utils.WaitCRDsEstablished()).To(Succeed())
+
+		By("deploying the controller-manager")
+		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+		By("waiting for controller-manager pod to be Ready")
+		verifyControllerUp := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+				"-n", namespace,
+				"-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"), "Controller not Ready: %s", output)
+		}
+		Eventually(verifyControllerUp, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("creating + labeling test namespace")
+		cmd = exec.Command("kubectl", "create", "ns", testNamespace)
+		_, _ = utils.Run(cmd)
+		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", testNamespace,
+			"pod-security.kubernetes.io/enforce=restricted")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		By("cleaning up unified-cluster test resources")
+		cmd := exec.Command("kubectl", "delete", "garagecluster", clusterName, "-n", testNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+		time.Sleep(10 * time.Second)
+		cmd = exec.Command("kubectl", "delete", "ns", testNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+		cmd = exec.Command("make", "undeploy")
+		_, _ = utils.Run(cmd)
+		cmd = exec.Command("make", "uninstall")
+		_, _ = utils.Run(cmd)
+	})
+
+	It("creates the unified cluster and reaches Running", func() {
+		By("creating admin token secret")
+		adminTokenSecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-admin-token
+  namespace: %s
+type: Opaque
+stringData:
+  admin-token: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+`, testNamespace)
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(adminTokenSecret)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("applying a unified GarageCluster (storage + gateway in one CR)")
+		unifiedYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replication:
+    factor: 1
+  layoutManagement:
+    autoApply: true
+  storage:
+    replicas: 1
+    metadata:
+      size: 1Gi
+    data:
+      size: 1Gi
+    resources:
+      limits: {memory: 256Mi}
+      requests: {memory: 128Mi}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+      seccompProfile: {type: RuntimeDefault}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities: {drop: [ALL]}
+      seccompProfile: {type: RuntimeDefault}
+  gateway:
+    replicas: 1
+    resources:
+      limits: {memory: 128Mi}
+      requests: {memory: 64Mi}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+      seccompProfile: {type: RuntimeDefault}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities: {drop: [ALL]}
+      seccompProfile: {type: RuntimeDefault}
+  admin:
+    adminTokenSecretRef:
+      name: garage-admin-token
+      key: admin-token
+  security:
+    allowInsecureSecretPermissions: true
+`, clusterName, testNamespace)
+		applyUnified := func(g Gomega) {
+			c := exec.Command("kubectl", "apply", "-f", "-")
+			c.Stdin = strings.NewReader(unifiedYAML)
+			out, err := utils.Run(c)
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to create unified cluster: %s", out)
+		}
+		Eventually(applyUnified, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("waiting for the unified cluster to be Running")
+		verifyRunning := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagecluster", clusterName,
+				"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Running"), "Unified cluster not Running: phase=%s", output)
+		}
+		Eventually(verifyRunning, 5*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("runs the gateway tier as per-node GarageNodes, not a cluster StatefulSet", func() {
+		By("verifying an operator-owned gateway GarageNode exists")
+		verifyGatewayNode := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagenode",
+				"-n", testNamespace,
+				"-l", fmt.Sprintf("garage.rajsingh.info/cluster=%s,garage.rajsingh.info/tier=gateway,app.kubernetes.io/managed-by=operator", clusterName),
+				"-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring(clusterName+"-gateway-0"),
+				"expected an operator-owned gateway GarageNode <cluster>-gateway-0, got: %q", output)
+		}
+		Eventually(verifyGatewayNode, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the per-node gateway StatefulSet exists")
+		verifyPerNodeSTS := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "statefulset", clusterName+"-gateway-0",
+				"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred(), "per-node gateway STS missing: %s", output)
+			g.Expect(output).To(Equal(clusterName + "-gateway-0"))
+		}
+		Eventually(verifyPerNodeSTS, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying NO legacy cluster-level gateway StatefulSet exists")
+		cmd := exec.Command("kubectl", "get", "statefulset", clusterName+"-gateway",
+			"-n", testNamespace, "--ignore-not-found", "-o", "jsonpath={.metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(output)).To(BeEmpty(),
+			"legacy cluster-level gateway StatefulSet <cluster>-gateway must NOT exist in a per-node unified cluster")
+	})
+
+	It("assigns the gateway pod a capacity=nil layout role (#209)", func() {
+		adminToken := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		verifyGatewayRole := func(g Gomega) {
+			curlCmd := fmt.Sprintf("curl -s -H 'Authorization: Bearer %s' http://%s.%s.svc.cluster.local:3903/v2/GetClusterLayout",
+				adminToken, clusterName, testNamespace)
+			cmd := exec.Command("kubectl", "run", "curl-unified-layout", "--rm", "-i", "--restart=Never",
+				"-n", testNamespace,
+				"--image=docker.io/curlimages/curl:latest",
+				"--overrides", fmt.Sprintf(`{
+					"spec": {
+						"containers": [{
+							"name": "curl-unified-layout",
+							"image": "docker.io/curlimages/curl:latest",
+							"imagePullPolicy": "IfNotPresent",
+							"command": ["/bin/sh", "-c"],
+							"args": [%q],
+							"securityContext": {
+								"readOnlyRootFilesystem": true,
+								"allowPrivilegeEscalation": false,
+								"capabilities": {"drop": ["ALL"]},
+								"runAsNonRoot": true,
+								"runAsUser": 1000,
+								"seccompProfile": {"type": "RuntimeDefault"}
+							}
+						}]
+					}
+				}`, curlCmd))
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to query layout: %s", output)
+
+			var layout struct {
+				Roles []struct {
+					ID       string   `json:"id"`
+					Tags     []string `json:"tags"`
+					Capacity *uint64  `json:"capacity"`
+				} `json:"roles"`
+			}
+			jsonStart := strings.Index(output, "{")
+			jsonEnd := strings.LastIndex(output, "}")
+			g.Expect(jsonStart).To(BeNumerically(">=", 0), "No JSON in output: %s", output)
+			jsonStr := output[jsonStart : jsonEnd+1]
+			g.Expect(json.Unmarshal([]byte(jsonStr), &layout)).To(Succeed(), "bad layout JSON: %s", jsonStr)
+
+			gatewayRoles, storageRoles := 0, 0
+			for _, role := range layout.Roles {
+				isGateway := false
+				for _, tag := range role.Tags {
+					if tag == "tier:gateway" {
+						isGateway = true
+					}
+				}
+				if isGateway && role.Capacity == nil {
+					gatewayRoles++
+				}
+				if role.Capacity != nil {
+					storageRoles++
+				}
+			}
+			g.Expect(gatewayRoles).To(BeNumerically(">=", 1),
+				"expected >=1 gateway role (capacity=nil + tier:gateway) in unified cluster layout: %+v", layout.Roles)
+			g.Expect(storageRoles).To(BeNumerically(">=", 1),
+				"expected the storage node to still hold a capacity role: %+v", layout.Roles)
+		}
+		Eventually(verifyGatewayRole, 4*time.Minute, 10*time.Second).Should(Succeed())
+	})
+})
+
 var _ = Describe("Webhooks", Ordered, Label("webhooks"), func() {
 	const webhookNamespace = "garage-webhook-system"
 	var webhookControllerPodName string


### PR DESCRIPTION
## Summary

Unifies the gateway path and hardens layout/fault-tolerance, validated against upstream Garage **v2.3.0** before any code was written (adversarial validation of every upstream-grounded assumption; see `docs/superpowers/specs/2026-05-31-gateway-path-and-fault-tolerance-design.md`).

### What's in this PR

**1. Layout-apply correctness (latent bug, affects storage too)**
`ApplyClusterLayout`'s version-rejection is a generic `Error::Message` that maps to **HTTP 500, not 409** (`src/rpc/layout/history.rs:273-276`), so the operator's `garage.IsConflict()` retry was dead code at all 8 apply sites. New `Client.ApplyStagedLayoutChanges` re-reads the layout, skips apply when nothing is staged (apply always bumps the version → gossip churn), and on failure re-reads to detect whether a concurrent writer already committed our merged change (staging is a per-node `LwwMap`). Every layout-apply site routes through it.

**2. Per-node gateway unification for unified clusters (#209)**
In a unified `storage + gateway` CR, the gateway tier now runs as per-node `GarageNode`s (`gateway: true`, `capacity: nil` role, metadata PVC, EmptyDir data) — symmetric with storage — instead of a cluster-level StatefulSet. Each gateway pod gets a `capacity: nil` layout role via the GarageNode controller, so `key_table`/`bucket_table` are full-replicated locally and S3 sig-auth resolves keys via `get_local()` without a per-request quorum RPC to the storage tier.

> **Validation correction:** a roleless gateway is **not** a deterministic 403 — auth falls back to a quorum `get()` that succeeds in a healthy cluster. The `capacity: nil` role is a **resilience + latency** optimization (local-first auth, decoupled from storage availability) and keeps ephemeral gateway IDs out of partition math. Framed accordingly.

Includes the v0.5.3-safe per-node gateway config (gateway nodes never inherit the storage tier's `rpc_public_addr`) and tombstone cleanup that preserves roles claimed by live gateway `GarageNode` CRs so it never fights the per-node controller.

**Edge gateways** (gateway-only CR + `connectTo`, layout owned remotely) keep the cluster-level StatefulSet path — they already get their role correctly via the gateway-connection path; only unified clusters were broken.

**3. Actionable cluster-health surface**
- `QuorumAtRisk` — Garage's own `PartitionsQuorum < Partitions` (object writes blocked); message names the real levers (restore nodes / `consistencyMode: dangerous`), not a layout edit.
- `RemoteClustersHealthy` — a federated remote unreachable > 1h flips False with the staleness duration; short blips ignored.
- `FederationConfigured` — False (+ webhook warning) when `remoteClusters` is set but no `rpc_public_addr`, since HelloMessage then advertises the unroutable pod IP.
- `status.layoutDiagnosis` printcolumn surfaces the most-severe problem in `kubectl get gc`.

## Validation-driven scoping

- **Edge gateways unchanged** — migrating them to per-node would add a dual-admin-client path with no functional gain.
- **Coordinated factor migration (#208) deferred to its own PR.** The validation showed it is genuinely destructive (delete on-disk `cluster_layout`, rebuild the entire layout, simultaneous restart, asymmetric crash hazard on factor *increase*) and **narrower in value than framed** (fixes sharded-data write quorum, not stuck admin-table writes — those need restore-majority or `dangerous` mode). It warrants dedicated chaos e2e. The precise validated safe sequence is documented in the spec, ready to build next.

## Testing

- Unit/envtest: `make test` green (new tests for `ApplyStagedLayoutChanges`, unified-gateway automode, v0.5.3 config regression, health conditions).
- `make lint`: 0 issues.
- e2e: new `Unified Cluster` Describe block asserts per-node gateway GarageNodes + `capacity: nil` roles + no legacy cluster gateway STS (#209).
- Adversarial diff review across dispatch, layout-apply, gateway construction, config safety, tombstone preservation, and migration: no correctness bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
