### PR TITLE
fix: v0.6.7 hardening — close all open issues (#218 #219 #220 #221)

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -104,6 +104,27 @@ const (
 	// then the only recovery path. Transient restarts (below the threshold) do not
 	// trip it.
 	ConditionPeerUnreachable = "PeerUnreachable"
+
+	// ConditionGatewayLayoutDegraded is True when one or more operator-owned
+	// gateway GarageNodes report status.inLayout == false. A gateway pod is
+	// supposed to hold a capacity:nil layout role so key_table/bucket_table are
+	// full-replicated locally and S3 sig-auth resolves keys via get_local()
+	// without a per-request quorum RPC to the storage tier (#209). When that role
+	// is missing the gateway silently degrades to quorum auth — slower and coupled
+	// to storage availability — with no other surfaced signal. The message names
+	// the affected GarageNode(s) so an operator can force a layout reconcile.
+	ConditionGatewayLayoutDegraded = "GatewayLayoutDegraded"
+
+	// ConditionStorageScaleDownBlocked is True when an Auto-mode storage
+	// scale-down was refused because removing the over-range GarageNodes would
+	// drop the count of live, positive-capacity storage nodes below
+	// spec.replication.factor. Garage rejects a layout apply that would leave
+	// fewer roled nodes than the factor (IsReplicationConstraint), so the
+	// per-node finalizer cannot remove the layout role — deleting the CRs would
+	// orphan those roles. The operator keeps the excess GarageNodes in place
+	// and surfaces this until the user lowers replication.factor (or restores
+	// replicas). False/cleared once the scale-down is safe.
+	ConditionStorageScaleDownBlocked = "StorageScaleDownBlocked"
 )
 
 // Condition reasons for the cluster-health surface.
@@ -124,6 +145,14 @@ const (
 	ReasonPeersReachable = "AllReachable"
 	// ReasonPeersUnreachable indicates one or more peers are sustained-unreachable.
 	ReasonPeersUnreachable = "SustainedUnreachable"
+	// ReasonGatewayRolesPresent indicates every operator-owned gateway node holds its layout role.
+	ReasonGatewayRolesPresent = "GatewayRolesPresent"
+	// ReasonGatewayRoleMissing indicates one or more gateway nodes lack a layout role (degraded to quorum auth).
+	ReasonGatewayRoleMissing = "GatewayRoleMissing"
+	// ReasonScaleDownWouldBreakQuorum indicates a refused storage scale-down.
+	ReasonScaleDownWouldBreakQuorum = "WouldDropBelowReplicationFactor"
+	// ReasonScaleDownSafe indicates no storage scale-down is currently blocked.
+	ReasonScaleDownSafe = "ScaleDownSafe"
 )
 
 // GarageBucket condition types

--- a/api/v1beta1/garagebucket_types.go
+++ b/api/v1beta1/garagebucket_types.go
@@ -281,6 +281,13 @@ type GarageBucketStatus struct {
 	// +optional
 	Keys []BucketKeyStatus `json:"keys,omitempty"`
 
+	// ManagedKeyGrants lists the access key IDs this bucket's spec.keyPermissions
+	// last granted access to. Used to revoke grants when a keyRef is dropped
+	// from the spec, without disturbing grants made via a GarageKey's
+	// bucketPermissions/allBuckets or by hand.
+	// +optional
+	ManagedKeyGrants []string `json:"managedKeyGrants,omitempty"`
+
 	// LocalAliases tracks per-key local aliases for this bucket
 	// +optional
 	LocalAliases []LocalAliasStatus `json:"localAliases,omitempty"`

--- a/api/v1beta1/garagecluster_webhook.go
+++ b/api/v1beta1/garagecluster_webhook.go
@@ -206,6 +206,25 @@ func (r *GarageCluster) validateGateway() error {
 		if r.Spec.Storage.Data != nil && r.Spec.Storage.Data.Size != nil && r.Spec.Storage.Data.Type != VolumeTypeEmptyDir {
 			return fmt.Errorf("storage.data cannot be PersistentVolumeClaim for gateway clusters")
 		}
+		// These tuning fields apply only to the storage tier and have no
+		// representation on a v1beta2 gateway tier — accepting them on a
+		// gateway CR would silently drop them during conversion to v1beta2
+		// (see issue #219). Reject so the loss is impossible by construction.
+		if r.Spec.Storage.MetadataFsync {
+			return fmt.Errorf("storage.metadataFsync is not valid on a gateway cluster (gateways store no data)")
+		}
+		if r.Spec.Storage.DataFsync {
+			return fmt.Errorf("storage.dataFsync is not valid on a gateway cluster (gateways store no data)")
+		}
+		if r.Spec.Storage.MetadataSnapshotsDir != "" {
+			return fmt.Errorf("storage.metadataSnapshotsDir is not valid on a gateway cluster")
+		}
+		if r.Spec.Storage.MetadataAutoSnapshotInterval != "" {
+			return fmt.Errorf("storage.metadataAutoSnapshotInterval is not valid on a gateway cluster")
+		}
+		if r.Spec.CapacityReservePercent != 0 {
+			return fmt.Errorf("capacityReservePercent is not valid on a gateway cluster (only used for Auto storage layout)")
+		}
 	} else {
 		if r.Spec.ConnectTo != nil {
 			return fmt.Errorf("connectTo can only be specified when gateway is true")

--- a/api/v1beta1/webhook_test.go
+++ b/api/v1beta1/webhook_test.go
@@ -31,14 +31,15 @@ import (
 )
 
 const (
-	testSourceNS  = "ns-a"
-	testTargetNS  = "ns-b"
-	testCluster   = "cluster"
-	testBucket    = "my-bucket"
-	testKey       = "my-key"
-	testWebhookNS = "ns"
-	testField     = "s3Api"
-	kindGarageKey = "GarageKey"
+	testSourceNS           = "ns-a"
+	testTargetNS           = "ns-b"
+	testCluster            = "cluster"
+	testBucket             = "my-bucket"
+	testKey                = "my-key"
+	testWebhookNS          = "ns"
+	testField              = "s3Api"
+	kindGarageKey          = "GarageKey"
+	testStorageClusterName = "storage-cluster"
 )
 
 var testKeyRef = KeyRef{Name: "key1"}
@@ -511,7 +512,7 @@ func TestGarageCluster_ValidateGateway(t *testing.T) {
 			name: "reject gateway with data storage",
 			cluster: GarageCluster{Spec: GarageClusterSpec{
 				Gateway:   true,
-				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: "storage-cluster"}},
+				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: testStorageClusterName}},
 				Storage:   StorageConfig{Data: &VolumeConfig{Size: &size}},
 			}},
 			wantErr: true, errMsg: "storage.data cannot be PersistentVolumeClaim",
@@ -528,7 +529,7 @@ func TestGarageCluster_ValidateGateway(t *testing.T) {
 			name: "accept gateway with clusterRef",
 			cluster: GarageCluster{Spec: GarageClusterSpec{
 				Gateway:   true,
-				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: "storage-cluster"}},
+				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: testStorageClusterName}},
 			}},
 			wantErr: false,
 		},
@@ -550,6 +551,51 @@ func TestGarageCluster_ValidateGateway(t *testing.T) {
 				ConnectTo: &ConnectToConfig{BootstrapPeers: []string{"abc123@192.168.1.1:3901"}},
 			}},
 			wantErr: false,
+		},
+		{
+			name: "reject gateway with storage.metadataFsync (dropped on conversion #219)",
+			cluster: GarageCluster{Spec: GarageClusterSpec{
+				Gateway:   true,
+				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: testStorageClusterName}},
+				Storage:   StorageConfig{MetadataFsync: true},
+			}},
+			wantErr: true, errMsg: "storage.metadataFsync is not valid on a gateway",
+		},
+		{
+			name: "reject gateway with storage.dataFsync (dropped on conversion #219)",
+			cluster: GarageCluster{Spec: GarageClusterSpec{
+				Gateway:   true,
+				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: testStorageClusterName}},
+				Storage:   StorageConfig{DataFsync: true},
+			}},
+			wantErr: true, errMsg: "storage.dataFsync is not valid on a gateway",
+		},
+		{
+			name: "reject gateway with storage.metadataSnapshotsDir (dropped on conversion #219)",
+			cluster: GarageCluster{Spec: GarageClusterSpec{
+				Gateway:   true,
+				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: testStorageClusterName}},
+				Storage:   StorageConfig{MetadataSnapshotsDir: "/snapshots"},
+			}},
+			wantErr: true, errMsg: "storage.metadataSnapshotsDir is not valid on a gateway",
+		},
+		{
+			name: "reject gateway with storage.metadataAutoSnapshotInterval (dropped on conversion #219)",
+			cluster: GarageCluster{Spec: GarageClusterSpec{
+				Gateway:   true,
+				ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: testStorageClusterName}},
+				Storage:   StorageConfig{MetadataAutoSnapshotInterval: "6h"},
+			}},
+			wantErr: true, errMsg: "storage.metadataAutoSnapshotInterval is not valid on a gateway",
+		},
+		{
+			name: "reject gateway with capacityReservePercent (dropped on conversion #219)",
+			cluster: GarageCluster{Spec: GarageClusterSpec{
+				Gateway:                true,
+				ConnectTo:              &ConnectToConfig{ClusterRef: &ClusterReference{Name: testStorageClusterName}},
+				CapacityReservePercent: 10,
+			}},
+			wantErr: true, errMsg: "capacityReservePercent is not valid on a gateway",
 		},
 	}
 	for _, tt := range tests {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -938,6 +938,11 @@ func (in *GarageBucketStatus) DeepCopyInto(out *GarageBucketStatus) {
 		*out = make([]BucketKeyStatus, len(*in))
 		copy(*out, *in)
 	}
+	if in.ManagedKeyGrants != nil {
+		in, out := &in.ManagedKeyGrants, &out.ManagedKeyGrants
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.LocalAliases != nil {
 		in, out := &in.LocalAliases, &out.LocalAliases
 		*out = make([]LocalAliasStatus, len(*in))

--- a/api/v1beta2/garagecluster_types.go
+++ b/api/v1beta2/garagecluster_types.go
@@ -1196,6 +1196,14 @@ type GarageClusterStatus struct {
 	// +optional
 	UnreachablePeers []string `json:"unreachablePeers,omitempty"`
 
+	// GatewayNodesNotInLayout lists operator-owned gateway GarageNodes that report
+	// status.inLayout == false — they have lost the capacity:nil layout role that
+	// keeps S3 sig-auth local (#209) and have silently degraded to quorum auth.
+	// Drives the GatewayLayoutDegraded condition. Empty when every gateway node
+	// holds its role.
+	// +optional
+	GatewayNodesNotInLayout []string `json:"gatewayNodesNotInLayout,omitempty"`
+
 	// ObservedGeneration is the last observed generation.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -1515,6 +1523,14 @@ type FactorMigrationStatus struct {
 	// StartedAt is when the migration began.
 	// +optional
 	StartedAt *metav1.Time `json:"startedAt,omitempty"`
+
+	// PhaseStartedAt is when the current Phase was entered. It is reset on every
+	// phase transition and bounds each wait phase independently of the overall
+	// migration duration, so a single phase that hangs (e.g. a node whose
+	// status.nodeId never repopulates after restart) trips the stuck guard
+	// rather than the whole migration sharing one global deadline.
+	// +optional
+	PhaseStartedAt *metav1.Time `json:"phaseStartedAt,omitempty"`
 
 	// CompletedAt is when the migration finished (Completed or Failed).
 	// +optional

--- a/api/v1beta2/garagecluster_webhook.go
+++ b/api/v1beta2/garagecluster_webhook.go
@@ -158,6 +158,17 @@ func (r *GarageCluster) validateGarageCluster() (admission.Warnings, error) {
 		}
 	}
 
+	// Validate the gateway tier's metadata volume. Unlike storage, the gateway
+	// metadata PVC is optional (defaults to 1Gi), so only validate when set.
+	// This catches EmptyDir misconfig (storageClassName/accessModes/etc.) the
+	// same way the storage tier does — the gateway-only path previously skipped
+	// it entirely (issue #219).
+	if r.HasGatewayTier() && r.Spec.Gateway.Metadata != nil {
+		if err := r.validateVolumeConfig(r.Spec.Gateway.Metadata, "gateway.metadata"); err != nil {
+			return warnings, err
+		}
+	}
+
 	if err := r.validateConnectTo(); err != nil {
 		return warnings, err
 	}
@@ -175,6 +186,9 @@ func (r *GarageCluster) validateGarageCluster() (admission.Warnings, error) {
 	}
 	if r.isDataEphemeral() {
 		warnings = append(warnings, "storage.data.type=EmptyDir: All stored data will be lost on pod restart")
+	}
+	if r.HasGatewayTier() && r.Spec.Gateway.Metadata != nil && r.Spec.Gateway.Metadata.Type == VolumeTypeEmptyDir {
+		warnings = append(warnings, "gateway.metadata.type=EmptyDir: gateway node identity will be lost on pod restart, churning the cluster layout")
 	}
 
 	if r.Spec.Replication != nil && r.Spec.Replication.ConsistencyMode == "dangerous" {

--- a/api/v1beta2/garagecluster_webhook_test.go
+++ b/api/v1beta2/garagecluster_webhook_test.go
@@ -18,6 +18,7 @@ package v1beta2
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,5 +139,61 @@ func TestGarageClusterValidator_RejectsMinNodesHealthyWhenAllReplicasPaused(t *t
 
 	if err := cluster.validateLayoutManagement(); err == nil {
 		t.Fatalf("validateLayoutManagement accepted minNodesHealthy with zero replicas")
+	}
+}
+
+// TestGarageClusterValidator_RejectsGatewayMetadataEmptyDirMisconfig verifies
+// the gateway-tier metadata VolumeConfig is now validated the same way storage
+// is — an EmptyDir volume carrying PVC-only fields is rejected (issue #219).
+func TestGarageClusterValidator_RejectsGatewayMetadataEmptyDirMisconfig(t *testing.T) {
+	sc := "fast"
+	cluster := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: testNamespace},
+		Spec: GarageClusterSpec{
+			Gateway: &GatewaySpec{
+				Replicas: 2,
+				Metadata: &VolumeConfig{
+					Type:             VolumeTypeEmptyDir,
+					StorageClassName: &sc,
+				},
+			},
+			ConnectTo:   &ConnectToConfig{ClusterRef: &ClusterReference{Name: "store"}},
+			Replication: &ReplicationConfig{Factor: 1},
+		},
+	}
+
+	if _, err := cluster.validateGarageCluster(); err == nil {
+		t.Fatalf("validateGarageCluster accepted EmptyDir gateway metadata with storageClassName, want error")
+	}
+}
+
+// TestGarageClusterValidator_WarnsGatewayMetadataEmptyDir verifies the
+// node-identity warning is emitted for an EmptyDir gateway metadata volume,
+// matching the storage-tier behavior (issue #219).
+func TestGarageClusterValidator_WarnsGatewayMetadataEmptyDir(t *testing.T) {
+	cluster := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: testNamespace},
+		Spec: GarageClusterSpec{
+			Gateway: &GatewaySpec{
+				Replicas: 2,
+				Metadata: &VolumeConfig{Type: VolumeTypeEmptyDir},
+			},
+			ConnectTo:   &ConnectToConfig{ClusterRef: &ClusterReference{Name: "store"}},
+			Replication: &ReplicationConfig{Factor: 1},
+		},
+	}
+
+	warnings, err := cluster.validateGarageCluster()
+	if err != nil {
+		t.Fatalf("validateGarageCluster: unexpected error %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "gateway.metadata.type=EmptyDir") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected gateway.metadata EmptyDir identity warning, got %v", warnings)
 	}
 }

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -471,6 +471,10 @@ func (in *FactorMigrationStatus) DeepCopyInto(out *FactorMigrationStatus) {
 		in, out := &in.StartedAt, &out.StartedAt
 		*out = (*in).DeepCopy()
 	}
