### PR TITLE
feat: PeerUnreachable condition for sustained-down peers

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -19,7 +19,7 @@ jobs:
   e2e-ginkgo:
     name: Ginkgo E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 55
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,6 +478,7 @@ On failure, `succeeded: false` and `error` contains the message. The annotation 
 | `QuorumAtRisk` | True when Garage reports `PartitionsQuorum < Partitions` — object writes to those partitions block | restore storage nodes, or `consistencyMode: dangerous` (NOT a layout edit) |
 | `RemoteClustersHealthy` | False when a federated remote is unreachable > 1h (short blips ignored) | if a zone is permanently gone, reduce `replication.factor` |
 | `FederationConfigured` | False when `spec.remoteClusters` is set but no `rpc_public_addr`/`publicEndpoint` (HelloMessage advertises the unroutable pod IP) | set `spec.network.rpcPublicAddr` or a `publicEndpoint` (also a webhook admission warning) |
+| `PeerUnreachable` | True when a peer has been continuously down (`is_up:false`) beyond ~10m — surfaced in `status.unreachablePeers`. Detection is duration-based via `lastSeenSecsAgo` (the admin API can't read Garage's internal `Abandoned` state). | the operator's periodic `ConnectClusterNodes` nudge is the recovery path (esp. for single-link edge gateways) |
 
 Validation notes: a roleless gateway is **not** a deterministic 403 — S3 auth
 falls back to a quorum `get()` that succeeds in a healthy cluster; the

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout 30m
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout 50m
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -94,6 +94,16 @@ const (
 	// and remote peers infer the unroutable pod IP — cross-cluster RPC degrades
 	// after any pod restart. Surfaced as a webhook warning at admission too.
 	ConditionFederationConfigured = "FederationConfigured"
+
+	// ConditionPeerUnreachable is True when one or more peers have been
+	// continuously down (is_up=false) beyond a sustained threshold. The operator
+	// can only read is_up + lastSeenSecsAgo from the admin API — NOT Garage's
+	// internal Abandoned state — so detection is duration-based. Matters most for
+	// edge gateways on a single RPC link: Garage stops retrying a peer after ~10
+	// failed attempts, and the operator's periodic ConnectClusterNodes nudge is
+	// then the only recovery path. Transient restarts (below the threshold) do not
+	// trip it.
+	ConditionPeerUnreachable = "PeerUnreachable"
 )
 
 // Condition reasons for the cluster-health surface.
@@ -110,6 +120,10 @@ const (
 	ReasonMissingRPCPublicAddr = "MissingRPCPublicAddr"
 	// ReasonFederationReady indicates federation networking is configured.
 	ReasonFederationReady = "Configured"
+	// ReasonPeersReachable indicates all known peers are reachable.
+	ReasonPeersReachable = "AllReachable"
+	// ReasonPeersUnreachable indicates one or more peers are sustained-unreachable.
+	ReasonPeersUnreachable = "SustainedUnreachable"
 )
 
 // GarageBucket condition types

