### PR TITLE
fix: preserve tier tags on federated imports + reap tag-stripped gateway orphans (#224)

### DIFF
--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -638,6 +638,9 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 			Expect(updatedRoles).To(HaveLen(1))
 			Expect(updatedRoles[0].ID).To(Equal("fedcba9876543210fedcba98newnode01"))
 			Expect(updatedRoles[0].Zone).To(Equal(testZoneRemote))
+			// Recovery path gets the same tag treatment as the remoteStatus path:
+			// remote.Name retained + tier derived from capacity (#224).
+			Expect(updatedRoles[0].Tags).To(ContainElements("tier:storage", testTagRemoteCluster))
 		})
 
 		It("should not stage nodes that are already in the layout", func() {
@@ -722,12 +725,12 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					{
 						ID:   "fedcba9876543210fedcba98fromapi1",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap}, // storage
 					},
 					{
 						ID:   "fedcba9876543210fedcba98fromapi2",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: nil}, // gateway
 					},
 				},
 			}
@@ -751,8 +754,103 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 
 			// Should have staged both remote nodes from remoteStatus
 			Expect(updatedRoles).To(HaveLen(2))
-			ids := []string{updatedRoles[0].ID, updatedRoles[1].ID}
-			Expect(ids).To(ContainElements("fedcba9876543210fedcba98fromapi1", "fedcba9876543210fedcba98fromapi2"))
+			byID := map[string]garage.NodeRoleChange{}
+			for _, role := range updatedRoles {
+				byID[role.ID] = role
+			}
+			Expect(byID).To(HaveKey("fedcba9876543210fedcba98fromapi1"))
+			Expect(byID).To(HaveKey("fedcba9876543210fedcba98fromapi2"))
+			// Tier derived from capacity; remote.Name retained for removeStaleRemoteNodes;
+			// a cluster:<remote>/<ns> ownership tag added so tier-aware logic recognizes it (#224).
+			storage := byID["fedcba9876543210fedcba98fromapi1"]
+			gateway := byID["fedcba9876543210fedcba98fromapi2"]
+			Expect(storage.Tags).To(ContainElements("tier:storage", testTagRemoteCluster))
+			Expect(gateway.Tags).To(ContainElements("tier:gateway", testTagRemoteCluster))
+			Expect(gateway.Tags).To(ContainElement(HavePrefix("cluster:")))
+		})
+
+		It("should skip importing a remote node that is reported down", func() {
+			cap := uint64(107374182400)
+			var updatedRoles []garage.NodeRoleChange
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case pathGetClusterLayout:
+					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
+						Version: 1,
+						Roles:   []garage.LayoutNodeRole{{ID: testFedNodeID1, Zone: testZoneLocal}},
+					})
+				case pathUpdateLayout:
+					var req garage.UpdateClusterLayoutRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					updatedRoles = req.Roles
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+			localClient := garage.NewClient(server.URL, adminToken)
+
+			remoteStatus := &garage.ClusterStatus{
+				Nodes: []garage.NodeInfo{
+					{ID: "fedcba9876543210fedcba98upnode01", IsUp: true, Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap}},
+					{ID: "fedcba9876543210fedcba98downnode1", IsUp: false, Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Capacity: &cap}},
+				},
+			}
+			localStatus := &garage.ClusterStatus{Nodes: []garage.NodeInfo{{ID: testFedNodeID1, IsUp: true, Role: &garage.NodeAssignedRole{Zone: testZoneLocal}}}}
+			remote := garagev1beta2.RemoteClusterConfig{Name: testTagRemoteCluster, Zone: testZoneRemote}
+
+			err := reconciler.addRemoteNodesToLayout(ctx, cluster, localClient, garage.NewClient(server.URL, adminToken), remoteStatus, localStatus, remote)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Only the up node is imported; the down node is skipped (#224: avoids
+			// re-importing a just-orphaned node before its removal propagates).
+			Expect(updatedRoles).To(HaveLen(1))
+			Expect(updatedRoles[0].ID).To(Equal("fedcba9876543210fedcba98upnode01"))
+		})
+	})
+
+	Context("removeStaleRemoteNodes (#224 regression)", func() {
+		It("still matches imported roles by the remote.Name tag after tier tags were added", func() {
+			var staged []garage.NodeRoleChange
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case pathGetClusterLayout:
+					// Re-fetch after staging: report nothing staged so ApplyStagedLayoutChanges no-ops.
+					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{Version: 2})
+				case pathUpdateLayout:
+					var req garage.UpdateClusterLayoutRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					staged = req.Roles
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+			localClient := garage.NewClient(server.URL, adminToken)
+
+			remote := garagev1beta2.RemoteClusterConfig{Name: testTagRemoteCluster, Zone: testZoneRemote}
+			staleID := "fedcba9876543210fedcba98stale001"
+			// Imported role carrying the NEW full tag set (ownership + tier:gateway + remote.Name);
+			// its node ID is absent from remoteStatus, so it must be flagged stale via remote.Name.
+			layout := &garage.ClusterLayout{
+				Version: 1,
+				Roles: []garage.LayoutNodeRole{
+					{ID: staleID, Zone: testZoneRemote, Tags: remoteImportTags(remote, cluster.Namespace, nil)},
+				},
+			}
+			remoteStatus := &garage.ClusterStatus{Nodes: []garage.NodeInfo{
+				{ID: "fedcba9876543210fedcba98live0001", IsUp: true},
+			}}
+
+			err := reconciler.removeStaleRemoteNodes(ctx, localClient, layout, remoteStatus, remote)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(staged).To(HaveLen(1))
+			Expect(staged[0].ID).To(Equal(staleID))
+			Expect(staged[0].Remove).To(BeTrue())
 		})
 	})
 })

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3965,8 +3965,13 @@ func (r *GarageClusterReconciler) connectToRemoteCluster(
 	log := logf.FromContext(ctx)
 
 	// Skip self-connection: if remote zone matches local zone, this is likely
-	// the same cluster listed in remoteClusters (common in templated deployments)
-	if remote.Zone == cluster.Spec.Zone {
+	// the same cluster listed in remoteClusters (common in templated deployments).
+	// Compare against the EFFECTIVE local zone (localGatewayZone applies the same
+	// empty->"default" fallback used when stamping local roles), so an empty
+	// spec.zone cluster still recognizes a remote configured zone:"default" as
+	// self — otherwise its imported capacity:null roles would land in the local
+	// zone where the gateway reaper could mistake them for orphans (#224).
+	if remote.Zone == localGatewayZone(cluster) {
 		log.Info("Skipping self-connection (remote zone matches local zone)", "zone", remote.Zone)
 		return nil
 	}
@@ -4250,6 +4255,30 @@ func parseRemoteGatewayOrdinal(tags []string) (string, bool) {
 	return "", false
 }
 
+// remoteImportTags builds the layout tags for a federated remote node imported into
+// the local layout. remote.Name is kept as a standalone tag because removeStaleRemoteNodes
+// exact-matches it to find imported roles whose node has vanished from the remote cluster.
+// The tier tag (derived from capacity: nil => gateway, non-nil => storage) makes the role
+// tier-identifiable instead of untyped — previously imported roles carried only remote.Name,
+// so when such a gateway role later orphaned in its own zone the owning region's gateway
+// reaper had no tier signal and it stuck forever (#224); the reaper's capacity-shape
+// backstop now also covers that case. (It does NOT let connectRemoteGatewayPods dial the
+// node: that needs a "<name>-gateway-<ordinal>" pod-name tag the import does not carry, so
+// connectRemoteGatewayPods still skips imported nodes — gracefully.) The ownership tag
+// encodes the REMOTE region's name, not the local cluster's, so the local finalizer cleanup
+// and zone-gated reaper never mistake an imported role for local-owned.
+func remoteImportTags(remote garagev1beta2.RemoteClusterConfig, namespace string, capacity *uint64) []string {
+	tier := tierGateway
+	if capacity != nil {
+		tier = tierStorage
+	}
+	return []string{
+		fmt.Sprintf("cluster:%s/%s", remote.Name, namespace),
+		"tier:" + tier,
+		remote.Name,
+	}
+}
+
 // addRemoteNodesToLayout adds remote cluster nodes to the local cluster's layout.
 // This ensures remote nodes participate in data replication with proper zone assignment.
 // It also propagates the cluster's zone redundancy settings to ensure consistent layout parameters.
@@ -4331,6 +4360,16 @@ func (r *GarageClusterReconciler) addRemoteNodesToLayout(
 		if existingNodes[node.ID] {
 			continue // Already in local layout
 		}
+		// Don't (re-)import a node the source reports as down. A node that was just
+		// orphaned and removed from the layout still briefly appears here with its old
+		// role until the removal propagates; re-importing it recreates the orphan — and,
+		// because the import tags it, an orphan that later loses its claim lingers (#224).
+		// A genuinely-down remote node is re-imported automatically once it reports up,
+		// so a false skip is self-correcting (unlike a false import, which sticks).
+		if !node.IsUp {
+			log.V(1).Info("Skipping down remote node during import", "nodeId", shortID(node.ID))
+			continue
+		}
 
 		var role garage.NodeRoleChange
 
@@ -4338,9 +4377,9 @@ func (r *GarageClusterReconciler) addRemoteNodesToLayout(
 			// Node has a committed role - use it
 			role = garage.NodeRoleChange{
 				ID:       node.ID,
-				Zone:     remote.Zone,           // Use configured zone from CRD
-				Tags:     []string{remote.Name}, // Tag with cluster name
-				Capacity: node.Role.Capacity,    // nil = gateway, non-nil = storage
+				Zone:     remote.Zone, // Use configured zone from CRD
+				Tags:     remoteImportTags(remote, cluster.Namespace, node.Role.Capacity),
+				Capacity: node.Role.Capacity, // nil = gateway, non-nil = storage
 			}
 		} else if stagedRole, ok := remoteStagedRoles[node.ID]; ok {
 			// Node doesn't have a committed role but IS in staged changes
@@ -4349,9 +4388,9 @@ func (r *GarageClusterReconciler) addRemoteNodesToLayout(
 			log.V(1).Info("Using staged role for remote node", "nodeId", node.ID[:16]+"...", "zone", remote.Zone)
 			role = garage.NodeRoleChange{
 				ID:       node.ID,
-				Zone:     remote.Zone,           // Use configured zone from CRD
-				Tags:     []string{remote.Name}, // Tag with cluster name
-				Capacity: stagedRole.Capacity,   // Use capacity from staged role
+				Zone:     remote.Zone, // Use configured zone from CRD
+				Tags:     remoteImportTags(remote, cluster.Namespace, stagedRole.Capacity),
+				Capacity: stagedRole.Capacity, // Use capacity from staged role
 			}
 		} else {
 			// Node has no committed or staged role - skip it

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -420,9 +421,19 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 	}
 
 	live := make(map[string]bool, len(status.Nodes))
+	// sustainedDown gates the untagged #224 backstop: a tag-stripped, gateway-shaped
+	// role is only reaped after it has been continuously down past the same dwell
+	// PeerUnreachable uses, so a transient blip — or a briefly-down federated peer
+	// whose role landed in the local zone — is never reaped on a single isUp=false
+	// snapshot (the tagged path keeps its claimed-set protection and needs no dwell).
+	sustainedDown := make(map[string]bool)
 	for _, n := range status.Nodes {
 		if n.IsUp {
 			live[n.ID] = true
+			continue
+		}
+		if n.LastSeenSecsAgo != nil && time.Duration(*n.LastSeenSecsAgo)*time.Second >= peerUnreachableThreshold {
+			sustainedDown[n.ID] = true
 		}
 	}
 
@@ -455,7 +466,15 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 	// churn (#220). The gateway role carries the region's zone (set by
 	// buildAutoModeGatewayNode -> GarageNode layout staging), so only roles whose
 	// zone matches this cluster's zone are ours to remove.
-	stale := staleGatewayRoles(layout.Roles, localGatewayZone(cluster), cluster.Name, cluster.Namespace, live, claimed)
+	// In a unified Auto cluster the reaper runs against the LOCAL layout, where the
+	// only capacity:null roles in the local zone are gateways (storage always carries
+	// non-nil capacity). That lets us reap a local-zone, capacity:null, unclaimed,
+	// down role even if it lost its tier:gateway tag — e.g. a federation re-import
+	// stripped it (#224). Gate this backstop off for edge gateways (claimed map is
+	// empty and the layout is the remote storage cluster's) and for Manual clusters
+	// (user-owned roles aren't claimed), where it could over-reap.
+	hardenUntagged := cluster.HasStorageTier() && cluster.Spec.LayoutPolicy != LayoutPolicyManual
+	stale := staleGatewayRoles(layout.Roles, localGatewayZone(cluster), cluster.Name, cluster.Namespace, live, claimed, sustainedDown, hardenUntagged)
 
 	if len(stale) == 0 {
 		if len(cluster.Status.PendingGatewayTombstones) > 0 {
@@ -560,7 +579,12 @@ func localGatewayZone(cluster *garagev1beta2.GarageCluster) string {
 // (#220). A role qualifies only when it carries BOTH the cluster ownership tag
 // and the tier:gateway tag, sits in localZone, and is neither live (isUp) nor
 // claimed by a live operator-owned gateway GarageNode CR.
-func staleGatewayRoles(roles []garage.LayoutNodeRole, localZone, clusterName, clusterNamespace string, live, claimed map[string]bool) []string {
+// hardenUntagged enables the #224 backstop: reap a local-zone, capacity:null,
+// unclaimed, down role even when it lacks the tier:gateway / ownership tags (e.g. a
+// federation re-import stripped them). The caller sets it only for unified Auto
+// clusters, where local-zone capacity:null roles are exclusively operator-owned
+// gateways and a mid-restart gateway is protected by the claimed set.
+func staleGatewayRoles(roles []garage.LayoutNodeRole, localZone, clusterName, clusterNamespace string, live, claimed, sustainedDown map[string]bool, hardenUntagged bool) []string {
 	ownershipTag := fmt.Sprintf("cluster:%s/%s", clusterName, clusterNamespace)
 	tierTag := "tier:" + tierGateway
 	var stale []string
@@ -578,7 +602,14 @@ func staleGatewayRoles(roles []garage.LayoutNodeRole, localZone, clusterName, cl
 				isGatewayTier = true
 			}
 		}
-		if !ownsThis || !isGatewayTier {
+		tagged := ownsThis && isGatewayTier
+		// Gateway-shaped backstop for tag-stripped orphans (#224): in a unified
+		// cluster the local zone's only capacity:null roles are gateways. Requires
+		// sustainedDown so a transiently-down peer (e.g. an imported federated role
+		// that lands in the local zone) is never reaped on a single snapshot — the
+		// tagged path above stays claimed-protected and needs no dwell.
+		untaggedGatewayShaped := hardenUntagged && role.Capacity == nil && sustainedDown[role.ID]
+		if !tagged && !untaggedGatewayShaped {
 			continue
 		}
 		if live[role.ID] || claimed[role.ID] {

--- a/internal/controller/garagecluster_gateway_reaper_test.go
+++ b/internal/controller/garagecluster_gateway_reaper_test.go
@@ -23,7 +23,7 @@ func TestStaleGatewayRoles_ZoneScoped(t *testing.T) {
 	live := map[string]bool{}
 	claimed := map[string]bool{}
 
-	got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed)
+	got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed, nil, false)
 	want := []string{"local-dead"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("staleGatewayRoles zone scoping: got %v, want %v", got, want)
@@ -45,9 +45,52 @@ func TestStaleGatewayRoles_LivePreservedTierFiltered(t *testing.T) {
 	live := map[string]bool{"gw-live": true}
 	claimed := map[string]bool{"gw-claimed": true}
 
-	got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed)
+	got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed, nil, false)
 	want := []string{"gw-orphan"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("staleGatewayRoles: got %v, want %v", got, want)
+	}
+}
+
+// #224 backstop: a federation re-import can strip a gateway role's tier:gateway /
+// ownership tags, leaving only a remote-name tag, which makes the tag-based path miss
+// it. With hardenUntagged (set for unified Auto clusters) a local-zone, capacity:null,
+// unclaimed, SUSTAINED-down role is reaped by shape even without the tier tag — but the
+// gate must not over-reap (different zone, claimed/live, storage-shaped, not-yet-sustained
+// down, or hardenUntagged off).
+func TestStaleGatewayRoles_HardenUntagged(t *testing.T) {
+	cap := uint64(1 << 40)
+	const strayTag = "someremote" // a federation re-import left only this tag (no tier/ownership)
+	const orphanID = "tagless-orphan"
+	roles := []garage.LayoutNodeRole{
+		// the #224 orphan: local zone, capacity:null, only a stray remote-name tag, sustained down
+		{ID: orphanID, Zone: testZone, Tags: []string{strayTag}, Capacity: nil},
+		// down but NOT sustained (transient blip / briefly-down federated peer): must be preserved
+		{ID: "tagless-blip", Zone: testZone, Tags: []string{strayTag}, Capacity: nil},
+		// live: must be preserved even when tagless+shaped
+		{ID: "tagless-live", Zone: testZone, Tags: []string{strayTag}, Capacity: nil},
+		// claimed by a live GarageNode (mid-restart): must be preserved
+		{ID: "tagless-claimed", Zone: testZone, Tags: []string{strayTag}, Capacity: nil},
+		// different zone: zone gate must skip it
+		{ID: "tagless-remote", Zone: "eu-west-1", Tags: []string{strayTag}, Capacity: nil},
+		// storage-shaped (capacity non-nil): not gateway-shaped, never reaped by the backstop
+		{ID: "tagless-storage", Zone: testZone, Tags: []string{strayTag}, Capacity: &cap},
+	}
+	live := map[string]bool{"tagless-live": true}
+	claimed := map[string]bool{"tagless-claimed": true}
+	// Only sustained-down IDs are eligible for the untagged backstop. tagless-blip is
+	// deliberately absent (down but within the dwell window).
+	sustainedDown := map[string]bool{orphanID: true, "tagless-remote": true, "tagless-storage": true}
+
+	// hardenUntagged=true (unified Auto cluster): only the genuine sustained-down orphan is reaped.
+	got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed, sustainedDown, true)
+	want := []string{orphanID}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("staleGatewayRoles hardenUntagged=true: got %v, want %v", got, want)
+	}
+
+	// hardenUntagged=false (edge gateway / Manual): tagless roles are never reaped.
+	if got := staleGatewayRoles(roles, testZone, "gc", "garage", live, claimed, sustainedDown, false); len(got) != 0 {
+		t.Fatalf("staleGatewayRoles hardenUntagged=false: expected no reaping, got %v", got)
 	}
 }


### PR DESCRIPTION
Closes #224.

## Problem

The federation node-import path (`addRemoteNodesToLayout`) tagged imported remote nodes with only the remote cluster name (`Tags: []string{remote.Name}`), dropping `tier:gateway`. When such a gateway role later orphaned in its own zone (e.g. after a gateway lost its identity), the gateway tombstone reaper — which identifies gateway roles by the `tier:gateway` tag — could not see it. The orphan stuck in the layout indefinitely, and during a removal-propagation race the other region's reconcile re-imported it.

Found in production on the keiretsu federation (ottawa + robbinsdale) during gateway chaos-testing.

## Fix

- **`remoteImportTags`** derives `tier:gateway`/`tier:storage` from capacity and adds a remote-scoped ownership tag, while keeping `remote.Name` as a standalone tag so `removeStaleRemoteNodes` (which exact-matches it) still finds vanished imported roles.
- **Skip importing a down remote node** so a just-orphaned node isn't re-imported before its removal propagates. A false skip self-corrects on the next reconcile (the node is re-imported once up); a false import sticks.
- **Reaper backstop:** in a unified Auto cluster, reap a local-zone, `capacity:null`, unclaimed role even when a re-import stripped its `tier:gateway` tag — gated on `HasStorageTier() && LayoutPolicy != Manual` **and** on sustained down-time (`LastSeenSecsAgo` past `peerUnreachableThreshold`, parity with `PeerUnreachable`), so a transient blip or briefly-down federated peer is never reaped on a single `isUp=false` snapshot.
- **Self-connection guard** now compares the *effective* local zone (`localGatewayZone`, applying the empty→`"default"` fallback used when stamping local roles), so an empty-`spec.zone` cluster recognizes a remote configured `zone:"default"` as self and never imports its roles into the local zone.

## Why this shape (adversarial review)

An adversarial review of the first cut flagged two real over-reap risks in the reaper backstop: (1) a zone-collision where an empty-`spec.zone` cluster federating a `zone:"default"` remote imported that remote's `capacity:null` roles into the *local* zone, and (2) reaping on a single `isUp=false` snapshot with no dwell. Both are addressed above (self-guard fix + dwell gate); the dwell gate also bounds the backstop to genuinely-dead orphans.

## Tests

- `federation_test.go`: tier-tag derivation (gateway vs storage), down-node import skip, and a `removeStaleRemoteNodes` regression test (previously untested) proving the `remote.Name` matcher still works after tags were added.
- `garagecluster_gateway_reaper_test.go`: `hardenUntagged` over-reap guards — zone gate, live/claimed protection, storage-shape exclusion, the dwell gate (not-yet-sustained role preserved), and `hardenUntagged=false` (edge/Manual) never reaping tagless roles.

No API/CRD change. Validated locally: build, vet, golangci-lint (0), full envtest suite.