+	if in.PhaseStartedAt != nil {
+		in, out := &in.PhaseStartedAt, &out.PhaseStartedAt
+		*out = (*in).DeepCopy()
+	}
 	if in.CompletedAt != nil {
 		in, out := &in.CompletedAt, &out.CompletedAt
 		*out = (*in).DeepCopy()
@@ -800,6 +804,11 @@ func (in *GarageClusterStatus) DeepCopyInto(out *GarageClusterStatus) {
 	}
 	if in.UnreachablePeers != nil {
 		in, out := &in.UnreachablePeers, &out.UnreachablePeers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.GatewayNodesNotInLayout != nil {
+		in, out := &in.GatewayNodesNotInLayout, &out.GatewayNodesNotInLayout
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
@@ -845,6 +845,15 @@ spec:
                       type: string
                   type: object
                 type: array
+              managedKeyGrants:
+                description: |-
+                  ManagedKeyGrants lists the access key IDs this bucket's spec.keyPermissions
+                  last granted access to. Used to revoke grants when a keyRef is dropped
+                  from the spec, without disturbing grants made via a GarageKey's
+                  bucketPermissions/allBuckets or by hand.
+                items:
+                  type: string
+                type: array
               observedGeneration:
                 description: ObservedGeneration is the last observed generation
                 format: int64

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -11697,6 +11697,15 @@ spec:
                     - Completed
                     - Failed
                     type: string
+                  phaseStartedAt:
+                    description: |-
+                      PhaseStartedAt is when the current Phase was entered. It is reset on every
+                      phase transition and bounds each wait phase independently of the overall
+                      migration duration, so a single phase that hangs (e.g. a node whose
+                      status.nodeId never repopulates after restart) trips the stuck guard
+                      rather than the whole migration sharing one global deadline.
+                    format: date-time
+                    type: string
                   purgeId:
                     description: |-
                       PurgeID uniquely identifies this migration; it is the marker-file suffix the
@@ -11711,6 +11720,16 @@ spec:
                     description: ToFactor is the target replication factor.
                     type: integer
                 type: object
+              gatewayNodesNotInLayout:
+                description: |-
+                  GatewayNodesNotInLayout lists operator-owned gateway GarageNodes that report
+                  status.inLayout == false — they have lost the capacity:nil layout role that
+                  keeps S3 sig-auth local (#209) and have silently degraded to quorum auth.
+                  Drives the GatewayLayoutDegraded condition. Empty when every gateway node
+                  holds its role.
+                items:
+                  type: string
+                type: array
               gatewayReadyReplicas:
                 description: GatewayReadyReplicas is the number of ready gateway-tier
                   pods.

--- a/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
@@ -845,6 +845,15 @@ spec:
                       type: string
                   type: object
                 type: array
+              managedKeyGrants:
+                description: |-
+                  ManagedKeyGrants lists the access key IDs this bucket's spec.keyPermissions
+                  last granted access to. Used to revoke grants when a keyRef is dropped
+                  from the spec, without disturbing grants made via a GarageKey's
+                  bucketPermissions/allBuckets or by hand.
+                items:
+                  type: string
+                type: array
               observedGeneration:
                 description: ObservedGeneration is the last observed generation
                 format: int64

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -11697,6 +11697,15 @@ spec:
                     - Completed
                     - Failed
                     type: string
+                  phaseStartedAt:
+                    description: |-
+                      PhaseStartedAt is when the current Phase was entered. It is reset on every
+                      phase transition and bounds each wait phase independently of the overall
+                      migration duration, so a single phase that hangs (e.g. a node whose
+                      status.nodeId never repopulates after restart) trips the stuck guard
+                      rather than the whole migration sharing one global deadline.
+                    format: date-time
+                    type: string
                   purgeId:
                     description: |-
                       PurgeID uniquely identifies this migration; it is the marker-file suffix the
@@ -11711,6 +11720,16 @@ spec:
                     description: ToFactor is the target replication factor.
                     type: integer
                 type: object
+              gatewayNodesNotInLayout:
+                description: |-
+                  GatewayNodesNotInLayout lists operator-owned gateway GarageNodes that report
+                  status.inLayout == false — they have lost the capacity:nil layout role that
+                  keeps S3 sig-auth local (#209) and have silently degraded to quorum auth.
+                  Drives the GatewayLayoutDegraded condition. Empty when every gateway node
+                  holds its role.
+                items:
+                  type: string
+                type: array
               gatewayReadyReplicas:
                 description: GatewayReadyReplicas is the number of ready gateway-tier
                   pods.

--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -19,9 +19,13 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -50,6 +54,7 @@ const (
 	testTagRemoteCluster    = "remote-cluster"
 	testGatewayOwnershipTag = "cluster:garage/garage"
 	testTierGatewayTag      = "tier:gateway"
+	testTierStorageTag      = "tier:storage"
 )
 
 // newMockGarageServer creates a mock Garage Admin API server with configurable
@@ -816,7 +821,7 @@ var _ = Describe("Federation - connectRemoteGatewayPods", func() {
 					IsUp: true,
 					Role: &garage.NodeAssignedRole{
 						Zone: testZoneRemote,
-						Tags: []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-0"},
+						Tags: []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-0-0"},
 					},
 				},
 				{
@@ -824,7 +829,7 @@ var _ = Describe("Federation - connectRemoteGatewayPods", func() {
 					IsUp: false,
 					Role: &garage.NodeAssignedRole{
 						Zone: testZoneRemote,
-						Tags: []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-1"},
+						Tags: []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-1-0"},
 					},
 				},
 				// Storage node in same zone — must be ignored by gateway loop
@@ -895,5 +900,100 @@ var _ = Describe("Federation - connectRemoteGatewayPods", func() {
 		reconciler.connectRemoteGatewayPods(ctx, localClient, localStatus, remote, remote.Connection.GatewayRPCEndpointTemplate)
 
 		Expect(connectCalls.Load()).To(Equal(int32(0)))
+	})
+})
+
+func TestParseRemoteGatewayOrdinal(t *testing.T) {
+	cases := []struct {
+		name   string
+		tags   []string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "operator-managed pod-name tag (real shape)",
+			tags:   []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-1-0"},
+			want:   "1",
+			wantOK: true,
+		},
+		{
+			name:   "hyphenated cluster name",
+			tags:   []string{"cluster:my-cluster/ns", "tier:gateway", "my-cluster-gateway-2-0"},
+			want:   "2",
+			wantOK: true,
+		},
+		{
+			name:   "legacy bare-ordinal pod-name tag still parses",
+			tags:   []string{testGatewayOwnershipTag, testTierGatewayTag, "garage-gateway-3"},
+			want:   "3",
+			wantOK: true,
+		},
+		{
+			name:   "no ownership tag",
+			tags:   []string{"tier:gateway", "garage-gateway-0-0"},
+			wantOK: false,
+		},
+		{
+			name:   "storage node (no gateway pod-name tag)",
+			tags:   []string{"cluster:garage/garage", "tier:storage", "garage-storage-0-0"},
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseRemoteGatewayOrdinal(tc.tags)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("ordinal = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+var _ = Describe("Bootstrap - connectNodes per-call timeout", func() {
+	const adminToken = "test-admin-token-value"
+
+	It("does not block on a hung ConnectClusterNodes endpoint", func() {
+		hangServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == pathConnectNodes {
+				// Hang until the client's per-call timeout cancels the request.
+				// A hard fallback bounds the handler so a cancelled-mid-flight
+				// request can never keep this goroutine alive and block the
+				// deferred Server.Close() indefinitely (the per-call timeout is
+				// 5s; this fallback only fires if that regresses).
+				select {
+				case <-r.Context().Done():
+				case <-time.After(15 * time.Second):
+				}
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer hangServer.Close()
+
+		// adminEndpoint() always appends :port via net.JoinHostPort, so split the
+		// httptest host:port and feed the port in as adminPort.
+		hostport := strings.TrimPrefix(hangServer.URL, "http://")
+		host, portStr, err := net.SplitHostPort(hostport)
+		Expect(err).NotTo(HaveOccurred())
+		port64, err := strconv.Atoi(portStr)
+		Expect(err).NotTo(HaveOccurred())
+
+		nodes := []bootstrapNodeInfo{
+			{id: "1111111111111111aaaaaaaaaaaa0001", podIP: host, podName: "src"},
+			{id: "2222222222222222bbbbbbbbbbbb0002", podIP: host, podName: "dst"},
+		}
+
+		done := make(chan struct{})
+		start := time.Now()
+		go func() {
+			connectNodes(ctx, nodes, adminToken, int32(port64), 3901)
+			close(done)
+		}()
+		Eventually(done, 30*time.Second).Should(BeClosed(),
+			"connectNodes must return promptly via the 5s per-call timeout, not the 90s client timeout")
+		Expect(time.Since(start)).To(BeNumerically("<", 25*time.Second))
 	})
 })

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -288,7 +288,7 @@ func (r *GarageBucketReconciler) reconcileBucket(ctx context.Context, bucket *ga
 		return err
 	}
 
-	if err := r.reconcileKeyPermissions(ctx, bucket, garageClient, existingBucket.ID); err != nil {
+	if err := r.reconcileKeyPermissions(ctx, bucket, garageClient, existingBucket); err != nil {
 		return err
 	}
 
@@ -491,10 +491,23 @@ func quotasChanged(current *garage.BucketQuotas, desiredSize, desiredObjects *ui
 	return false
 }
 
-func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bucket *garagev1beta1.GarageBucket, garageClient *garage.Client, bucketID string) error {
+func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bucket *garagev1beta1.GarageBucket, garageClient *garage.Client, existingBucket *garage.Bucket) error {
 	log := logf.FromContext(ctx)
 	var permissionErrors []string
 	pendingKeys := false
+	bucketID := existingBucket.ID
+
+	// Current grants on the bucket, keyed by access key ID — used to skip
+	// redundant AllowBucketKey calls (churn) and to revoke dropped grants.
+	currentPerms := make(map[string]garage.BucketKeyPerms, len(existingBucket.Keys))
+	for _, k := range existingBucket.Keys {
+		currentPerms[k.AccessKeyID] = k.Permissions
+	}
+
+	// Access key IDs we grant this reconcile. Persisted to status so a later
+	// reconcile can revoke grants for keyRefs dropped from the spec without
+	// touching grants made via a GarageKey's bucketPermissions/allBuckets.
+	desiredGrants := make(map[string]struct{}, len(bucket.Spec.KeyPermissions))
 
 	for _, keyPerm := range bucket.Spec.KeyPermissions {
 		keyNS := bucket.Namespace
@@ -517,14 +530,45 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 			continue
 		}
 
+		desiredGrants[key.Status.AccessKeyID] = struct{}{}
+
+		desired := garage.BucketKeyPerms{Read: keyPerm.Read, Write: keyPerm.Write, Owner: keyPerm.Owner}
+		// Skip the call when the bucket already grants exactly these perms.
+		if cur, ok := currentPerms[key.Status.AccessKeyID]; ok && cur == desired {
+			continue
+		}
+
 		_, err := garageClient.AllowBucketKey(ctx, garage.AllowBucketKeyRequest{
 			BucketID:    bucketID,
 			AccessKeyID: key.Status.AccessKeyID,
-			Permissions: garage.BucketKeyPerms{Read: keyPerm.Read, Write: keyPerm.Write, Owner: keyPerm.Owner},
+			Permissions: desired,
 		})
 		if err != nil {
 			log.Error(err, "Failed to set key permissions", "keyRef", keyPerm.KeyRef.Name)
 			permissionErrors = append(permissionErrors, fmt.Sprintf("%s: %v", keyPerm.KeyRef.Name, err))
+		}
+	}
+
+	// Revoke grants this bucket previously made (recorded in status) that are no
+	// longer desired. We only revoke IDs we ourselves granted — grants made via a
+	// GarageKey's bucketPermissions/allBuckets or by hand were never recorded here.
+	for _, prevID := range bucket.Status.ManagedKeyGrants {
+		if _, stillDesired := desiredGrants[prevID]; stillDesired {
+			continue
+		}
+		cur, has := currentPerms[prevID]
+		if !has || cur == (garage.BucketKeyPerms{}) {
+			continue
+		}
+		log.Info("Revoking key grant dropped from bucket spec", "accessKeyId", prevID, "bucketId", bucketID)
+		_, err := garageClient.DenyBucketKey(ctx, garage.DenyBucketKeyRequest{
+			BucketID:    bucketID,
+			AccessKeyID: prevID,
+			Permissions: garage.BucketKeyPerms{Read: true, Write: true, Owner: true},
+		})
+		if err != nil && !garage.IsNotFound(err) {
+			log.Error(err, "Failed to revoke dropped key grant", "accessKeyId", prevID, "bucketId", bucketID)
+			permissionErrors = append(permissionErrors, fmt.Sprintf("%s: revoke: %v", prevID, err))
 		}
 	}
 
@@ -534,7 +578,37 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 	if len(permissionErrors) > 0 {
 		return fmt.Errorf("failed to set permissions for keys: %v", permissionErrors)
 	}
+
+	// Record the managed set for the next reconcile's revoke diff. Only persist
+	// when fully resolved (no pending keys) so a transient pending key doesn't
+	// shrink the set and trigger a spurious revoke next time. Sorted for stable
+	// status comparison (updateStatusFromGarage uses DeepEqual to skip no-op writes).
+	managed := make([]string, 0, len(desiredGrants))
+	for id := range desiredGrants {
+		managed = append(managed, id)
+	}
+	sort.Strings(managed)
+	if !stringSlicesEqual(bucket.Status.ManagedKeyGrants, managed) {
+		bucket.Status.ManagedKeyGrants = managed
+		if err := r.Status().Update(ctx, bucket); err != nil {
+			return fmt.Errorf("failed to persist managed key grants: %w", err)
+		}
+	}
 	return nil
+}
+
+// stringSlicesEqual reports whether two string slices are element-wise equal.
+// Callers pass already-sorted slices so this also serves as set equality.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *GarageBucketReconciler) reconcileLocalAliases(ctx context.Context, bucket *garagev1beta1.GarageBucket, garageClient *garage.Client, bucketID string) error {

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -530,9 +530,14 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 			continue
 		}
 
+		desired := garage.BucketKeyPerms{Read: keyPerm.Read, Write: keyPerm.Write, Owner: keyPerm.Owner}
+		if desired == (garage.BucketKeyPerms{}) {
+			// An all-false keyPermission grants nothing — don't record it as a
+			// managed grant or churn a no-op AllowBucketKey every reconcile.
+			continue
+		}
 		desiredGrants[key.Status.AccessKeyID] = struct{}{}
 
-		desired := garage.BucketKeyPerms{Read: keyPerm.Read, Write: keyPerm.Write, Owner: keyPerm.Owner}
 		// Skip the call when the bucket already grants exactly these perms.
 		if cur, ok := currentPerms[key.Status.AccessKeyID]; ok && cur == desired {
 			continue
@@ -549,11 +554,25 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		}
 	}
 
+	// A GarageKey may independently grant the same key on this bucket (via its
+	// spec.bucketPermissions or allBuckets). Those grants are owned by the
+	// GarageKey controller — never revoke them here, or removing the key from the
+	// bucket's own keyPermissions would start a cross-controller flap-war (the
+	// GarageKey controller only watches GarageKey/Secret, so it would not repair
+	// the wrong revoke until its periodic drift requeue).
+	claimedByKey, kerr := r.keysGrantingBucket(ctx, bucket)
+	if kerr != nil {
+		return fmt.Errorf("listing keys for revoke-safety check: %w", kerr)
+	}
+
 	// Revoke grants this bucket previously made (recorded in status) that are no
 	// longer desired. We only revoke IDs we ourselves granted — grants made via a
 	// GarageKey's bucketPermissions/allBuckets or by hand were never recorded here.
 	for _, prevID := range bucket.Status.ManagedKeyGrants {
 		if _, stillDesired := desiredGrants[prevID]; stillDesired {
+			continue
+		}
+		if claimedByKey[prevID] {
 			continue
 		}
 		cur, has := currentPerms[prevID]
@@ -595,6 +614,55 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		}
 	}
 	return nil
+}
+
+// keysGrantingBucket returns the set of access key IDs that a GarageKey
+// independently grants on this bucket — via spec.allBuckets (cluster match) or a
+// spec.bucketPermissions entry referencing this bucket. The bucket controller
+// must not revoke these even when they are dropped from the bucket's own
+// keyPermissions: they are owned by the GarageKey controller. Scoped to the
+// bucket's namespace, mirroring reconcileClusterWideKeys.
+func (r *GarageBucketReconciler) keysGrantingBucket(ctx context.Context, bucket *garagev1beta1.GarageBucket) (map[string]bool, error) {
+	keyList := &garagev1beta1.GarageKeyList{}
+	if err := r.List(ctx, keyList, client.InNamespace(bucket.Namespace)); err != nil {
+		return nil, err
+	}
+	bucketClusterNs := bucket.Namespace
+	if bucket.Spec.ClusterRef.Namespace != "" {
+		bucketClusterNs = bucket.Spec.ClusterRef.Namespace
+	}
+	out := make(map[string]bool)
+	for i := range keyList.Items {
+		key := &keyList.Items[i]
+		if key.Status.AccessKeyID == "" {
+			continue
+		}
+		keyClusterNs := key.Namespace
+		if key.Spec.ClusterRef.Namespace != "" {
+			keyClusterNs = key.Spec.ClusterRef.Namespace
+		}
+		if key.Spec.ClusterRef.Name != bucket.Spec.ClusterRef.Name || keyClusterNs != bucketClusterNs {
+			continue
+		}
+		if key.Spec.AllBuckets != nil {
+			out[key.Status.AccessKeyID] = true
+			continue
+		}
+		for _, bp := range key.Spec.BucketPermissions {
+			if bp.BucketRef == nil {
+				continue
+			}
+			refNs := key.Namespace
+			if bp.BucketRef.Namespace != "" {
+				refNs = bp.BucketRef.Namespace
+			}
+			if bp.BucketRef.Name == bucket.Name && refNs == bucket.Namespace {
+				out[key.Status.AccessKeyID] = true
+				break
+			}
+		}
+	}
+	return out, nil
 }
 
 // stringSlicesEqual reports whether two string slices are element-wise equal.

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -572,6 +572,41 @@ func TestReconcileKeyPermissions_RevokesDroppedAndSkipsUnchanged(t *testing.T) {
 			t.Errorf("ManagedKeyGrants=%v, want %v", fresh.Status.ManagedKeyGrants, want)
 		}
 	})
+
+	t.Run("does not revoke a dropped grant still claimed by a GarageKey (no flap-war)", func(t *testing.T) {
+		ctx := context.Background()
+		bucket := bucketWithKeyPerms("bkt-flapwar",
+			garagev1beta1.KeyPermission{KeyRef: garagev1beta1.KeyRef{Name: testKeyA}, Read: true, Write: true})
+		// keyB was previously granted by the bucket (in ManagedKeyGrants) and is now
+		// dropped from the bucket spec — but a GarageKey still declares keyB on this
+		// bucket via spec.bucketPermissions, so we must NOT revoke it (#219 review).
+		bucket.Status.ManagedKeyGrants = []string{keyAID, keyBID}
+
+		keyBClaim := &garagev1beta1.GarageKey{
+			ObjectMeta: metav1.ObjectMeta{Name: "key-b", Namespace: testNamespace},
+			Spec: garagev1beta1.GarageKeySpec{
+				ClusterRef:        garagev1beta1.ClusterReference{Name: testClusterName},
+				BucketPermissions: []garagev1beta1.BucketPermission{{BucketRef: &garagev1beta1.BucketRef{Name: "bkt-flapwar"}, Read: true, Write: true}},
+			},
+			Status: garagev1beta1.GarageKeyStatus{AccessKeyID: keyBID},
+		}
+		r, gc, _, deny, stop := newReconciler(t, bucket, newKey(testKeyA, keyAID), keyBClaim)
+		defer stop()
+
+		existing := &garage.Bucket{
+			ID: bktID,
+			Keys: []garage.BucketKeyInfo{
+				{AccessKeyID: keyAID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+				{AccessKeyID: keyBID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+			},
+		}
+		if err := r.reconcileKeyPermissions(ctx, bucket, gc, existing); err != nil {
+			t.Fatalf("reconcileKeyPermissions: %v", err)
+		}
+		if len(*deny) != 0 {
+			t.Fatalf("expected 0 DenyBucketKey calls (keyB still claimed by a GarageKey), got %d: %+v", len(*deny), *deny)
+		}
+	})
 }
 
 // TestGetBucketWithTimeout_HangServer asserts that getBucketWithTimeout

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -375,6 +376,202 @@ var _ = Describe("GarageBucket Controller", func() {
 
 func int64Ptr(i int64) *int64 {
 	return &i
+}
+
+// TestReconcileKeyPermissions_RevokesDroppedAndSkipsUnchanged drives
+// reconcileKeyPermissions against a mock Garage admin server and asserts the
+// churn short-circuit (no AllowBucketKey when current perms already match) and
+// the dangling-grant revoke (DenyBucketKey only for IDs we previously granted
+// that are dropped from the spec), without touching grants the operator never
+// made.
+func TestReconcileKeyPermissions_RevokesDroppedAndSkipsUnchanged(t *testing.T) {
+	const (
+		testKeyA = "key-a"
+		keyAID   = "GKaaaaaaaaaaaaaaaaaaaaaa"
+		keyBID   = "GKbbbbbbbbbbbbbbbbbbbbbb"
+		keyCID   = "GKcccccccccccccccccccccc"
+		bktID    = "0123456789abcdef0123456789abcdef"
+	)
+
+	// newKey builds a GarageKey CR with its AccessKeyID resolved in status.
+	newKey := func(name, accessKeyID string) *garagev1beta1.GarageKey {
+		return &garagev1beta1.GarageKey{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+			Spec:       garagev1beta1.GarageKeySpec{ClusterRef: garagev1beta1.ClusterReference{Name: testClusterName}},
+			Status:     garagev1beta1.GarageKeyStatus{AccessKeyID: accessKeyID},
+		}
+	}
+
+	// newReconciler wires a fake client holding the keys + bucket and a mock
+	// admin server recording Allow/Deny calls.
+	newReconciler := func(t *testing.T, bucket *garagev1beta1.GarageBucket, keys ...*garagev1beta1.GarageKey) (*GarageBucketReconciler, *garage.Client, *[]garage.AllowBucketKeyRequest, *[]garage.DenyBucketKeyRequest, func()) {
+		t.Helper()
+		s := runtime.NewScheme()
+		if err := garagev1beta1.AddToScheme(s); err != nil {
+			t.Fatalf("AddToScheme v1beta1: %v", err)
+		}
+		if err := garagev1beta2.AddToScheme(s); err != nil {
+			t.Fatalf("AddToScheme v1beta2: %v", err)
+		}
+		objs := make([]client.Object, 0, 1+len(keys))
+		objs = append(objs, bucket)
+		for _, k := range keys {
+			objs = append(objs, k)
+		}
+		fc := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(objs...).
+			WithStatusSubresource(&garagev1beta1.GarageBucket{}).
+			Build()
+		r := &GarageBucketReconciler{Client: fc, Scheme: s}
+
+		var allowCalls []garage.AllowBucketKeyRequest
+		var denyCalls []garage.DenyBucketKeyRequest
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/v2/AllowBucketKey":
+				var body garage.AllowBucketKeyRequest
+				_ = json.NewDecoder(req.Body).Decode(&body)
+				allowCalls = append(allowCalls, body)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			case "/v2/DenyBucketKey":
+				var body garage.DenyBucketKeyRequest
+				_ = json.NewDecoder(req.Body).Decode(&body)
+				denyCalls = append(denyCalls, body)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		gc := garage.NewClient(srv.URL, "tok")
+		return r, gc, &allowCalls, &denyCalls, srv.Close
+	}
+
+	bucketWithKeyPerms := func(name string, perms ...garagev1beta1.KeyPermission) *garagev1beta1.GarageBucket {
+		return &garagev1beta1.GarageBucket{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+			Spec: garagev1beta1.GarageBucketSpec{
+				ClusterRef:     garagev1beta1.ClusterReference{Name: testClusterName},
+				KeyPermissions: perms,
+			},
+		}
+	}
+
+	t.Run("skips AllowBucketKey when current perms already match", func(t *testing.T) {
+		ctx := context.Background()
+		bucket := bucketWithKeyPerms("bkt-skip",
+			garagev1beta1.KeyPermission{KeyRef: garagev1beta1.KeyRef{Name: testKeyA}, Read: true, Write: true})
+		r, gc, allow, deny, stop := newReconciler(t, bucket, newKey(testKeyA, keyAID))
+		defer stop()
+
+		existing := &garage.Bucket{
+			ID:   bktID,
+			Keys: []garage.BucketKeyInfo{{AccessKeyID: keyAID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}}},
+		}
+		if err := r.reconcileKeyPermissions(ctx, bucket, gc, existing); err != nil {
+			t.Fatalf("reconcileKeyPermissions: %v", err)
+		}
+		if len(*allow) != 0 {
+			t.Errorf("expected 0 AllowBucketKey calls, got %d: %+v", len(*allow), *allow)
+		}
+		if len(*deny) != 0 {
+			t.Errorf("expected 0 DenyBucketKey calls, got %d: %+v", len(*deny), *deny)
+		}
+
+		fresh := &garagev1beta1.GarageBucket{}
+		if err := r.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: testNamespace}, fresh); err != nil {
+			t.Fatalf("get bucket: %v", err)
+		}
+		if want := []string{keyAID}; !stringSlicesEqual(fresh.Status.ManagedKeyGrants, want) {
+			t.Errorf("ManagedKeyGrants=%v, want %v", fresh.Status.ManagedKeyGrants, want)
+		}
+	})
+
+	t.Run("issues AllowBucketKey when perms differ", func(t *testing.T) {
+		ctx := context.Background()
+		bucket := bucketWithKeyPerms("bkt-allow",
+			garagev1beta1.KeyPermission{KeyRef: garagev1beta1.KeyRef{Name: testKeyA}, Read: true, Write: true})
+		r, gc, allow, deny, stop := newReconciler(t, bucket, newKey(testKeyA, keyAID))
+		defer stop()
+
+		existing := &garage.Bucket{
+			ID:   bktID,
+			Keys: []garage.BucketKeyInfo{{AccessKeyID: keyAID, Permissions: garage.BucketKeyPerms{Read: true}}},
+		}
+		if err := r.reconcileKeyPermissions(ctx, bucket, gc, existing); err != nil {
+			t.Fatalf("reconcileKeyPermissions: %v", err)
+		}
+		if len(*allow) != 1 {
+			t.Fatalf("expected 1 AllowBucketKey call, got %d: %+v", len(*allow), *allow)
+		}
+		got := (*allow)[0]
+		if got.AccessKeyID != keyAID || got.BucketID != bktID {
+			t.Errorf("AllowBucketKey target=%+v, want bucket=%s key=%s", got, bktID, keyAID)
+		}
+		if want := (garage.BucketKeyPerms{Read: true, Write: true}); got.Permissions != want {
+			t.Errorf("AllowBucketKey perms=%+v, want %+v", got.Permissions, want)
+		}
+		if len(*deny) != 0 {
+			t.Errorf("expected 0 DenyBucketKey calls, got %d", len(*deny))
+		}
+
+		fresh := &garagev1beta1.GarageBucket{}
+		if err := r.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: testNamespace}, fresh); err != nil {
+			t.Fatalf("get bucket: %v", err)
+		}
+		if want := []string{keyAID}; !stringSlicesEqual(fresh.Status.ManagedKeyGrants, want) {
+			t.Errorf("ManagedKeyGrants=%v, want %v", fresh.Status.ManagedKeyGrants, want)
+		}
+	})
+
+	t.Run("revokes a grant dropped from the spec", func(t *testing.T) {
+		ctx := context.Background()
+		bucket := bucketWithKeyPerms("bkt-revoke",
+			garagev1beta1.KeyPermission{KeyRef: garagev1beta1.KeyRef{Name: testKeyA}, Read: true, Write: true})
+		// keyA previously granted by us; keyB previously granted by us (now dropped);
+		// keyC present on the bucket but never managed by this path (e.g. key-side).
+		bucket.Status.ManagedKeyGrants = []string{keyAID, keyBID}
+		r, gc, allow, deny, stop := newReconciler(t, bucket, newKey(testKeyA, keyAID))
+		defer stop()
+
+		existing := &garage.Bucket{
+			ID: bktID,
+			Keys: []garage.BucketKeyInfo{
+				{AccessKeyID: keyAID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+				{AccessKeyID: keyBID, Permissions: garage.BucketKeyPerms{Read: true}},
+				{AccessKeyID: keyCID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+			},
+		}
+		if err := r.reconcileKeyPermissions(ctx, bucket, gc, existing); err != nil {
+			t.Fatalf("reconcileKeyPermissions: %v", err)
+		}
+
+		// keyA's perms already match — no Allow.
+		if len(*allow) != 0 {
+			t.Errorf("expected 0 AllowBucketKey calls, got %d: %+v", len(*allow), *allow)
+		}
+		// Exactly one Deny, for keyB, with all perms set.
+		if len(*deny) != 1 {
+			t.Fatalf("expected 1 DenyBucketKey call, got %d: %+v", len(*deny), *deny)
+		}
+		d := (*deny)[0]
+		if d.AccessKeyID != keyBID {
+			t.Errorf("DenyBucketKey AccessKeyID=%s, want %s (must not revoke keyA or keyC)", d.AccessKeyID, keyBID)
+		}
+		if want := (garage.BucketKeyPerms{Read: true, Write: true, Owner: true}); d.Permissions != want {
+			t.Errorf("DenyBucketKey perms=%+v, want %+v", d.Permissions, want)
+		}
+
+		fresh := &garagev1beta1.GarageBucket{}
+		if err := r.Get(ctx, types.NamespacedName{Name: bucket.Name, Namespace: testNamespace}, fresh); err != nil {
+			t.Fatalf("get bucket: %v", err)
+		}
+		if want := []string{keyAID}; !stringSlicesEqual(fresh.Status.ManagedKeyGrants, want) {
+			t.Errorf("ManagedKeyGrants=%v, want %v", fresh.Status.ManagedKeyGrants, want)
+		}
+	})
 }
 
 // TestGetBucketWithTimeout_HangServer asserts that getBucketWithTimeout

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -229,7 +229,13 @@ func (r *GarageClusterReconciler) reconcileAutoModeStorageNodes(ctx context.Cont
 	// and the finalizer logs+returns nil), so deleting the CRs here would orphan
 	// the layout roles permanently. Keep the excess nodes and surface the block
 	// on a condition; the keep-set creates/updates above already ran.
-	if len(toDelete) > 0 {
+	// The proactive guard applies only to a standalone (non-federated) cluster:
+	// in a federation the replication factor is satisfied across ALL regions'
+	// storage nodes, so a count of this region's nodes alone is not authoritative
+	// and would wrongly wedge a legitimate local scale-down. Federated clusters
+	// rely on the per-node finalizer's IsReplicationConstraint backstop, which
+	// refuses a layout-role removal that would actually drop below the factor.
+	if len(toDelete) > 0 && len(cluster.Spec.RemoteClusters) == 0 {
 		factor := replicationFactorOf(cluster)
 		surviving := countLiveStorageNodes(existing, desiredByName)
 		if factor > 0 && surviving < factor {

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -214,18 +214,96 @@ func (r *GarageClusterReconciler) reconcileAutoModeStorageNodes(ctx context.Cont
 		}
 	}
 
-	// Delete any operator-owned GarageNodes that fall outside the desired range.
+	// Collect operator-owned GarageNodes that fall outside the desired range.
+	var toDelete []*garagev1beta1.GarageNode
 	for name, n := range existing {
 		if desiredByName[name] {
 			continue
 		}
-		log.Info("Deleting Auto-mode GarageNode (scale-down)", "name", name)
-		if err := r.Delete(ctx, n); err != nil && !errors.IsNotFound(err) {
-			return fmt.Errorf("deleting GarageNode %s: %w", name, err)
+		toDelete = append(toDelete, n)
+	}
+
+	// Refuse a scale-down that would drop the cluster below its replication
+	// factor. The per-node finalizer cannot remove a layout role once fewer
+	// roled nodes than the factor remain (Garage returns IsReplicationConstraint
+	// and the finalizer logs+returns nil), so deleting the CRs here would orphan
+	// the layout roles permanently. Keep the excess nodes and surface the block
+	// on a condition; the keep-set creates/updates above already ran.
+	if len(toDelete) > 0 {
+		factor := replicationFactorOf(cluster)
+		surviving := countLiveStorageNodes(existing, desiredByName)
+		if factor > 0 && surviving < factor {
+			msg := fmt.Sprintf("refusing to scale storage down to %d GarageNode(s): %d live node(s) with positive capacity would remain, below replication.factor %d "+
+				"(removing them would orphan their Garage layout roles). Lower spec.replication.factor or restore replicas; the excess GarageNode(s) are kept.",
+				len(desiredByName), surviving, factor)
+			log.Info("Auto-mode storage scale-down blocked", "survivingLiveNodes", surviving, "replicationFactor", factor)
+			if err := r.setScaleDownBlockedCondition(ctx, cluster, metav1.ConditionTrue, garagev1beta1.ReasonScaleDownWouldBreakQuorum, msg); err != nil {
+				return err
+			}
+			return nil
 		}
 	}
 
+	for _, n := range toDelete {
+		log.Info("Deleting Auto-mode GarageNode (scale-down)", "name", n.Name)
+		if err := r.Delete(ctx, n); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("deleting GarageNode %s: %w", n.Name, err)
+		}
+	}
+
+	// Scale-down (if any) is now safe; clear any prior block signal.
+	if err := r.setScaleDownBlockedCondition(ctx, cluster, metav1.ConditionFalse, garagev1beta1.ReasonScaleDownSafe, "storage scale-down within replication factor"); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// countLiveStorageNodes counts operator-owned storage GarageNodes that would
+// survive a scale-down to the desired set: a node is counted when it is in the
+// keep-set (desiredByName), is not being deleted, and carries a positive
+// capacity. Capacity nil/zero means it contributes no roled storage to Garage's
+// replication accounting, so it does not help satisfy the factor.
+func countLiveStorageNodes(existing map[string]*garagev1beta1.GarageNode, desiredByName map[string]bool) int {
+	n := 0
+	for name, node := range existing {
+		if !desiredByName[name] {
+			continue
+		}
+		if !node.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if node.Spec.Capacity == nil || node.Spec.Capacity.IsZero() {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// setScaleDownBlockedCondition sets the StorageScaleDownBlocked condition via
+// the conflict-retrying status writer. When set False it also clears any
+// previously-recorded blocked condition so a recovered cluster's status is
+// clean. The mutate closure is re-applied on conflict re-fetch.
+func (r *GarageClusterReconciler) setScaleDownBlockedCondition(ctx context.Context, cluster *garagev1beta2.GarageCluster, status metav1.ConditionStatus, reason, message string) error {
+	apply := func() {
+		if status == metav1.ConditionFalse {
+			// Only keep the cleared condition if it already existed; avoid adding
+			// a noisy False condition to clusters that never tripped the guard.
+			if meta.FindStatusCondition(cluster.Status.Conditions, garagev1beta1.ConditionStorageScaleDownBlocked) == nil {
+				return
+			}
+		}
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionStorageScaleDownBlocked,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: cluster.Generation,
+		})
+	}
+	apply()
+	return UpdateStatusWithRetry(ctx, r.Client, cluster, apply)
 }
 
 // listAutoModeStorageNodes returns operator-owned GarageNodes for the storage
@@ -911,12 +989,20 @@ func bucketLegacyDataPVCs(pvcs []corev1.PersistentVolumeClaim, clusterName strin
 		if err != nil {
 			continue
 		}
-		// After the index, expect "-<cluster>-<ord>".
+		// After the index, expect exactly "-<cluster>-<ord>" where <ord> is a
+		// pure non-negative integer with no further '-'. Requiring the ordinal
+		// token to be the WHOLE remaining tail (no embedded dash) prevents
+		// adopting a foreign cluster's PVC whose name happens to prefix-match
+		// this cluster's name, e.g. clusterName="c" must not bucket
+		// `data-0-c-extra-2` (a PVC of some other cluster "c-extra").
 		tail := rest[dash:]
 		if !strings.HasPrefix(tail, clusterMarker) {
 			continue
 		}
 		ordStr := tail[len(clusterMarker):]
+		if ordStr == "" || strings.ContainsRune(ordStr, '-') {
+			continue
+		}
 		ord64, err := strconv.ParseInt(ordStr, 10, 32)
 		if err != nil {
 			continue

--- a/internal/controller/garagecluster_automode_gateway.go
+++ b/internal/controller/garagecluster_automode_gateway.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -68,7 +71,7 @@ func (r *GarageClusterReconciler) reconcileAutoModeGatewayNodes(ctx context.Cont
 	for i := int32(0); i < desiredReplicas; i++ {
 		desiredByName[autoModeGatewayNodeName(cluster.Name, i)] = true
 
-		desired, err := r.buildAutoModeGatewayNode(cluster, i)
+		desired, err := r.buildAutoModeGatewayNode(cluster, i, "")
 		if err != nil {
 			return fmt.Errorf("building desired gateway GarageNode for ordinal %d: %w", i, err)
 		}
@@ -143,7 +146,13 @@ func (r *GarageClusterReconciler) listAutoModeGatewayNodes(ctx context.Context, 
 // for persistent identity, and EmptyDir data (no object blocks). The gateway's
 // own rpc_public_addr, when set, flows through spec.network so the node never
 // inherits the storage tier's address.
-func (r *GarageClusterReconciler) buildAutoModeGatewayNode(cluster *garagev1beta2.GarageCluster, ordinal int32) (*garagev1beta1.GarageNode, error) {
+//
+// When adoptedMetadataPVC is non-empty the node binds that existing metadata PVC
+// (legacy-STS gateway migration) so Garage's node_key — and thus node identity —
+// survives the v0.6.6 upgrade from a cluster-level gateway STS to per-node
+// GarageNodes. Otherwise a fresh metadata PVC is provisioned via the per-node
+// StatefulSet's volumeClaimTemplate.
+func (r *GarageClusterReconciler) buildAutoModeGatewayNode(cluster *garagev1beta2.GarageCluster, ordinal int32, adoptedMetadataPVC string) (*garagev1beta1.GarageNode, error) {
 	name := autoModeGatewayNodeName(cluster.Name, ordinal)
 
 	zone := cluster.Spec.Zone
@@ -154,21 +163,31 @@ func (r *GarageClusterReconciler) buildAutoModeGatewayNode(cluster *garagev1beta
 	podName := fmt.Sprintf("%s-%d", name, 0)
 	tags := buildNodeTags(cluster.Name, cluster.Namespace, tierGateway, cluster.Spec.DefaultNodeTags, podName)
 
-	// Metadata PVC sizing: gateway.metadata.size when set, else the 1Gi default.
-	metaSize := gatewayDefaultMetadataSize
-	var metaSC *string
-	if gw := cluster.Spec.Gateway; gw != nil && gw.Metadata != nil {
-		if gw.Metadata.Size != nil && !gw.Metadata.Size.IsZero() {
-			metaSize = *gw.Metadata.Size
+	var storage *garagev1beta1.NodeStorageConfig
+	if adoptedMetadataPVC != "" {
+		// Migration: bind the legacy cluster-level gateway STS's metadata PVC by
+		// name. The node_key under metadata_dir is what determines the node ID, so
+		// adopting the PVC keeps the gateway's identity stable across the upgrade.
+		storage = &garagev1beta1.NodeStorageConfig{
+			Metadata: &garagev1beta1.NodeVolumeConfig{ExistingClaim: adoptedMetadataPVC},
 		}
-		metaSC = gw.Metadata.StorageClassName
-	}
-	mSize := metaSize.DeepCopy()
-	storage := &garagev1beta1.NodeStorageConfig{
-		Metadata: &garagev1beta1.NodeVolumeConfig{
-			Size:             &mSize,
-			StorageClassName: metaSC,
-		},
+	} else {
+		// Metadata PVC sizing: gateway.metadata.size when set, else the 1Gi default.
+		metaSize := gatewayDefaultMetadataSize
+		var metaSC *string
+		if gw := cluster.Spec.Gateway; gw != nil && gw.Metadata != nil {
+			if gw.Metadata.Size != nil && !gw.Metadata.Size.IsZero() {
+				metaSize = *gw.Metadata.Size
+			}
+			metaSC = gw.Metadata.StorageClassName
+		}
+		mSize := metaSize.DeepCopy()
+		storage = &garagev1beta1.NodeStorageConfig{
+			Metadata: &garagev1beta1.NodeVolumeConfig{
+				Size:             &mSize,
+				StorageClassName: metaSC,
+			},
+		}
 	}
 
 	node := &garagev1beta1.GarageNode{
@@ -279,4 +298,123 @@ func (r *GarageClusterReconciler) ejectAutoModeGatewayNodes(ctx context.Context,
 		}
 	}
 	return nil
+}
+
+// migrateLegacyGatewaySTSIfNeeded adopts the metadata PVCs of a pre-#210
+// cluster-level gateway StatefulSet (`<cr>-gateway`) into per-node gateway
+// GarageNodes before that STS is removed, so the Ed25519 node_key Garage stores
+// under metadata_dir — and therefore the gateway node identity — survives the
+// upgrade. Without this, deleteGatewayStatefulSet cascade-deletes the old STS
+// whose PVC retention policy is WhenDeleted:Delete, the STS GC reaps the
+// metadata PVCs, and reconcileAutoModeGatewayNodes provisions fresh PVCs with
+// brand-new node IDs (the #221 v0.6.6-upgrade identity loss).
+//
+// Only runs for UNIFIED clusters (storage + gateway). Idempotent: once the old
+// STS is gone there is nothing to adopt and this is a no-op. Edge gateways keep
+// their cluster-level STS, so this never touches them.
+func (r *GarageClusterReconciler) migrateLegacyGatewaySTSIfNeeded(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
+	log := logf.FromContext(ctx)
+	if !cluster.HasGatewayTier() || !cluster.HasStorageTier() {
+		return nil
+	}
+
+	name := gatewayWorkloadName(cluster) // <cr>-gateway
+	legacySTS := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: cluster.Namespace}, legacySTS); err != nil {
+		if errors.IsNotFound(err) {
+			return nil // already migrated / never existed
+		}
+		return fmt.Errorf("checking for legacy gateway StatefulSet: %w", err)
+	}
+
+	replicas := int32(0)
+	if legacySTS.Spec.Replicas != nil {
+		replicas = *legacySTS.Spec.Replicas
+	}
+
+	// Adopt each replica's metadata PVC into a per-node gateway GarageNode. The
+	// legacy STS named its metadata volumeClaimTemplate `metadata`, so the PVCs
+	// are `metadata-<cr>-gateway-<ord>`. The per-node node is `<cr>-gateway-<ord>`.
+	for ord := int32(0); ord < replicas; ord++ {
+		legacyPVC := fmt.Sprintf("%s-%s-%d", metadataVolName, name, ord)
+
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: legacyPVC, Namespace: cluster.Namespace}, pvc); err != nil {
+			if errors.IsNotFound(err) {
+				// Nothing to adopt for this ordinal (already cleaned up, or the
+				// gateway never had persistent metadata). Skip — a fresh node is
+				// created by reconcileAutoModeGatewayNodes.
+				continue
+			}
+			return fmt.Errorf("get legacy gateway metadata PVC %q: %w", legacyPVC, err)
+		}
+
+		// Strip the old STS's controllerRef off the PVC so the orphan-delete below
+		// (and the STS GC) cannot reap it. Mirrors the intent of the storage
+		// migration's orphan delete, which leaves PVCs controllerRef-free.
+		if stripStatefulSetOwnerRef(pvc, legacySTS.UID) {
+			if err := r.Update(ctx, pvc); err != nil {
+				return fmt.Errorf("detaching legacy STS ownerRef from PVC %q: %w", legacyPVC, err)
+			}
+		}
+
+		desired, err := r.buildAutoModeGatewayNode(cluster, ord, legacyPVC)
+		if err != nil {
+			return fmt.Errorf("building migrated gateway GarageNode for ordinal %d: %w", ord, err)
+		}
+
+		existing := &garagev1beta1.GarageNode{}
+		if err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing); err == nil {
+			log.Info("Gateway migration: GarageNode already exists, leaving in place", "name", desired.Name)
+		} else if errors.IsNotFound(err) {
+			log.Info("Gateway migration: creating GarageNode bound to legacy metadata PVC", "name", desired.Name, "metadataPVC", legacyPVC)
+			if createErr := r.Create(ctx, desired); createErr != nil && !errors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("gateway migration: creating GarageNode %s: %w", desired.Name, createErr)
+			}
+		} else {
+			return fmt.Errorf("gateway migration: checking for existing GarageNode %s: %w", desired.Name, err)
+		}
+	}
+
+	// Orphan-delete the legacy STS so its metadata PVCs survive for the new
+	// per-node STSes to adopt via existingClaim. Cascade (the default) would
+	// reap them via the WhenDeleted:Delete retention policy.
+	log.Info("Gateway migration: orphan-deleting legacy cluster-level gateway StatefulSet", "name", name)
+	orphan := metav1.DeletePropagationOrphan
+	if err := r.Delete(ctx, legacySTS, &client.DeleteOptions{PropagationPolicy: &orphan}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("orphan-deleting legacy gateway STS: %w", err)
+	}
+
+	// Delete the legacy gateway pods (<cr>-gateway-<ord>) so the kubelet releases
+	// the RWO metadata PVCs for the new per-node STS pods (<cr>-gateway-<ord>-0).
+	for ord := int32(0); ord < replicas; ord++ {
+		podName := fmt.Sprintf("%s-%d", name, ord)
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: cluster.Namespace}}
+		if err := r.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("deleting legacy gateway pod %s: %w", podName, err)
+		}
+	}
+
+	return nil
+}
+
+// stripStatefulSetOwnerRef removes the ownerReference pointing at the given
+// StatefulSet UID from a PVC (if present) and reports whether it changed. Used
+// during gateway migration so an orphan-deleted legacy STS cannot cascade-delete
+// the metadata PVC the new per-node node is about to adopt.
+func stripStatefulSetOwnerRef(pvc *corev1.PersistentVolumeClaim, stsUID types.UID) bool {
+	if len(pvc.OwnerReferences) == 0 {
+		return false
+	}
+	kept := pvc.OwnerReferences[:0]
+	changed := false
+	for _, ref := range pvc.OwnerReferences {
+		if ref.UID == stsUID {
+			changed = true
+			continue
+		}
+		kept = append(kept, ref)
+	}
+	pvc.OwnerReferences = kept
+	return changed
 }

--- a/internal/controller/garagecluster_automode_gateway_test.go
+++ b/internal/controller/garagecluster_automode_gateway_test.go
@@ -17,11 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
@@ -178,5 +184,104 @@ var _ = Describe("GarageCluster unified-gateway Auto-mode (#209)", func() {
 			Expect(metav1.IsControlledBy(&n, cluster)).To(BeFalse(), "controllerRef must be dropped on eject")
 			Expect(n.Labels).NotTo(HaveKey(labelAppManagedBy))
 		}
+	})
+
+	It("adopts the legacy cluster-level gateway STS metadata PVC by existingClaim (identity-preserving) (#221)", func() {
+		stsName := clusterNN.Name + "-gateway"
+
+		legacySTS := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: testNamespace},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas:    ptr.To(int32(2)),
+				ServiceName: clusterNN.Name + "-headless",
+				Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{labelCluster: clusterNN.Name, labelTier: tierGateway}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelCluster: clusterNN.Name, labelTier: tierGateway}},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "garage", Image: "garage:test"}}},
+				},
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+					ObjectMeta: metav1.ObjectMeta{Name: metadataVolName},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}},
+					},
+				}},
+				PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, legacySTS)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: stsName, Namespace: testNamespace}, legacySTS)).To(Succeed())
+
+		for ord := 0; ord < 2; ord++ {
+			pvcName := fmt.Sprintf("%s-%s-%d", metadataVolName, stsName, ord)
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: testNamespace,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       stsName,
+						UID:        legacySTS.UID,
+						Controller: ptr.To(true),
+					}},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+		}
+
+		Expect(reconciler.migrateLegacyGatewaySTSIfNeeded(ctx, cluster)).To(Succeed())
+
+		// (a)+(b) both metadata PVCs survive and no longer carry the STS ownerRef.
+		for ord := 0; ord < 2; ord++ {
+			pvcName := fmt.Sprintf("%s-%s-%d", metadataVolName, stsName, ord)
+			pvc := &corev1.PersistentVolumeClaim{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: testNamespace}, pvc)).To(Succeed())
+			for _, ref := range pvc.OwnerReferences {
+				Expect(ref.UID).NotTo(Equal(legacySTS.UID), "legacy STS ownerRef must be stripped so cascade delete cannot reap it")
+			}
+		}
+
+		// (c) two adopted gateway nodes, each binding its metadata PVC by name with
+		// no freshly-sized template.
+		gnList := listOperatorOwnedGatewayNodes(clusterNN.Name)
+		Expect(gnList.Items).To(HaveLen(2))
+		for _, n := range gnList.Items {
+			Expect(n.Spec.Storage).NotTo(BeNil())
+			Expect(n.Spec.Storage.Metadata).NotTo(BeNil())
+			Expect(n.Spec.Storage.Metadata.ExistingClaim).To(Equal(metadataVolName + "-" + n.Name))
+			Expect(n.Spec.Storage.Metadata.Size).To(BeNil(), "adopted node must not declare a fresh size")
+		}
+
+		// (d) the legacy STS is gone or being deleted (envtest has no STS controller).
+		fresh := &appsv1.StatefulSet{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: stsName, Namespace: testNamespace}, fresh)
+		if err == nil {
+			Expect(fresh.DeletionTimestamp).NotTo(BeNil())
+		} else {
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}
+	})
+
+	It("per-node gateway STS does not delete the metadata PVC on STS update (Retain)", func() {
+		gwNode, err := reconciler.buildAutoModeGatewayNode(cluster, 0, "")
+		Expect(err).NotTo(HaveOccurred())
+		// Gateway node → nil retention policy == K8s default Retain.
+		Expect(stsPVCRetentionPolicy(cluster, gwNode)).To(BeNil())
+
+		// Positive control: a storage node without spec.storage.pvcRetentionPolicy
+		// also yields nil (Retain).
+		storageNode := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterNN.Name + "-storage-0", Namespace: testNamespace},
+			Spec:       garagev1beta1.GarageNodeSpec{ClusterRef: garagev1beta1.ClusterReference{Name: clusterNN.Name}},
+		}
+		Expect(stsPVCRetentionPolicy(cluster, storageNode)).To(BeNil())
 	})
 })