--- a/api/v1beta2/garagecluster_types.go
+++ b/api/v1beta2/garagecluster_types.go
@@ -1190,6 +1190,12 @@ type GarageClusterStatus struct {
 	// +optional
 	FactorMigration *FactorMigrationStatus `json:"factorMigration,omitempty"`
 
+	// UnreachablePeers lists peers that have been continuously down beyond the
+	// sustained-unreachable threshold, each as "<shortNodeId> (down <duration>)".
+	// Drives the PeerUnreachable condition. Empty when all peers are reachable.
+	// +optional
+	UnreachablePeers []string `json:"unreachablePeers,omitempty"`
+
 	// ObservedGeneration is the last observed generation.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -798,6 +798,11 @@ func (in *GarageClusterStatus) DeepCopyInto(out *GarageClusterStatus) {
 		*out = new(FactorMigrationStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.UnreachablePeers != nil {
+		in, out := &in.UnreachablePeers, &out.UnreachablePeers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -12121,6 +12121,14 @@ spec:
                 description: TotalNodes is the total nodes across all clusters (local
                   + remote).
                 type: integer
+              unreachablePeers:
+                description: |-
+                  UnreachablePeers lists peers that have been continuously down beyond the
+                  sustained-unreachable threshold, each as "<shortNodeId> (down <duration>)".
+                  Drives the PeerUnreachable condition. Empty when all peers are reachable.
+                items:
+                  type: string
+                type: array
               workerCount:
                 description: WorkerCount is the total number of background workers.
                 format: int32

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -12121,6 +12121,14 @@ spec:
                 description: TotalNodes is the total nodes across all clusters (local
                   + remote).
                 type: integer
+              unreachablePeers:
+                description: |-
+                  UnreachablePeers lists peers that have been continuously down beyond the
+                  sustained-unreachable threshold, each as "<shortNodeId> (down <duration>)".
+                  Drives the PeerUnreachable condition. Empty when all peers are reachable.
+                items:
+                  type: string
+                type: array
               workerCount:
                 description: WorkerCount is the total number of background workers.
                 format: int32

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -2525,6 +2525,12 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		if err != nil {
 			log.V(1).Info("Failed to get cluster status", "error", err)
 		} else {
+			// Sustained-unreachable peer detection: the admin API exposes only
+			// is_up + lastSeenSecsAgo (not Garage's internal Abandoned state), so
+			// we flag peers down longer than the threshold. Transient restarts
+			// (below the threshold) don't trip it.
+			cluster.Status.UnreachablePeers = computeUnreachablePeers(status.Nodes)
+
 			// Use a stable cluster identifier:
 			// - Keep existing ClusterID if still present in the cluster
 			// - Otherwise use the lexicographically smallest node ID for consistency

--- a/internal/controller/garagecluster_health.go
+++ b/internal/controller/garagecluster_health.go
@@ -26,12 +26,48 @@ import (
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 // remoteStaleThreshold is how long a federated remote cluster may be
 // unreachable before RemoteClustersHealthy flips False. Below this it's treated
 // as a transient blip.
 const remoteStaleThreshold = time.Hour
+
+// peerUnreachableThreshold is how long a peer may be continuously down before
+// PeerUnreachable trips. Comfortably above a normal pod restart so routine
+// rollouts don't flap the condition, well under Garage's ~10-retry Abandoned
+// window so the operator still gets early warning.
+const peerUnreachableThreshold = 10 * time.Minute
+
+// computeUnreachablePeers returns "<shortId> (down <duration>)" descriptions for
+// peers that are not up and were last seen longer ago than the threshold. A peer
+// with no lastSeenSecsAgo (never seen) is also flagged.
+func computeUnreachablePeers(nodes []garage.NodeInfo) []string {
+	var out []string
+	for _, n := range nodes {
+		if n.IsUp {
+			continue
+		}
+		secs := uint64(0)
+		if n.LastSeenSecsAgo != nil {
+			secs = *n.LastSeenSecsAgo
+			if time.Duration(secs)*time.Second < peerUnreachableThreshold {
+				continue // transient — not yet sustained
+			}
+		}
+		short := n.ID
+		if len(short) > 16 {
+			short = short[:16]
+		}
+		desc := fmt.Sprintf("%s (never seen)", short)
+		if n.LastSeenSecsAgo != nil {
+			desc = fmt.Sprintf("%s (down %s)", short, (time.Duration(secs) * time.Second).Round(time.Minute))
+		}
+		out = append(out, desc)
+	}
+	return out
+}
 
 // clusterHasRPCPublicAddr reports whether the cluster advertises an
 // externally-routable RPC address — either an explicit network.rpcPublicAddr or
@@ -155,6 +191,30 @@ func setClusterHealthConditions(cluster *garagev1beta2.GarageCluster) {
 		}
 	} else {
 		meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionFederationConfigured)
+	}
+
+	// --- PeerUnreachable: sustained-down peers ----------------------------
+	if len(cluster.Status.UnreachablePeers) > 0 {
+		msg := fmt.Sprintf(
+			"peers unreachable beyond %s: %s; the operator's periodic ConnectClusterNodes nudge is the recovery path "+
+				"(Garage stops retrying a peer after ~10 attempts)",
+			peerUnreachableThreshold, strings.Join(cluster.Status.UnreachablePeers, ", "))
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionPeerUnreachable,
+			Status:             metav1.ConditionTrue,
+			Reason:             garagev1beta1.ReasonPeersUnreachable,
+			Message:            msg,
+			ObservedGeneration: gen,
+		})
+		diagnoses = append(diagnoses, msg)
+	} else {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionPeerUnreachable,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonPeersReachable,
+			Message:            "all known peers are reachable",
+			ObservedGeneration: gen,
+		})
 	}
 
 	// One-line human summary = most severe active problem.