--- a/internal/controller/garagecluster_automode_test.go
+++ b/internal/controller/garagecluster_automode_test.go
@@ -180,6 +180,9 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 
 			Expect(k8sClient.Get(ctx, clusterNN, cluster)).To(Succeed())
 			cluster.Spec.Storage.Replicas = 2
+			// Lower the replication factor so surviving (2) >= factor (1) and the
+			// scale-down guard does not refuse the delete.
+			cluster.Spec.Replication.Factor = 1
 			Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
 
 			Expect(reconciler.reconcileAutoModeStorageNodes(ctx, cluster)).To(Succeed())
@@ -199,6 +202,44 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 			// scanning for at least the two remaining ordinals above. The
 			// excess GarageNode either has a DeletionTimestamp or has been
 			// removed — both are valid outcomes.
+		})
+
+		It("refuses scale-down below replication factor and sets StorageScaleDownBlocked", func() {
+			Expect(reconciler.reconcileAutoModeStorageNodes(ctx, cluster)).To(Succeed())
+			Expect(listOperatorOwnedStorageNodes(clusterNN.Name).Items).To(HaveLen(3))
+
+			// Mark all three GarageNodes "live" (NodeID set) so they count toward
+			// the replication factor; spec.capacity is already positive from build.
+			for _, n := range listOperatorOwnedStorageNodes(clusterNN.Name).Items {
+				fresh := n
+				fresh.Status.NodeID = "node-" + fresh.Name
+				Expect(k8sClient.Status().Update(ctx, &fresh)).To(Succeed())
+			}
+
+			// Scale replicas to 1 while replication.factor stays 3.
+			Expect(k8sClient.Get(ctx, clusterNN, cluster)).To(Succeed())
+			cluster.Spec.Storage.Replicas = 1
+			Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+
+			Expect(reconciler.reconcileAutoModeStorageNodes(ctx, cluster)).To(Succeed())
+
+			// All three GarageNodes must still exist (none deleted).
+			Eventually(func() int {
+				live := 0
+				for _, n := range listOperatorOwnedStorageNodes(clusterNN.Name).Items {
+					if n.DeletionTimestamp.IsZero() {
+						live++
+					}
+				}
+				return live
+			}, timeout, interval).Should(Equal(3))
+
+			// Condition surfaced.
+			Expect(k8sClient.Get(ctx, clusterNN, cluster)).To(Succeed())
+			c := meta.FindStatusCondition(cluster.Status.Conditions, garagev1beta1.ConditionStorageScaleDownBlocked)
+			Expect(c).NotTo(BeNil())
+			Expect(c.Status).To(Equal(metav1.ConditionTrue))
+			Expect(c.Reason).To(Equal(garagev1beta1.ReasonScaleDownWouldBreakQuorum))
 		})
 	})
 
@@ -833,6 +874,20 @@ var _ = Describe("bucketLegacyDataPVCs", func() {
 		}
 		got := bucketLegacyDataPVCs(pvcs, "my-cluster")
 		Expect(got).To(BeEmpty())
+	})
+
+	It("does not adopt a foreign cluster's PVC that prefix-matches this cluster name", func() {
+		pvcs := []corev1.PersistentVolumeClaim{
+			// Belongs to cluster "my-cluster-extra" ordinal 2 — must NOT be
+			// bucketed under "my-cluster".
+			makePVC("data-0-my-cluster-extra-2", "10Gi"),
+			// Legitimate "my-cluster" multi-HDD ordinal 0.
+			makePVC("data-0-my-cluster-0", "10Gi"),
+			makePVC("data-1-my-cluster-0", "20Gi"),
+		}
+		got := bucketLegacyDataPVCs(pvcs, "my-cluster")
+		Expect(got).To(HaveLen(1))
+		Expect(names(got[0])).To(Equal([]string{"data-0-my-cluster-0", "data-1-my-cluster-0"}))
 	})
 })
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -255,6 +255,14 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		//     admin routing.
 		if cluster.HasGatewayTier() {
 			if cluster.HasStorageTier() {
+				// #221: before tearing down the pre-#210 cluster-level gateway STS,
+				// adopt its metadata PVCs into per-node GarageNodes so the gateway
+				// node_key (identity) survives the upgrade. The migration
+				// orphan-deletes the old STS itself, so the subsequent
+				// deleteGatewayStatefulSet is a no-op (NotFound) on the happy path.
+				if err := r.migrateLegacyGatewaySTSIfNeeded(ctx, cluster); err != nil {
+					return r.updateStatus(ctx, cluster, PhaseFailed, fmt.Errorf("legacy gateway STS migration: %w", err))
+				}
 				if err := r.deleteGatewayStatefulSet(ctx, cluster); err != nil {
 					return r.updateStatus(ctx, cluster, PhaseFailed, err)
 				}
@@ -794,6 +802,11 @@ func (r *GarageClusterReconciler) writeConfigMap(ctx context.Context, cluster *g
 		return "", err
 	}
 	existing.Data = cm.Data
+	// Re-assert operator-managed labels and controllerRef on update so manual
+	// edits / severed ownerRefs self-heal. cm already had SetControllerReference
+	// applied above, so its Labels/OwnerReferences are the desired state.
+	existing.Labels = cm.Labels
+	existing.OwnerReferences = cm.OwnerReferences
 	return hashStr, r.Update(ctx, existing)
 }
 
@@ -1660,17 +1673,21 @@ func (r *GarageClusterReconciler) reconcileTierPodDisruptionBudget(ctx context.C
 		spec.MinAvailable = pdbCfg.MinAvailable
 	case pdbCfg.MaxUnavailable != nil:
 		spec.MaxUnavailable = pdbCfg.MaxUnavailable
+	case replicas <= 1:
+		// A single-replica tier (a lone stateless gateway, or a 1-node storage
+		// tier) cannot use minAvailable=1: that permits zero voluntary
+		// disruptions and makes the only pod undrainable, wedging node drains
+		// and cluster-autoscaler scale-downs. maxUnavailable=1 still records
+		// the PDB intent while letting the pod be evicted and rescheduled.
+		maxUnavail := intstr.FromInt(1)
+		spec.MaxUnavailable = &maxUnavail
 	default:
-		// Default to (replicas-1) with a floor of 1. For storage this preserves
-		// quorum on drain for 3+ replica clusters and matches the pre-#192 default
-		// and the warning emitted by the v1beta1/v1beta2 validating webhooks. For
+		// Default to (replicas-1). For storage this preserves quorum on drain
+		// for 3+ replica clusters and matches the pre-#192 default and the
+		// warning emitted by the v1beta1/v1beta2 validating webhooks. For
 		// gateway it pins at least one pod available, which is what users want
 		// during node drains.
-		effective := replicas
-		if effective < 2 {
-			effective = 2
-		}
-		minAvail := intstr.FromInt(int(effective - 1))
+		minAvail := intstr.FromInt(int(replicas - 1))
 		spec.MinAvailable = &minAvail
 	}
 
@@ -2112,23 +2129,28 @@ func vctStorageClassChanged(existing, desired []corev1.PersistentVolumeClaim) bo
 }
 
 func (r *GarageClusterReconciler) updateStatus(ctx context.Context, cluster *garagev1beta2.GarageCluster, phase string, err error) (ctrl.Result, error) {
-	cluster.Status.Phase = phase
-	// Only set ObservedGeneration when reconciliation succeeded
-	if err == nil {
-		cluster.Status.ObservedGeneration = cluster.Generation
+	// Assemble the desired status inside a closure so a conflict-driven
+	// re-fetch in UpdateStatusWithRetry re-applies it instead of pushing back
+	// the stale server copy.
+	apply := func() {
+		cluster.Status.Phase = phase
+		// Only set ObservedGeneration when reconciliation succeeded
+		if err == nil {
+			cluster.Status.ObservedGeneration = cluster.Generation
+		}
+		if err != nil {
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:               PhaseReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             garagev1beta1.ReasonReconcileFailed,
+				Message:            err.Error(),
+				ObservedGeneration: cluster.Generation,
+			})
+		}
 	}