--- a/internal/controller/garagecluster_health_test.go
+++ b/internal/controller/garagecluster_health_test.go
@@ -26,6 +26,7 @@ import (
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 func condStatus(cluster *garagev1beta2.GarageCluster, condType string) (metav1.ConditionStatus, bool) {
@@ -154,6 +155,50 @@ func TestSetClusterHealthConditions_NoFederationClearsConditions(t *testing.T) {
 	}
 	if _, ok := condStatus(cluster, garagev1beta1.ConditionFederationConfigured); ok {
 		t.Fatal("FederationConfigured must be removed for a non-federated cluster")
+	}
+}
+
+func TestComputeUnreachablePeers(t *testing.T) {
+	up := func(secs uint64) *uint64 { return &secs }
+	nodes := []garage.NodeInfo{
+		{ID: "aaaaaaaaaaaaaaaaaaaa", IsUp: true},                             // up → ignored
+		{ID: "bbbbbbbbbbbbbbbbbbbb", IsUp: false, LastSeenSecsAgo: up(120)},  // 2m down → transient
+		{ID: "cccccccccccccccccccc", IsUp: false, LastSeenSecsAgo: up(1800)}, // 30m down → flagged
+		{ID: "dddddddddddddddddddd", IsUp: false, LastSeenSecsAgo: nil},      // never seen → flagged
+	}
+	got := computeUnreachablePeers(nodes)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unreachable peers, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "cccccccccccccccc") || !strings.Contains(got[0], "down") {
+		t.Fatalf("unexpected first entry: %q", got[0])
+	}
+	if !strings.Contains(got[1], "never seen") {
+		t.Fatalf("expected a never-seen entry, got %q", got[1])
+	}
+}
+
+func TestSetClusterHealthConditions_PeerUnreachable(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{
+		Status: garagev1beta2.GarageClusterStatus{
+			Health:           &garagev1beta2.ClusterHealth{Partitions: 256, PartitionsQuorum: 256},
+			UnreachablePeers: []string{"abc123 (down 30m0s)"},
+		},
+	}
+	setClusterHealthConditions(cluster)
+	st, ok := condStatus(cluster, garagev1beta1.ConditionPeerUnreachable)
+	if !ok || st != metav1.ConditionTrue {
+		t.Fatalf("expected PeerUnreachable=True, got %v (present=%v)", st, ok)
+	}
+	if cluster.Status.LayoutDiagnosis == "" {
+		t.Fatal("expected a diagnosis when a peer is sustained-unreachable")
+	}
+
+	// Clears when peers recover.
+	cluster.Status.UnreachablePeers = nil
+	setClusterHealthConditions(cluster)
+	if st, _ := condStatus(cluster, garagev1beta1.ConditionPeerUnreachable); st != metav1.ConditionFalse {
+		t.Fatalf("expected PeerUnreachable=False after recovery, got %v", st)
 	}
 }
 

--- a/schemas/garagecluster_v1beta2.json
+++ b/schemas/garagecluster_v1beta2.json
@@ -6847,6 +6847,13 @@
           "description": "TotalNodes is the total nodes across all clusters (local + remote).",
           "type": "integer"
         },
+        "unreachablePeers": {
+          "description": "UnreachablePeers lists peers that have been continuously down beyond the\nsustained-unreachable threshold, each as \"<shortNodeId> (down <duration>)\".\nDrives the PeerUnreachable condition. Empty when all peers are reachable.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "workerCount": {
           "description": "WorkerCount is the total number of background workers.",
           "format": "int32",


### PR DESCRIPTION
## Summary

Surfaces sustained-unreachable peers as an actionable `PeerUnreachable` condition + `status.unreachablePeers`, completing the resilience-observability surface started in #210.

### Why duration-based detection
The validation against upstream Garage v2.3.0 established that the admin API exposes only `is_up` + `lastSeenSecsAgo` per peer — **not** Garage's internal `Abandoned` state. So the operator detects a sustained problem by duration: a peer continuously down beyond ~10 minutes is flagged. Transient restarts (below the threshold) don't trip it, so routine rollouts don't flap the condition.

### Why it matters
For an **edge gateway on a single RPC link**, Garage stops retrying a peer after ~10 failed attempts and the operator's periodic `ConnectClusterNodes` nudge becomes the only recovery path. Making the sustained-down state visible lets an operator confirm the cluster is in that regime.

### What it does
- `computeUnreachablePeers` (from raw `GetClusterStatus` `NodeInfo`) → `status.unreachablePeers` (`"<shortId> (down <duration>)"`).
- `PeerUnreachable` condition (True/False) set in `setClusterHealthConditions`, feeding `status.layoutDiagnosis` at lowest severity.
- **Observability only** — no auto-restart hammer. The existing reconnect nudge is the recovery; this just makes the condition legible.

## Testing
- `computeUnreachablePeers`: up node ignored, 2m-down transient ignored, 30m-down flagged, never-seen flagged.
- `PeerUnreachable` condition: trips True with a diagnosis, clears False on recovery.
- `make test` + `make lint` green.

Builds on #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