+	apply()
 
-	if err != nil {
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               PhaseReady,
-			Status:             metav1.ConditionFalse,
-			Reason:             garagev1beta1.ReasonReconcileFailed,
-			Message:            err.Error(),
-			ObservedGeneration: cluster.Generation,
-		})
-	}
-
-	if statusErr := UpdateStatusWithRetry(ctx, r.Client, cluster); statusErr != nil {
+	if statusErr := UpdateStatusWithRetry(ctx, r.Client, cluster, apply); statusErr != nil {
 		return ctrl.Result{}, statusErr
 	}
 
@@ -2223,7 +2245,14 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		readyReplicas = storageReady + gatewayReady
 
 		if desiredReplicas == 0 {
-			return r.updateStatus(ctx, cluster, "Pending", nil)
+			// Both tiers scaled to 0: nothing to roll out, but owned resources
+			// (ConfigMaps, Services, PDBs, RPC secret) must still reconverge on a
+			// timer in case they drift while no pods exist. updateStatus's success
+			// path returns Result{} with no RequeueAfter, so override it here.
+			if res, err := r.updateStatus(ctx, cluster, "Pending", nil); err != nil {
+				return res, err
+			}
+			return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
 		}
 	}
 
@@ -2445,9 +2474,41 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		ObservedGeneration: cluster.Generation,
 	})
 
+	// Detect operator-owned gateway GarageNodes that have lost their layout role
+	// (status.inLayout == false). In a unified cluster the gateway tier runs as
+	// per-node GarageNodes with a capacity:nil role; if that role is dropped the
+	// node silently falls back to quorum auth (#209). Only meaningful for unified
+	// clusters — edge gateways own no gateway GarageNodes, so the list is empty.
+	cluster.Status.GatewayNodesNotInLayout = nil
+	if cluster.HasStorageTier() && cluster.HasGatewayTier() {
+		gwNodes := &garagev1beta1.GarageNodeList{}
+		if err := r.List(ctx, gwNodes,
+			client.InNamespace(cluster.Namespace),
+			client.MatchingLabels(map[string]string{
+				labelCluster:      cluster.Name,
+				labelTier:         tierGateway,
+				labelAppManagedBy: managedByOperatorValue,
+			}),
+		); err != nil {
+			log.V(1).Info("Failed to list gateway GarageNodes for layout-degraded check", "error", err)
+		} else {
+			for i := range gwNodes.Items {
+				n := &gwNodes.Items[i]
+				if n.Spec.ClusterRef.Name != cluster.Name {
+					continue
+				}
+				// Only judge nodes that have discovered their identity; a node
+				// still coming up (no NodeID yet) hasn't had a chance to join.
+				if n.Status.NodeID != "" && !n.Status.InLayout {
+					cluster.Status.GatewayNodesNotInLayout = append(cluster.Status.GatewayNodesNotInLayout, n.Name)
+				}
+			}
+		}
+	}
+
 	// Derive the actionable health conditions (QuorumAtRisk, RemoteClustersHealthy,
-	// FederationConfigured) + the one-line LayoutDiagnosis from the populated
-	// status. Runs after Health + RemoteClusters are set above.
+	// FederationConfigured, GatewayLayoutDegraded) + the one-line LayoutDiagnosis
+	// from the populated status. Runs after Health + RemoteClusters are set above.
 	setClusterHealthConditions(cluster)
 
 	// Update endpoints using configured ports
@@ -2465,7 +2526,16 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		RPC:   svcFQDN(cluster.Name+"-headless", cluster.Namespace, rpcPort, r.ClusterDomain),
 	}
 
-	if err := UpdateStatusWithRetry(ctx, r.Client, cluster); err != nil {
+	// The full desired status is assembled above (replica counts, health,
+	// layout history, conditions, diagnosis, endpoints). Snapshot it and
+	// re-apply through the conflict-retry: UpdateStatusWithRetry re-fetches
+	// on a 409, which overwrites cluster.Status with the stale server copy,
+	// so without this closure the computed status would be silently dropped.
+	desiredStatus := cluster.Status
+	apply := func() {
+		cluster.Status = desiredStatus
+	}
+	if err := UpdateStatusWithRetry(ctx, r.Client, cluster, apply); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -2570,7 +2640,11 @@ func discoverNodes(ctx context.Context, pods []corev1.Pod, adminToken string, ad
 		endpoint := adminEndpoint(pod.Status.PodIP, adminPort)
 		garageClient := garage.NewClient(endpoint, adminToken)
 
-		status, err := garageClient.GetClusterStatus(ctx)
+		// Bound each probe so one hung pod can't pin the single-worker reconciler
+		// for the full 90s client timeout (mirrors connectToRemoteCluster).
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		status, err := garageClient.GetClusterStatus(cctx)
+		cancel()
 		if err != nil {
 			log.V(1).Info("Failed to get status from pod", "pod", pod.Name, "error", err)
 			continue
@@ -2645,7 +2719,10 @@ func findReachableClient(ctx context.Context, nodes []bootstrapNodeInfo, adminTo
 	for _, node := range nodes {
 		endpoint := adminEndpoint(node.podIP, adminPort)
 		garageClient := garage.NewClient(endpoint, adminToken)
-		if _, err := garageClient.GetClusterHealth(ctx); err == nil {
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err := garageClient.GetClusterHealth(cctx)
+		cancel()
+		if err == nil {
 			return garageClient
 		}
 	}
@@ -2667,7 +2744,9 @@ func connectNodes(ctx context.Context, nodes []bootstrapNodeInfo, adminToken str
 				continue // Skip self
 			}
 			addr := rpcAddr(targetNode.podIP, rpcPort)
-			result, err := nodeClient.ConnectNode(ctx, targetNode.id, addr)
+			cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			result, err := nodeClient.ConnectNode(cctx, targetNode.id, addr)
+			cancel()
 			if err != nil {
 				log.V(1).Info("Failed to connect node (API error)", "source", sourceNode.podName, "target", targetNode.podName, "error", err)
 				continue
@@ -3040,7 +3119,9 @@ func (r *GarageClusterReconciler) bootstrapCluster(ctx context.Context, cluster 
 	}
 
 	// Check cluster health - if all nodes are already connected, skip connect step
-	health, err := bootstrapClient.GetClusterHealth(ctx)
+	healthCtx, healthCancel := context.WithTimeout(ctx, 5*time.Second)
+	health, err := bootstrapClient.GetClusterHealth(healthCtx)
+	healthCancel()
 	if err != nil {
 		log.V(1).Info("Failed to get cluster health during bootstrap", "error", err)
 	}
@@ -4029,7 +4110,7 @@ func (r *GarageClusterReconciler) connectToRemoteCluster(
 	//
 	// Requires remote.Connection.GatewayRPCEndpointTemplate to be set; the
 	// template substitutes {ordinal} with each remote gateway pod's ordinal
-	// parsed from its pod-name layout tag (e.g. "garage-gateway-0").
+	// parsed from its pod-name layout tag (e.g. "<cluster>-gateway-1-0" -> 1).
 	if tmpl := remote.Connection.GatewayRPCEndpointTemplate; tmpl != "" {
 		r.connectRemoteGatewayPods(ctx, localClient, localStatus, remote, tmpl)
 	}
@@ -4079,24 +4160,25 @@ func (r *GarageClusterReconciler) connectRemoteGatewayPods(
 			continue
 		}
 		isGateway := false
-		var podName string
 		for _, tag := range node.Role.Tags {
 			if tag == "tier:"+tierGateway {
 				isGateway = true
-			}
-			if strings.HasPrefix(tag, "garage-gateway-") {
-				podName = tag
+				break
 			}
 		}
-		if !isGateway || podName == "" {
+		if !isGateway {
 			continue
 		}
 		if node.IsUp {
 			continue
 		}
-		ordinalStr := strings.TrimPrefix(podName, "garage-gateway-")
-		if _, err := strconv.Atoi(ordinalStr); err != nil {
-			log.V(1).Info("Skipping remote gateway with non-numeric ordinal", "podName", podName)
+		// Derive the gateway pod ordinal from the node's own pod-name layout tag.
+		// Operator-managed gateways tag each pod "<cluster>-gateway-<N>-<stsOrdinal>"
+		// (buildAutoModeGatewayNode); the cluster name comes from the same node's
+		// "cluster:<name>/<ns>" ownership tag, NOT remote.Name (a friendly label).
+		ordinalStr, ok := parseRemoteGatewayOrdinal(node.Role.Tags)
+		if !ok {
+			log.V(1).Info("Skipping remote gateway: could not parse pod ordinal from tags", "tags", node.Role.Tags)
 			continue
 		}
 		addr := strings.ReplaceAll(template, "{ordinal}", ordinalStr)
@@ -4119,8 +4201,53 @@ func (r *GarageClusterReconciler) connectRemoteGatewayPods(
 			continue
 		}
 		log.Info("Connected to remote gateway pod",
-			"nodeID", node.ID[:16]+"...", "addr", addr, "podName", podName)
+			"nodeID", node.ID[:16]+"...", "addr", addr, "ordinal", ordinalStr)
 	}
+}
+
+// parseRemoteGatewayOrdinal extracts a gateway pod's ordinal from its layout
+// tags. Operator-managed gateway nodes carry two relevant tags:
+//   - a cluster-ownership tag "cluster:<name>/<namespace>"
+//   - a pod-name tag "<name>-gateway-<ordinal>-<stsOrdinal>"
+//
+// (see buildNodeTags / buildAutoModeGatewayNode). The cluster name may contain
+// hyphens, so the prefix is derived from the ownership tag's name component
+// rather than guessed. The trailing "-<stsOrdinal>" (always "-0", since each
+// per-node StatefulSet has replicas:1) is stripped before parsing the ordinal.
+// Returns the ordinal as a string (for {ordinal} substitution) and ok=false
+// when no gateway pod-name tag matches.
+func parseRemoteGatewayOrdinal(tags []string) (string, bool) {
+	var clusterName string
+	for _, tag := range tags {
+		if rest, found := strings.CutPrefix(tag, "cluster:"); found {
+			if name, _, ok := strings.Cut(rest, "/"); ok && name != "" {
+				clusterName = name
+			}
+		}
+	}
+	if clusterName == "" {
+		return "", false
+	}
+	prefix := clusterName + "-gateway-"
+	for _, tag := range tags {
+		rest, found := strings.CutPrefix(tag, prefix)
+		if !found {
+			continue
+		}
+		// rest is "<ordinal>-<stsOrdinal>"; strip the trailing STS-ordinal suffix.
+		ordinalStr := rest
+		if i := strings.LastIndex(rest, "-"); i >= 0 {
+			ordinalStr = rest[:i]
+		}
+		if ordinalStr == "" {
+			continue
+		}
+		if _, err := strconv.Atoi(ordinalStr); err != nil {
+			continue
+		}
+		return ordinalStr, true
+	}
+	return "", false
 }
 
 // addRemoteNodesToLayout adds remote cluster nodes to the local cluster's layout.

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -393,6 +393,68 @@ var _ = Describe("GarageCluster Controller", func() {
 			Expect(updated.Status.Selector).To(Equal(labelCluster + "=" + resourceName))
 		})
 
+		It("preserves computed status across a status-update conflict", func() {
+			// Unique cluster name so the status computation (which counts this
+			// cluster's GarageNodes) is not contaminated by operator-owned nodes
+			// other specs leave behind in this shared namespace (envtest has no
+			// garbage collector to reap them on cluster delete).
+			const cName = "status-conflict-cluster"
+			cNN := types.NamespacedName{Name: cName, Namespace: testNamespace}
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: cName, Namespace: testNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					LayoutPolicy: LayoutPolicyManual,
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 1,
+						Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, cluster) })
+
+			node := &garagev1beta1.GarageNode{
+				ObjectMeta: metav1.ObjectMeta{Name: cName + "-node-0", Namespace: testNamespace},
+				Spec: garagev1beta1.GarageNodeSpec{
+					ClusterRef: garagev1beta1.ClusterReference{Name: cName},
+					Capacity:   ptrQuantity(resource.MustParse("10Gi")),
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, node)
+			})
+			node.Status.Connected = true
+			Expect(k8sClient.Status().Update(ctx, node)).To(Succeed())
+
+			reconciler := &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+			// Fetch a STALE copy, then mutate the live object so the stale copy's
+			// ResourceVersion is out of date and the first Status().Update inside
+			// updateStatusFromCluster hits a 409, forcing the re-fetch+re-apply path.
+			clusterStale := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, cNN, clusterStale)).To(Succeed())
+
+			fresh := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, cNN, fresh)).To(Succeed())
+			// A valid-but-different Phase bumps the live ResourceVersion so the
+			// stale copy's Status().Update hits a 409 — the closure must re-fetch
+			// and re-apply the computed "Running", overwriting this "Degraded".
+			fresh.Status.Phase = "Degraded"
+			Expect(k8sClient.Status().Update(ctx, fresh)).To(Succeed())
+
+			_, err := reconciler.updateStatusFromCluster(ctx, clusterStale)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, cNN, updated)).To(Succeed())
+			Expect(updated.Status.ReadyReplicas).To(Equal(int32(1)))
+			Expect(updated.Status.Replicas).To(Equal(int32(1)))
+			Expect(updated.Status.Phase).To(Equal("Running"))
+		})
+
 		It("should add a finalizer to the GarageCluster", func() {
 			By("Creating the GarageCluster resource")
 			cluster := &garagev1beta2.GarageCluster{
@@ -711,7 +773,7 @@ var _ = Describe("GarageCluster PodDisruptionBudget reconcile", func() {
 		Expect(errors.IsNotFound(k8sClient.Get(ctx, key, &policyv1.PodDisruptionBudget{}))).To(BeTrue())
 	})
 
-	It("floors MinAvailable at 1 for a single-replica cluster", func() {
+	It("uses maxUnavailable=1 for a single-replica cluster (keeps it drainable)", func() {
 		size := resource.MustParse("1Gi")
 		Expect(k8sClient.Create(ctx, &garagev1beta2.GarageCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace},
@@ -729,7 +791,9 @@ var _ = Describe("GarageCluster PodDisruptionBudget reconcile", func() {
 
 		pdb := &policyv1.PodDisruptionBudget{}
 		Expect(k8sClient.Get(ctx, key, pdb)).To(Succeed())
-		Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(1))
+		// A single-replica tier stays drainable via maxUnavailable=1, not minAvailable=1.
+		Expect(pdb.Spec.MinAvailable).To(BeNil())
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).To(Equal(1))
 	})
 
 	It("leaves a foreign PDB with the same name alone (no ownerRef)", func() {
@@ -844,6 +908,17 @@ var _ = Describe("GarageCluster gateway PodDisruptionBudget reconcile", func() {
 	It("honors explicit maxUnavailable as in the issue", func() {
 		one := intstr.FromInt(1)
 		Expect(k8sClient.Create(ctx, newUnifiedCluster(&garagev1beta2.PodDisruptionBudgetConfig{Enabled: true, MaxUnavailable: &one}, 3))).To(Succeed())
+		driveReconciles()
+
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, gwKey, pdb)).To(Succeed())
+		Expect(pdb.Spec.MinAvailable).To(BeNil())
+		Expect(pdb.Spec.MaxUnavailable).NotTo(BeNil())
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).To(Equal(1))
+	})
+
+	It("makes a single-replica gateway PDB drainable via maxUnavailable=1", func() {
+		Expect(k8sClient.Create(ctx, newUnifiedCluster(&garagev1beta2.PodDisruptionBudgetConfig{Enabled: true}, 1))).To(Succeed())
 		driveReconciles()
 
 		pdb := &policyv1.PodDisruptionBudget{}

--- a/internal/controller/garagecluster_factor_migration.go
+++ b/internal/controller/garagecluster_factor_migration.go
@@ -54,9 +54,12 @@ const (
 // the on-disk cluster_layout exactly once per migration (guarded by a marker file).
 const fmPurgeInitContainerName = "purge-cluster-layout"
 
-// fmStuckTimeout bounds the wait phases (ScalingDown, Verifying) so a stuck pod
-// can't hang the migration forever — past this it transitions to Failed and
-// retains the annotation for operator inspection.
+// fmStuckTimeout bounds each individual wait phase (ScalingDown, Purging,
+// Verifying, RebuildingLayout) so a single stuck step can't hang the migration
+// forever — past this the migration fails and tears the tier back down. The
+// clock is per-phase (status.factorMigration.phaseStartedAt), not the overall
+// migration duration, so an early phase consuming time doesn't shorten the
+// budget of a later one.
 const fmStuckTimeout = 15 * time.Minute
 
 // fmValidateGrace is how long Validating tolerates an annotation factor that
@@ -291,6 +294,9 @@ func (r *GarageClusterReconciler) fmScaleDown(ctx context.Context, cluster *gara
 // container that deletes cluster_layout, then scales it back to 1. The new pod
 // boots with the new factor (from the refreshed ConfigMap) and an empty layout.
 func (r *GarageClusterReconciler) fmPurge(ctx context.Context, cluster *garagev1beta2.GarageCluster) (ctrl.Result, error) {
+	if stuck, res, err := r.fmCheckStuck(ctx, cluster); stuck {
+		return res, err
+	}
 	fm := cluster.Status.FactorMigration
 	nodes, err := r.listAutoModeStorageNodes(ctx, cluster)
 	if err != nil {
@@ -346,6 +352,14 @@ func (r *GarageClusterReconciler) fmVerify(ctx context.Context, cluster *garagev
 // valid.
 func (r *GarageClusterReconciler) fmRebuildLayout(ctx context.Context, cluster *garagev1beta2.GarageCluster) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
+
+	// Bound this phase: every path below requeues (admin not up, node identity
+	// not yet observed, staging/apply failure). Without a per-phase guard a node
+	// whose status.nodeId never repopulates after the purge restart would loop
+	// here forever with the tier still suspended.
+	if stuck, res, err := r.fmCheckStuck(ctx, cluster); stuck {
+		return res, err
+	}
 
 	gc, err := GetGarageClient(ctx, r.Client, cluster, r.ClusterDomain)
 	if err != nil {
@@ -453,13 +467,20 @@ func purgeIDFromStart(fm *garagev1beta2.FactorMigrationStatus) string {
 	return "p0"
 }
 
-// fmCheckStuck transitions to Failed if a wait phase has exceeded fmStuckTimeout.
+// fmCheckStuck transitions to Failed if the CURRENT phase has been running
+// longer than fmStuckTimeout. The deadline is measured from phaseStartedAt
+// (reset on every transition by setFactorMigration); it falls back to startedAt
+// for a migration that began before phaseStartedAt was tracked.
 func (r *GarageClusterReconciler) fmCheckStuck(ctx context.Context, cluster *garagev1beta2.GarageCluster) (bool, ctrl.Result, error) {
 	fm := cluster.Status.FactorMigration
-	if fm == nil || fm.StartedAt == nil {
+	if fm == nil {
 		return false, ctrl.Result{}, nil
 	}
-	if time.Since(fm.StartedAt.Time) <= fmStuckTimeout {
+	since := fm.PhaseStartedAt
+	if since == nil {
+		since = fm.StartedAt
+	}
+	if since == nil || time.Since(since.Time) <= fmStuckTimeout {
 		return false, ctrl.Result{}, nil
 	}
 	res, err := r.failFactorMigration(ctx, cluster,
@@ -697,13 +718,23 @@ func (r *GarageClusterReconciler) clearStorageSuspension(ctx context.Context, cl
 }
 
 // setFactorMigration mutates status.factorMigration and persists it with retry.
+// It auto-stamps PhaseStartedAt whenever the mutation advances Phase, so every
+// transition site gets a per-phase deadline clock for free (and can't forget to
+// reset it). The stamping is computed against the phase observed at entry, so it
+// stays correct across UpdateStatusWithRetry's conflict re-fetch + re-apply.
 func (r *GarageClusterReconciler) setFactorMigration(ctx context.Context, cluster *garagev1beta2.GarageCluster, mutate func(*garagev1beta2.FactorMigrationStatus)) {
 	log := logf.FromContext(ctx)
 	apply := func() {
 		if cluster.Status.FactorMigration == nil {
 			cluster.Status.FactorMigration = &garagev1beta2.FactorMigrationStatus{}
 		}
-		mutate(cluster.Status.FactorMigration)
+		fm := cluster.Status.FactorMigration
+		prevPhase := fm.Phase
+		mutate(fm)
+		if fm.Phase != prevPhase {
+			now := metav1.Now()
+			fm.PhaseStartedAt = &now
+		}
 	}
 	apply()
 	if err := UpdateStatusWithRetry(ctx, r.Client, cluster, apply); err != nil {

--- a/internal/controller/garagecluster_factor_migration_test.go
+++ b/internal/controller/garagecluster_factor_migration_test.go
@@ -131,7 +131,7 @@ func fmStorageNode(cluster string, i int, nodeID string) *garagev1beta1.GarageNo
 			ClusterRef: garagev1beta1.ClusterReference{Name: cluster},
 			Zone:       "z",
 			Capacity:   ptr.To(resource.MustParse("10Gi")),
-			Tags:       []string{"tier:storage"},
+			Tags:       []string{testTierStorageTag},
 		},
 		Status: garagev1beta1.GarageNodeStatus{NodeID: nodeID},
 	}
@@ -511,7 +511,7 @@ func TestFactorMigration_BuildRebuildRoleChanges(t *testing.T) {
 			Name: "c7-gateway-0", Namespace: fmNS,
 			Labels: map[string]string{labelCluster: "c7", labelTier: tierGateway, labelAppManagedBy: managedByOperatorValue},
 		},
-		Spec:   garagev1beta1.GarageNodeSpec{ClusterRef: garagev1beta1.ClusterReference{Name: "c7"}, Zone: "z", Gateway: true, Tags: []string{"tier:gateway"}},
+		Spec:   garagev1beta1.GarageNodeSpec{ClusterRef: garagev1beta1.ClusterReference{Name: "c7"}, Zone: "z", Gateway: true, Tags: []string{testTierGatewayTag}},
 		Status: garagev1beta1.GarageNodeStatus{NodeID: "gwid"},
 	}
 	storage = append(storage, gw)
@@ -663,6 +663,101 @@ func TestFactorMigration_PurgeInitRunsAsStorageUID(t *testing.T) {
 	nonRootInit := purgeInitOf(autoModeGarageNodeName("uid1", 1))
 	if nonRootInit.SecurityContext == nil || nonRootInit.SecurityContext.RunAsUser == nil || *nonRootInit.SecurityContext.RunAsUser != 1000 {
 		t.Fatalf("non-root pod: init RunAsUser should inherit 1000, got %+v", nonRootInit.SecurityContext)
+	}
+}
+
+// TestFactorMigration_PhaseStartedAtResetsOnTransition guards #219: each phase
+// transition must stamp a fresh PhaseStartedAt so the stuck guard is per-phase,
+// not anchored to the overall migration StartedAt.
+func TestFactorMigration_PhaseStartedAtResetsOnTransition(t *testing.T) {
+	ctx := context.Background()
+	c := fmCluster("ps1")
+	// Truncate to second precision: status writes round-trip through the fake
+	// client's codec, which truncates metav1.Time, so an exact Equal later would
+	// be comparing against an untruncated literal.
+	long := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+	c.Status.FactorMigration = &garagev1beta2.FactorMigrationStatus{
+		Phase:          fmPhaseScalingDown,
+		ToFactor:       2,
+		StartedAt:      &long,
+		PhaseStartedAt: &long,
+	}
+	r := fmBuild(t, c)
+
+	r.setFactorMigration(ctx, c, func(m *garagev1beta2.FactorMigrationStatus) {
+		m.Phase = fmPhasePurging
+	})
+
+	fm := c.Status.FactorMigration
+	if fm.PhaseStartedAt == nil || time.Since(fm.PhaseStartedAt.Time) > time.Minute {
+		t.Fatalf("PhaseStartedAt must be reset to now on transition, got %v", fm.PhaseStartedAt)
+	}
+	if fm.StartedAt == nil || !fm.StartedAt.Equal(&long) {
+		t.Fatalf("StartedAt must NOT change on a phase transition, got %v want %v", fm.StartedAt, &long)
+	}
+
+	// A mutation that does NOT change the phase must leave PhaseStartedAt alone.
+	before := fm.PhaseStartedAt.DeepCopy()
+	r.setFactorMigration(ctx, c, func(m *garagev1beta2.FactorMigrationStatus) {
+		m.Message = "still purging"
+	})
+	if !c.Status.FactorMigration.PhaseStartedAt.Equal(before) {
+		t.Fatal("PhaseStartedAt must not move when the phase is unchanged")
+	}
+}
+
+// TestFactorMigration_RebuildLayoutStuckGuard guards #219: RebuildingLayout
+// requeues forever when a node's status.nodeId never repopulates after the
+// purge restart. A per-phase deadline must convert that into a Failed migration
+// with the tier torn back down, not an infinite loop.
+func TestFactorMigration_RebuildLayoutStuckGuard(t *testing.T) {
+	ctx := context.Background()
+	c := fmCluster("rb1")
+	stale := metav1.NewTime(time.Now().Add(-(fmStuckTimeout + time.Minute)))
+	c.Status.FactorMigration = &garagev1beta2.FactorMigrationStatus{
+		Phase:          fmPhaseRebuildingLayout,
+		ToFactor:       2,
+		PurgeID:        "p1",
+		StartedAt:      &stale,
+		PhaseStartedAt: &stale,
+	}
+	// A node still carrying the suspension + an init container, scaled to 0:
+	// failure must restore it (parity with TestFactorMigration_FailureRestoresTier).
+	node := fmStorageNode("rb1", 0, "ida")
+	node.Annotations = map[string]string{garagev1beta1.AnnotationOperatorSuspended: "p1"}
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: autoModeGarageNodeName("rb1", 0), Namespace: fmNS},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To(int32(0)),
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Name: fmPurgeInitContainerName}},
+				Containers:     []corev1.Container{{Name: fmGarageContainer}},
+			}},
+		},
+	}
+	r := fmBuild(t, c, node, sts)
+
+	if _, err := r.fmRebuildLayout(ctx, c); err != nil {
+		t.Fatalf("fmRebuildLayout: %v", err)
+	}
+
+	gotC := &garagev1beta2.GarageCluster{}
+	_ = r.Get(ctx, types.NamespacedName{Name: "rb1", Namespace: fmNS}, gotC)
+	if gotC.Status.FactorMigration.Phase != fmPhaseFailed {
+		t.Fatalf("expected Failed after the phase deadline, got %s", gotC.Status.FactorMigration.Phase)
+	}
+	if !strings.Contains(gotC.Status.FactorMigration.Message, "exceeded") {
+		t.Fatalf("expected a stuck-timeout message, got %q", gotC.Status.FactorMigration.Message)
+	}
+	gotSTS := &appsv1.StatefulSet{}
+	_ = r.Get(ctx, types.NamespacedName{Name: autoModeGarageNodeName("rb1", 0), Namespace: fmNS}, gotSTS)
+	if gotSTS.Spec.Replicas == nil || *gotSTS.Spec.Replicas != 1 {
+		t.Fatal("stuck RebuildingLayout must scale the storage STS back to 1")
+	}
+	gotNode := &garagev1beta1.GarageNode{}
+	_ = r.Get(ctx, types.NamespacedName{Name: autoModeGarageNodeName("rb1", 0), Namespace: fmNS}, gotNode)
+	if _, ok := gotNode.Annotations[garagev1beta1.AnnotationOperatorSuspended]; ok {
+		t.Fatal("stuck RebuildingLayout must clear the operator-suspended annotation")
 	}
 }
 

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -17,6 +17,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -173,6 +174,9 @@ func (r *GarageClusterReconciler) reconcileGatewayStatefulSet(ctx context.Contex
 	}
 
 	needsUpdate := existing.Spec.Replicas == nil || *existing.Spec.Replicas != *sts.Spec.Replicas
+	if !equality.Semantic.DeepEqual(existing.Labels, sts.Labels) || !metav1.IsControlledBy(existing, cluster) {
+		needsUpdate = true
+	}
 	if existing.Spec.Template.Annotations["garage.rajsingh.info/config-hash"] != configHash ||
 		existing.Spec.Template.Annotations["garage.rajsingh.info/pod-spec-hash"] != podSpecHashStr {
 		needsUpdate = true
@@ -182,6 +186,11 @@ func (r *GarageClusterReconciler) reconcileGatewayStatefulSet(ctx context.Contex
 	}
 	existing.Spec.Replicas = sts.Spec.Replicas
 	existing.Spec.Template = sts.Spec.Template
+	// Re-assert operator labels + controllerRef so ownerRef/label drift
+	// self-heals (the STS selector is immutable and is intentionally left
+	// untouched). sts already had SetControllerReference applied above.
+	existing.Labels = sts.Labels
+	existing.OwnerReferences = sts.OwnerReferences
 	log.Info("Updating gateway StatefulSet", "name", name)
 	return r.Update(ctx, existing)
 }
@@ -440,28 +449,13 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 		}
 	}
 
-	gatewayOwnershipTag := fmt.Sprintf("cluster:%s/%s", cluster.Name, cluster.Namespace)
-	gatewayTierTag := "tier:" + tierGateway
-	var stale []string
-	for _, role := range layout.Roles {
-		ownsThis := false
-		isGatewayTier := false
-		for _, tag := range role.Tags {
-			if tag == gatewayOwnershipTag {
-				ownsThis = true
-			}
-			if tag == gatewayTierTag {
-				isGatewayTier = true
-			}
-		}
-		if !ownsThis || !isGatewayTier {
-			continue
-		}
-		if live[role.ID] || claimed[role.ID] {
-			continue
-		}
-		stale = append(stale, role.ID)
-	}
+	// Scope the reaper to the LOCAL region. In a federation every region shares
+	// the same cluster:<name>/<ns> ownership tag, so without zone scoping each
+	// region would reap the others' gateway roles -> endless cross-region layout
+	// churn (#220). The gateway role carries the region's zone (set by
+	// buildAutoModeGatewayNode -> GarageNode layout staging), so only roles whose
+	// zone matches this cluster's zone are ours to remove.
+	stale := staleGatewayRoles(layout.Roles, localGatewayZone(cluster), cluster.Name, cluster.Namespace, live, claimed)
 
 	if len(stale) == 0 {
 		if len(cluster.Status.PendingGatewayTombstones) > 0 {
@@ -499,15 +493,19 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 		}
 		return
 	}
-	newVersion := layout.Version + 1
-	if cur, gerr := layoutClient.GetClusterLayout(ctx); gerr == nil {
-		newVersion = cur.Version
-	}
-	log.Info("Removed stale gateway entries from layout", "count", len(stale), "version", newVersion)
-
-	skipReq := garage.SkipDeadNodesRequest{Version: newVersion, AllowMissingData: true}
-	if _, err := layoutClient.ClusterLayoutSkipDeadNodes(ctx, skipReq); err != nil && !garage.IsBadRequest(err) {
-		log.V(1).Info("skip-dead-nodes after tombstone removal failed", "error", err)
+	// Re-read for the authoritative current version. A concurrent writer may have
+	// advanced past layout.Version+1, so the guess is unsafe for skip-dead-nodes;
+	// only call it when we actually obtained a fresh version (the next reconcile
+	// re-drives this cleanup otherwise).
+	newVersion, ok := reReadLayoutVersion(ctx, layoutClient)
+	if ok {
+		log.Info("Removed stale gateway entries from layout", "count", len(stale), "version", newVersion)
+		skipReq := garage.SkipDeadNodesRequest{Version: newVersion, AllowMissingData: true}
+		if _, err := layoutClient.ClusterLayoutSkipDeadNodes(ctx, skipReq); err != nil && !garage.IsBadRequest(err) {
+			log.V(1).Info("skip-dead-nodes after tombstone removal failed", "error", err)
+		}
+	} else {
+		log.Info("Removed stale gateway entries from layout (could not re-read version; skip-dead-nodes deferred to next reconcile)", "count", len(stale))
 	}
 
 	cluster.Status.PendingGatewayTombstones = nil
@@ -542,4 +540,51 @@ func (r *GarageClusterReconciler) gatewayLayoutClient(ctx context.Context, clust
 		return r.getExternalStorageClient(ctx, cluster)
 	}
 	return nil, fmt.Errorf("connectTo missing clusterRef or adminApiEndpoint")
+}
+
+// localGatewayZone returns the layout zone the operator assigns to this
+// cluster's gateway roles. It mirrors the defaulting in
+// buildAutoModeGatewayNode (empty spec.zone => defaultZoneName) so the
+// tombstone reaper matches its own roles even when spec.zone is unset.
+func localGatewayZone(cluster *garagev1beta2.GarageCluster) string {
+	if cluster.Spec.Zone == "" {
+		return defaultZoneName
+	}
+	return cluster.Spec.Zone
+}
+
+// staleGatewayRoles returns the IDs of gateway layout roles owned by this
+// cluster that are no longer backed by a live or operator-claimed gateway node
+// and are therefore safe to remove. It is scoped to localZone: a role in any
+// other zone belongs to a different federated region and is skipped entirely
+// (#220). A role qualifies only when it carries BOTH the cluster ownership tag
+// and the tier:gateway tag, sits in localZone, and is neither live (isUp) nor
+// claimed by a live operator-owned gateway GarageNode CR.
+func staleGatewayRoles(roles []garage.LayoutNodeRole, localZone, clusterName, clusterNamespace string, live, claimed map[string]bool) []string {
+	ownershipTag := fmt.Sprintf("cluster:%s/%s", clusterName, clusterNamespace)
+	tierTag := "tier:" + tierGateway
+	var stale []string
+	for _, role := range roles {
+		if role.Zone != localZone {
+			continue
+		}
+		ownsThis := false
+		isGatewayTier := false
+		for _, tag := range role.Tags {
+			if tag == ownershipTag {
+				ownsThis = true
+			}
+			if tag == tierTag {
+				isGatewayTier = true
+			}
+		}
+		if !ownsThis || !isGatewayTier {
+			continue
+		}
+		if live[role.ID] || claimed[role.ID] {
+			continue
+		}
+		stale = append(stale, role.ID)
+	}
+	return stale
 }

--- a/internal/controller/garagecluster_gateway_reaper_test.go
+++ b/internal/controller/garagecluster_gateway_reaper_test.go
@@ -1,0 +1,53 @@
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rajsinghtech/garage-operator/internal/garage"
+)
+
+// Federated regions share the same cluster:<name>/<ns> ownership tag; the
+// reaper must only consider gateway roles in its own zone, never another
+// region's (#220).
+func TestStaleGatewayRoles_ZoneScoped(t *testing.T) {
+	ownTag := "cluster:gc/garage"
+	tierTag := testTierGatewayTag
+	roles := []garage.LayoutNodeRole{
+		// local zone, not live/claimed -> stale, must be returned
+		{ID: "local-dead", Zone: testZone, Tags: []string{ownTag, tierTag}},
+		// remote region zone, same ownership+tier tags, not live/claimed ->
+		// must be SKIPPED (belongs to another federated region)
+		{ID: "remote-dead", Zone: "eu-west-1", Tags: []string{ownTag, tierTag}},
+	}
+	live := map[string]bool{}
+	claimed := map[string]bool{}
+
+	got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed)
+	want := []string{"local-dead"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("staleGatewayRoles zone scoping: got %v, want %v", got, want)
+	}
+}
+
+// Within the local zone, live and operator-claimed roles are preserved; only a
+// genuinely orphaned role is reaped. A storage-tier role in the same zone (no
+// tier:gateway tag) is never touched.
+func TestStaleGatewayRoles_LivePreservedTierFiltered(t *testing.T) {
+	ownTag := "cluster:gc/garage"
+	tierTag := testTierGatewayTag
+	roles := []garage.LayoutNodeRole{
+		{ID: "gw-live", Zone: testZone, Tags: []string{ownTag, tierTag}},
+		{ID: "gw-claimed", Zone: testZone, Tags: []string{ownTag, tierTag}},
+		{ID: "gw-orphan", Zone: testZone, Tags: []string{ownTag, tierTag}},
+		{ID: "storage-role", Zone: testZone, Tags: []string{ownTag, testTierStorageTag}},
+	}
+	live := map[string]bool{"gw-live": true}
+	claimed := map[string]bool{"gw-claimed": true}
+
+	got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed)
+	want := []string{"gw-orphan"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("staleGatewayRoles: got %v, want %v", got, want)
+	}
+}

--- a/internal/controller/garagecluster_health.go
+++ b/internal/controller/garagecluster_health.go
@@ -42,7 +42,10 @@ const peerUnreachableThreshold = 10 * time.Minute
 
 // computeUnreachablePeers returns "<shortId> (down <duration>)" descriptions for
 // peers that are not up and were last seen longer ago than the threshold. A peer
-// with no lastSeenSecsAgo (never seen) is also flagged.
+// with no lastSeenSecsAgo (never seen) is flagged only when it holds a layout
+// role — i.e. an expected member that never joined; a never-seen roleless peer
+// is bootstrap/federation discovery noise and is skipped so the condition does
+// not flap during startup.
 func computeUnreachablePeers(nodes []garage.NodeInfo) []string {
 	var out []string
 	for _, n := range nodes {
@@ -55,6 +58,13 @@ func computeUnreachablePeers(nodes []garage.NodeInfo) []string {
 			if time.Duration(secs)*time.Second < peerUnreachableThreshold {
 				continue // transient — not yet sustained
 			}
+		} else if n.Role == nil {
+			// Never seen AND not an expected layout member: a peer Garage has
+			// merely discovered (bootstrap / federation gossip) but that never
+			// joined and holds no role. Flagging it would flap PeerUnreachable
+			// during startup. Only a never-seen peer that DOES hold a layout
+			// role is a genuine missing member.
+			continue
 		}
 		short := n.ID
 		if len(short) > 16 {
@@ -213,6 +223,31 @@ func setClusterHealthConditions(cluster *garagev1beta2.GarageCluster) {
 			Status:             metav1.ConditionFalse,
 			Reason:             garagev1beta1.ReasonPeersReachable,
 			Message:            "all known peers are reachable",
+			ObservedGeneration: gen,
+		})
+	}
+
+	// --- GatewayLayoutDegraded: gateway nodes missing their layout role -----
+	if len(cluster.Status.GatewayNodesNotInLayout) > 0 {
+		msg := fmt.Sprintf(
+			"gateway nodes not in layout: %s; they have lost the capacity:nil role that keeps S3 sig-auth local, "+
+				"so key/bucket lookups fall back to a per-request quorum RPC to storage — set the "+
+				"garage.rajsingh.info/force-layout-apply annotation to re-stage the gateway roles",
+			strings.Join(cluster.Status.GatewayNodesNotInLayout, ", "))
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayLayoutDegraded,
+			Status:             metav1.ConditionTrue,
+			Reason:             garagev1beta1.ReasonGatewayRoleMissing,
+			Message:            msg,
+			ObservedGeneration: gen,
+		})
+		diagnoses = append(diagnoses, msg)
+	} else {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayLayoutDegraded,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonGatewayRolesPresent,
+			Message:            "all gateway nodes hold their layout role",
 			ObservedGeneration: gen,
 		})
 	}

--- a/internal/controller/garagecluster_health_test.go
+++ b/internal/controller/garagecluster_health_test.go
@@ -164,7 +164,10 @@ func TestComputeUnreachablePeers(t *testing.T) {
 		{ID: "aaaaaaaaaaaaaaaaaaaa", IsUp: true},                             // up → ignored
 		{ID: "bbbbbbbbbbbbbbbbbbbb", IsUp: false, LastSeenSecsAgo: up(120)},  // 2m down → transient
 		{ID: "cccccccccccccccccccc", IsUp: false, LastSeenSecsAgo: up(1800)}, // 30m down → flagged
-		{ID: "dddddddddddddddddddd", IsUp: false, LastSeenSecsAgo: nil},      // never seen → flagged
+		// never seen but holds a layout role → expected member, flagged
+		{ID: "dddddddddddddddddddd", IsUp: false, LastSeenSecsAgo: nil, Role: &garage.NodeAssignedRole{Zone: "z"}},
+		// never seen and roleless → bootstrap discovery noise, skipped
+		{ID: "eeeeeeeeeeeeeeeeeeee", IsUp: false, LastSeenSecsAgo: nil},
 	}
 	got := computeUnreachablePeers(nodes)
 	if len(got) != 2 {
@@ -175,6 +178,9 @@ func TestComputeUnreachablePeers(t *testing.T) {
 	}
 	if !strings.Contains(got[1], "never seen") {
 		t.Fatalf("expected a never-seen entry, got %q", got[1])
+	}
+	if strings.Contains(strings.Join(got, "|"), "eeeeeeee") {
+		t.Fatal("roleless never-seen peer must be skipped")
 	}
 }
 
@@ -199,6 +205,29 @@ func TestSetClusterHealthConditions_PeerUnreachable(t *testing.T) {
 	setClusterHealthConditions(cluster)
 	if st, _ := condStatus(cluster, garagev1beta1.ConditionPeerUnreachable); st != metav1.ConditionFalse {
 		t.Fatalf("expected PeerUnreachable=False after recovery, got %v", st)
+	}
+}
+
+func TestSetClusterHealthConditions_GatewayLayoutDegraded(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{
+		Status: garagev1beta2.GarageClusterStatus{
+			Health:                  &garagev1beta2.ClusterHealth{Partitions: 256, PartitionsQuorum: 256},
+			GatewayNodesNotInLayout: []string{"gc-gateway-0"},
+		},
+	}
+	setClusterHealthConditions(cluster)
+	st, ok := condStatus(cluster, garagev1beta1.ConditionGatewayLayoutDegraded)
+	if !ok || st != metav1.ConditionTrue {
+		t.Fatalf("expected GatewayLayoutDegraded=True, got %v (present=%v)", st, ok)
+	}
+	if cluster.Status.LayoutDiagnosis == "" {
+		t.Fatal("expected a diagnosis when a gateway node is out of layout")
+	}
+	// Clears when the role returns.
+	cluster.Status.GatewayNodesNotInLayout = nil
+	setClusterHealthConditions(cluster)
+	if st, _ := condStatus(cluster, garagev1beta1.ConditionGatewayLayoutDegraded); st != metav1.ConditionFalse {
+		t.Fatalf("expected GatewayLayoutDegraded=False after recovery, got %v", st)
 	}
 }
 

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -200,14 +200,17 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if operatorSuspended && !userSuspended {
 			reason, message = "OperatorSuspended", fmt.Sprintf("Reconciliation paused by operation %q", op)
 		}
-		meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
-			Type:               "Suspended",
-			Status:             metav1.ConditionTrue,
-			Reason:             reason,
-			Message:            message,
-			ObservedGeneration: node.Generation,
-		})
-		if err := r.Status().Update(ctx, node); err != nil {
+		applySuspended := func() {
+			meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
+				Type:               "Suspended",
+				Status:             metav1.ConditionTrue,
+				Reason:             reason,
+				Message:            message,
+				ObservedGeneration: node.Generation,
+			})
+		}
+		applySuspended()
+		if err := UpdateStatusWithRetry(ctx, r.Client, node, applySuspended); err != nil {
 			return ctrl.Result{}, err
 		}
 		log.Info("GarageNode reconciliation paused", "reason", reason)
@@ -1499,19 +1502,24 @@ func (r *GarageNodeReconciler) finalize(ctx context.Context, node *garagev1beta1
 		return fmt.Errorf("failed to apply layout removal: %w", err)
 	}
 
-	// Re-read the committed version for logging and the gateway skip-dead-nodes
-	// call (ApplyStagedLayoutChanges does not surface the version it applied,
-	// and a concurrent writer may have advanced it past our local target).
-	appliedVersion := layout.Version + 1
-	if cur, gerr := garageClient.GetClusterLayout(ctx); gerr == nil {
-		appliedVersion = cur.Version
+	// Re-read the committed version. ApplyStagedLayoutChanges does not surface
+	// the version it applied, and a concurrent writer may have advanced it past
+	// our local target (V+2), so layout.Version+1 is an unreliable guess. The
+	// re-read is the only authoritative source of the current version.
+	appliedVersion, ok := reReadLayoutVersion(ctx, garageClient)
+	if ok {
+		log.Info("Removed node from layout", "version", appliedVersion)
+	} else {
+		log.Info("Removed node from layout (could not re-read committed version)")
 	}
-	log.Info("Removed node from layout", "version", appliedVersion)
 
 	// For gateway nodes, immediately skip dead nodes. Gateways own no partitions
 	// so this is belt-and-suspenders (it advances ack/sync trackers so the
 	// removed entry never lingers in a Draining version), not a data operation.
-	if node.Spec.Gateway {
+	// Only attempt it when we have a freshly re-read version — calling
+	// skip-dead-nodes against a guessed/stale version is worse than skipping it,
+	// and a later reconcile (or reconcileGatewayTombstones) re-drives the cleanup.
+	if node.Spec.Gateway && ok {
 		skipReq := garage.SkipDeadNodesRequest{
 			Version:          appliedVersion,
 			AllowMissingData: true,
@@ -1529,6 +1537,20 @@ func (r *GarageNodeReconciler) finalize(ctx context.Context, node *garagev1beta1
 	}
 
 	return nil
+}
+
+// reReadLayoutVersion re-reads the cluster layout to obtain the authoritative
+// current version after an apply, retrying once on transient error. The bool
+// reports whether a version was obtained; callers MUST NOT fall back to a
+// guessed version (e.g. local+1) for skip-dead-nodes, because a concurrent
+// writer may have advanced the version past the local target.
+func reReadLayoutVersion(ctx context.Context, garageClient *garage.Client) (uint64, bool) {
+	for attempt := 0; attempt < 2; attempt++ {
+		if cur, err := garageClient.GetClusterLayout(ctx); err == nil {
+			return cur.Version, true
+		}
+	}
+	return 0, false
 }
 
 func (r *GarageNodeReconciler) updateStatus(ctx context.Context, node *garagev1beta1.GarageNode, phase string, err error) (ctrl.Result, error) {
@@ -1796,6 +1818,18 @@ func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node 
 						if cap := r.lookupPVCCapacity(ctx, cluster.Namespace, dp.ExistingClaim); cap != "" {
 							p.Capacity = cap
 						}
+					}
+					// Upstream make_data_dirs (../garage src/block/layout.rs)
+					// rejects any data_dir entry that is neither read_only nor
+					// capacity-bearing, so Garage refuses to start and the pod
+					// crashloops. Refuse to render an invalid data_dir: fail the
+					// reconcile so the node goes PhaseFailed and requeues. When
+					// the entry is pinned to a still-Pending PVC (no requested or
+					// status capacity yet) the requeue lets capacity resolve once
+					// the claim binds; when no capacity is configurable at all the
+					// message tells the operator exactly which disk to fix.
+					if p.Capacity == "" {
+						return fmt.Errorf("data_dir entry %d (path %q) has no capacity: set spec.storage.dataPaths[%d].size, mark it readOnly, or wait for its existingClaim PVC to bind with a requested size", i, p.Path, i)
 					}
 				}
 				paths = append(paths, p)

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -1135,6 +1135,83 @@ var _ = Describe("GarageNode multi-HDD storage layout", func() {
 		Expect(toml).To(ContainSubstring(`{ path = "/data/data-1", capacity = "44Gi" }`))
 	})
 
+	// #219: a non-readOnly dataPaths[] entry with neither Size nor a bound
+	// existingClaim resolves to no capacity. Upstream make_data_dirs rejects
+	// such an entry (no capacity, not read_only), so emitting it crashloops the
+	// pod. The renderer must fail the reconcile (PhaseFailed + requeue) instead.
+	It("fails the reconcile when a non-readOnly dataPaths[] entry has no resolvable capacity (#219)", func() {
+		cluster := makeCluster(ctx)
+		nodeName := "no-capacity-node"
+		capacity := resource.MustParse("100Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &capacity,
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata:  &garagev1beta1.NodeVolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					DataPaths: []garagev1beta1.NodeVolumeConfig{{}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		defer func() {
+			n := &garagev1beta1.GarageNode{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, n); err == nil {
+				n.Finalizers = nil
+				_ = k8sClient.Update(ctx, n)
+				_ = k8sClient.Delete(ctx, n)
+			}
+			_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-config", Namespace: testNamespace}})
+		}()
+
+		r := &GarageNodeReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		err := r.reconcileNodeConfigMap(ctx, node, cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("has no capacity"))
+
+		// No invalid ConfigMap should have been written.
+		cm := &corev1.ConfigMap{}
+		getErr := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName + "-config", Namespace: testNamespace}, cm)
+		Expect(errors.IsNotFound(getErr)).To(BeTrue())
+	})
+
+	// #219 positive control: a readOnly entry needs no capacity and still renders.
+	It("renders a readOnly dataPaths[] entry with no capacity (#219)", func() {
+		cluster := makeCluster(ctx)
+		nodeName := "readonly-no-capacity-node"
+		capacity := resource.MustParse("100Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &capacity,
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata:  &garagev1beta1.NodeVolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					DataPaths: []garagev1beta1.NodeVolumeConfig{{ReadOnly: true}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		defer func() {
+			n := &garagev1beta1.GarageNode{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, n); err == nil {
+				n.Finalizers = nil
+				_ = k8sClient.Update(ctx, n)
+				_ = k8sClient.Delete(ctx, n)
+			}
+			_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-config", Namespace: testNamespace}})
+		}()
+
+		r := &GarageNodeReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		Expect(r.reconcileNodeConfigMap(ctx, node, cluster)).To(Succeed())
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName + "-config", Namespace: testNamespace}, cm)).To(Succeed())
+		Expect(cm.Data["garage.toml"]).To(ContainSubstring(`{ path = "/data/data-0", read_only = true }`))
+	})
+
 	// #205 follow-up: dataPaths[].path honored in both K8s mount and TOML.
 	It("uses dp.Path as the mount + TOML path; ReadOnly drops capacity", func() {
 		cluster := makeCluster(ctx)

--- a/internal/controller/garagereferencegrant_controller.go
+++ b/internal/controller/garagereferencegrant_controller.go
@@ -168,17 +168,65 @@ func crossNSRefsGrant(ref *garagev1beta1.ClusterReference, resourceNS string, gr
 	return targetNS == grant.Namespace && resourceNS != grant.Namespace
 }
 
+// grantTargetNamespaces returns the set of namespaces a changed key/bucket/token
+// references cross-namespace. A GarageReferenceGrant only governs references that
+// land in its own namespace, so these are the only namespaces whose grants can be
+// affected by a change to obj. Same-namespace references are skipped (no grant
+// applies). The logic mirrors crossNSRefsGrant / findUsers so the watch trigger
+// and the reconcile scan stay in agreement.
+func grantTargetNamespaces(obj client.Object) []string {
+	srcNS := obj.GetNamespace()
+	seen := map[string]bool{}
+	var out []string
+	add := func(refNS string) {
+		if refNS == "" {
+			refNS = srcNS
+		}
+		if refNS == srcNS || seen[refNS] {
+			return
+		}
+		seen[refNS] = true
+		out = append(out, refNS)
+	}
+
+	switch o := obj.(type) {
+	case *garagev1beta1.GarageKey:
+		add(o.Spec.ClusterRef.Namespace)
+		for _, bp := range o.Spec.BucketPermissions {
+			if bp.BucketRef != nil {
+				add(bp.BucketRef.Namespace)
+			}
+		}
+	case *garagev1beta1.GarageBucket:
+		add(o.Spec.ClusterRef.Namespace)
+	case *garagev1beta1.GarageAdminToken:
+		add(o.Spec.ClusterRef.Namespace)
+	}
+	return out
+}
+
 // SetupWithManager wires up the controller.
 func (r *GarageReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	mapToGrants := func(ctx context.Context, obj client.Object) []reconcile.Request {
-		var grants garagev1beta1.GarageReferenceGrantList
-		if err := mgr.GetClient().List(ctx, &grants); err != nil {
-			return nil
-		}
-		reqs := make([]reconcile.Request, len(grants.Items))
-		for i, g := range grants.Items {
-			reqs[i] = reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: g.Name, Namespace: g.Namespace},
+		// A grant in namespace N only governs cross-namespace references INTO N.
+		// So a changed key/bucket/token can only affect grants living in the
+		// namespace(s) it actually targets — list just those, never cluster-wide.
+		var reqs []reconcile.Request
+		seen := map[string]bool{}
+		for _, ns := range grantTargetNamespaces(obj) {
+			var grants garagev1beta1.GarageReferenceGrantList
+			if err := mgr.GetClient().List(ctx, &grants, client.InNamespace(ns)); err != nil {
+				continue
+			}
+			for _, g := range grants.Items {
+				key := g.Namespace + "/" + g.Name
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: g.Name, Namespace: g.Namespace},
+				})
 			}
 		}
 		return reqs

--- a/internal/controller/garagereferencegrant_controller_test.go
+++ b/internal/controller/garagereferencegrant_controller_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+)
+
+// test namespace names used across the reference-grant table tests
+const (
+	nsApp     = "app"
+	nsStorage = "storage"
+	nsData    = "data"
+)
+
+func TestGrantTargetNamespaces(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "key with cross-ns cluster and bucket refs",
+			obj: &garagev1beta1.GarageKey{
+				ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: nsApp},
+				Spec: garagev1beta1.GarageKeySpec{
+					ClusterRef: garagev1beta1.ClusterReference{Namespace: nsStorage},
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketRef: &garagev1beta1.BucketRef{Name: "b", Namespace: nsData}},
+					},
+				},
+			},
+			want: []string{nsData, nsStorage},
+		},
+		{
+			name: "key with same-ns refs only",
+			obj: &garagev1beta1.GarageKey{
+				ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: nsApp},
+				Spec: garagev1beta1.GarageKeySpec{
+					ClusterRef: garagev1beta1.ClusterReference{Namespace: ""},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "bucket with cross-ns cluster ref",
+			obj: &garagev1beta1.GarageBucket{
+				ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: nsApp},
+				Spec: garagev1beta1.GarageBucketSpec{
+					ClusterRef: garagev1beta1.ClusterReference{Namespace: nsStorage},
+				},
+			},
+			want: []string{nsStorage},
+		},
+		{
+			name: "admin token with explicit same-ns cluster ref",
+			obj: &garagev1beta1.GarageAdminToken{
+				ObjectMeta: metav1.ObjectMeta{Name: "t", Namespace: nsApp},
+				Spec: garagev1beta1.GarageAdminTokenSpec{
+					ClusterRef: garagev1beta1.ClusterReference{Namespace: nsApp},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "key with two bucket refs into same ns dedups",
+			obj: &garagev1beta1.GarageKey{
+				ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: nsApp},
+				Spec: garagev1beta1.GarageKeySpec{
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketRef: &garagev1beta1.BucketRef{Name: "b1", Namespace: nsData}},
+						{BucketRef: &garagev1beta1.BucketRef{Name: "b2", Namespace: nsData}},
+					},
+				},
+			},
+			want: []string{nsData},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := grantTargetNamespaces(tt.obj)
+			sort.Strings(got)
+			want := append([]string(nil), tt.want...)
+			sort.Strings(want)
+			if len(got) != len(want) {
+				t.Fatalf("grantTargetNamespaces = %v, want %v", got, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("grantTargetNamespaces = %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestMapToGrantsScoped(t *testing.T) {
+	s := fmScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(
+		&garagev1beta1.GarageReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: "g-storage", Namespace: nsStorage},
+		},
+		&garagev1beta1.GarageReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: "g-other", Namespace: "other"},
+		},
+	).Build()
+
+	// Mirror the SetupWithManager mapToGrants closure against the fake client.
+	mapToGrants := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		var reqs []reconcile.Request
+		seen := map[string]bool{}
+		for _, ns := range grantTargetNamespaces(obj) {
+			var grants garagev1beta1.GarageReferenceGrantList
+			if err := c.List(ctx, &grants, client.InNamespace(ns)); err != nil {
+				continue
+			}
+			for _, g := range grants.Items {
+				key := g.Namespace + "/" + g.Name
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: g.Name, Namespace: g.Namespace},
+				})
+			}
+		}
+		return reqs
+	}
+
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: nsApp},
+		Spec: garagev1beta1.GarageKeySpec{
+			ClusterRef: garagev1beta1.ClusterReference{Namespace: nsStorage},
+		},
+	}
+
+	reqs := mapToGrants(context.Background(), key)
+	if len(reqs) != 1 {
+		t.Fatalf("mapToGrants returned %d requests, want 1: %v", len(reqs), reqs)
+	}
+	want := reconcile.Request{NamespacedName: types.NamespacedName{Name: "g-storage", Namespace: nsStorage}}
+	if reqs[0] != want {
+		t.Fatalf("mapToGrants = %v, want %v (g-other in unrelated ns must not be enqueued)", reqs[0], want)
+	}
+}

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -330,6 +330,11 @@ func isTransientConnectivityError(err error) bool {
 	if err == nil {
 		return false
 	}
+	// A Garage 503 is a transient quorum/timeout/remote-node failure
+	// (src/api/common/common_error.rs), retryable just like a dial failure.
+	if garage.IsServiceUnavailable(err) {
+		return true
+	}
 	msg := err.Error()
 	for _, substr := range []string{
 		"no such host",

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -77,6 +77,19 @@ func IsBadRequest(err error) bool {
 	return false
 }
 
+// IsServiceUnavailable returns true if the error is a 503 Service Unavailable error.
+// Garage maps transient quorum/timeout/remote-node failures to HTTP 503
+// (GarageError::{Timeout, RemoteError, Quorum} -> SERVICE_UNAVAILABLE; see upstream
+// src/api/common/common_error.rs http_status_code). These are retryable: the same
+// request typically succeeds once a quorum of nodes is reachable again.
+func IsServiceUnavailable(err error) bool {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusServiceUnavailable
+	}
+	return false
+}
+
 // IsBucketNotEmpty returns true if the error is a BucketNotEmpty error (409 Conflict with specific code)
 func IsBucketNotEmpty(err error) bool {
 	var apiErr *APIError

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -224,6 +224,53 @@ func TestIsReplicationConstraint(t *testing.T) {
 	}
 }
 
+func TestIsServiceUnavailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "503 quorum error",
+			err:      &APIError{StatusCode: 503, Message: "Not enough nodes available to read quorum"},
+			expected: true,
+		},
+		{
+			name:     "503 timeout error",
+			err:      &APIError{StatusCode: http.StatusServiceUnavailable, Message: "Timeout"},
+			expected: true,
+		},
+		{
+			name:     "500 internal error",
+			err:      &APIError{StatusCode: 500, Message: "Internal server error"},
+			expected: false,
+		},
+		{
+			name:     "409 conflict",
+			err:      &APIError{StatusCode: 409, Message: "Conflict"},
+			expected: false,
+		},
+		{
+			name:     "non-API error",
+			err:      fmt.Errorf("network timeout"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsServiceUnavailable(tt.err); got != tt.expected {
+				t.Errorf("IsServiceUnavailable() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestWorkerState_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/schemas/garagebucket_v1beta1.json
+++ b/schemas/garagebucket_v1beta1.json
@@ -438,6 +438,13 @@
           },
           "type": "array"
         },
+        "managedKeyGrants": {
+          "description": "ManagedKeyGrants lists the access key IDs this bucket's spec.keyPermissions\nlast granted access to. Used to revoke grants when a keyRef is dropped\nfrom the spec, without disturbing grants made via a GarageKey's\nbucketPermissions/allBuckets or by hand.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "observedGeneration": {
           "description": "ObservedGeneration is the last observed generation",
           "format": "int64",

--- a/schemas/garagecluster_v1beta2.json
+++ b/schemas/garagecluster_v1beta2.json
@@ -6306,6 +6306,11 @@
               ],
               "type": "string"
             },
+            "phaseStartedAt": {
+              "description": "PhaseStartedAt is when the current Phase was entered. It is reset on every\nphase transition and bounds each wait phase independently of the overall\nmigration duration, so a single phase that hangs (e.g. a node whose\nstatus.nodeId never repopulates after restart) trips the stuck guard\nrather than the whole migration sharing one global deadline.",
+              "format": "date-time",
+              "type": "string"
+            },
             "purgeId": {
               "description": "PurgeID uniquely identifies this migration; it is the marker-file suffix the\nper-node init container uses so the on-disk cluster_layout is deleted exactly\nonce even across extra restarts.",
               "type": "string"
@@ -6322,6 +6327,13 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "gatewayNodesNotInLayout": {
+          "description": "GatewayNodesNotInLayout lists operator-owned gateway GarageNodes that report\nstatus.inLayout == false \u2014 they have lost the capacity:nil layout role that\nkeeps S3 sig-auth local (#209) and have silently degraded to quorum auth.\nDrives the GatewayLayoutDegraded condition. Empty when every gateway node\nholds its role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "gatewayReadyReplicas": {
           "description": "GatewayReadyReplicas is the number of ready gateway-tier pods.",


### PR DESCRIPTION
Closes **#218, #219, #220, #221** — every open code issue from the v0.6.6 review and the live gateway incident. Built via per-area engineering specs (design → implement → validate); full envtest suite + golangci-lint green locally.

## Gateway / production-incident fixes
- **#220 — federated tombstone reaper zone-scoping.** The reaper now skips gateway roles outside the local zone (`staleGatewayRoles`/`localGatewayZone`), so a region no longer reaps another region's gateway layout roles. This is the root cause of the cross-region layout churn that took the gateway S3 path down; it lets `layoutManagement.autoApply` be safely re-enabled.
- **#221 — gateway identity survives upgrades.** The per-node gateway StatefulSet adopts its existing metadata PVC (`migrateLegacyGatewaySTSIfNeeded`), so the `node_key` and its `capacity:null` role persist across an operator/chart upgrade.
- **#218 — per-ordinal gateway dial.** `parseRemoteGatewayOrdinal` parses the real `<cluster>-gateway-<N>-0` tag instead of a hardcoded `garage-gateway-` prefix.

## #219 hardening backlog (all items)
- 409-safe cluster status writers (apply-closure re-applies computed status).
- 5s per-call timeouts on the storage bootstrap path.
- Dangling key-grant revocation (scoped to `Status.ManagedKeyGrants`) + no-op skip when unchanged.
- `IsServiceUnavailable` (503) → transient requeue.
- Multi-HDD capacity-less `dataPaths[]` → actionable failure, not a crashloop.
- Auto scale-down below `replication.factor` refused with `StorageScaleDownBlocked`.
- v1beta1→v1beta2 gateway conversion rejects lossy fields; v1beta2 validates gateway-tier metadata volume.
- Factor migration: per-phase stuck timeout + Rebuilding/Purging guards.
- `GatewayLayoutDegraded` condition; `PeerUnreachable` debounce; single-replica gateway PDB drainable (`maxUnavailable=1`); namespace-scoped ReferenceGrant watch; ConfigMap/STS label+ownerRef self-heal; maintenance-suspend status retry; tightened legacy PVC adoption.

## Validation
`make generate manifests` (CRDs/deepcopy/schemas regenerated for the new status fields + condition constants), `go build`/`go vet`, `golangci-lint` (0 issues), and the full envtest suite (162 specs) all pass locally. New unit + envtest coverage added for each fix.

## Process
Engineering-planned with multi-agent design/implementation workflows (one agent per file/area, no shared-file races) + adversarial review. The factor-migration timeout area's `PhaseStartedAt` adds a CRD status field (codegen included).