### PR TITLE
fix: gate PeerUnreachable to roled/draining peers + per-ordinal gateway rpc_public_addr

### DIFF
--- a/api/v1beta2/garagecluster_webhook.go
+++ b/api/v1beta2/garagecluster_webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -216,6 +217,22 @@ func (r *GarageCluster) validateGarageCluster() (admission.Warnings, error) {
 			"edge gateway has connectTo set but no externally-routable RPC address "+
 				"(spec.gateway.rpcPublicAddr, spec.network.rpcPublicAddr, or spec.publicEndpoint): "+
 				"the storage cluster will learn the unroutable pod IP and reverse connection will fail")
+	}
+
+	// A multi-pod gateway tier with one shared rpc_public_addr is only reachable at
+	// a single pod by remote regions — every pod advertises the same hostname via
+	// HelloMessage, so the rest show "never seen" cross-region. An {ordinal}
+	// placeholder makes each pod advertise its own address (the operator substitutes
+	// the pod ordinal, symmetric with remoteClusters[].gatewayRpcEndpointTemplate).
+	// Scoped to unified clusters, where per-node gateway GarageNodes do that
+	// substitution; an edge gateway runs a cluster-level STS and renders the address
+	// verbatim, so {ordinal} would not help there.
+	if r.HasStorageTier() && r.HasGatewayTier() && r.Spec.Gateway.Replicas > 1 &&
+		r.Spec.Gateway.RPCPublicAddr != "" && !strings.Contains(r.Spec.Gateway.RPCPublicAddr, "{ordinal}") {
+		warnings = append(warnings,
+			"spec.gateway.rpcPublicAddr is a single address shared by all gateway pods; with gateway.replicas > 1 "+
+				"remote regions can reach only one pod. Use an {ordinal} placeholder (e.g. gw-{ordinal}.example.ts.net:3901) "+
+				"for per-pod cross-region reachability")
 	}
 
 	if r.HasStorageTier() && r.Spec.Storage.PodDisruptionBudget != nil && r.Spec.Storage.PodDisruptionBudget.Enabled &&

--- a/api/v1beta2/garagecluster_webhook_test.go
+++ b/api/v1beta2/garagecluster_webhook_test.go
@@ -197,3 +197,38 @@ func TestGarageClusterValidator_WarnsGatewayMetadataEmptyDir(t *testing.T) {
 		t.Fatalf("expected gateway.metadata EmptyDir identity warning, got %v", warnings)
 	}
 }
+
+func TestGarageClusterValidator_WarnsSharedGatewayRPCAddr(t *testing.T) {
+	mk := func(addr string) *GarageCluster {
+		return &GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: testNamespace},
+			Spec: GarageClusterSpec{
+				Storage:     &StorageSpec{Replicas: 1, Metadata: &VolumeConfig{}, Data: &VolumeConfig{Type: VolumeTypeEmptyDir}},
+				Gateway:     &GatewaySpec{Replicas: 2, RPCPublicAddr: addr},
+				Replication: &ReplicationConfig{Factor: 1},
+			},
+		}
+	}
+	hasSharedWarning := func(t *testing.T, c *GarageCluster) bool {
+		t.Helper()
+		warnings, err := c.validateGarageCluster()
+		if err != nil {
+			t.Fatalf("validateGarageCluster: unexpected error %v", err)
+		}
+		for _, w := range warnings {
+			if strings.Contains(w, "shared by all gateway pods") {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Multi-pod gateway with a single shared addr (no {ordinal}) → warn.
+	if !hasSharedWarning(t, mk("shared.example.ts.net:3901")) {
+		t.Fatal("expected shared-gateway-rpcPublicAddr warning for a 2-replica gateway with no {ordinal}")
+	}
+	// Per-ordinal template → no warning.
+	if hasSharedWarning(t, mk("gw-{ordinal}.example.ts.net:3901")) {
+		t.Fatal("did not expect the warning when rpcPublicAddr uses an {ordinal} placeholder")
+	}
+}

--- a/internal/controller/garagecluster_automode_gateway.go
+++ b/internal/controller/garagecluster_automode_gateway.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -213,8 +215,17 @@ func (r *GarageClusterReconciler) buildAutoModeGatewayNode(cluster *garagev1beta
 	// per-node ConfigMap advertises it. Even when empty, gateway nodes get a
 	// dedicated ConfigMap (nodeHasConfigOverrides returns true for gateways) so
 	// they never inherit the storage tier's rpc_public_addr.
+	//
+	// A multi-pod gateway tier needs a PER-ORDINAL advertised address: a single
+	// shared rpc_public_addr makes every pod's HelloMessage hand remote regions
+	// the same hostname, which can route to at most one pod — the others are then
+	// unreachable cross-region ("never seen"). Substitute {ordinal} (symmetric
+	// with the consumer side's remoteClusters[].gatewayRpcEndpointTemplate) so each
+	// pod advertises its own address; addresses without the placeholder are used
+	// verbatim (fine for a single-replica gateway tier).
 	if gw := cluster.Spec.Gateway; gw != nil && gw.RPCPublicAddr != "" {
-		node.Spec.Network = &garagev1beta1.NodeNetworkConfig{RPCPublicAddr: gw.RPCPublicAddr}
+		addr := strings.ReplaceAll(gw.RPCPublicAddr, "{ordinal}", strconv.Itoa(int(ordinal)))
+		node.Spec.Network = &garagev1beta1.NodeNetworkConfig{RPCPublicAddr: addr}
 	}
 
 	if err := controllerutil.SetControllerReference(cluster, node, r.Scheme); err != nil {

--- a/internal/controller/garagecluster_automode_gateway_test.go
+++ b/internal/controller/garagecluster_automode_gateway_test.go
@@ -284,4 +284,30 @@ var _ = Describe("GarageCluster unified-gateway Auto-mode (#209)", func() {
 		}
 		Expect(stsPVCRetentionPolicy(cluster, storageNode)).To(BeNil())
 	})
+
+	It("substitutes {ordinal} into gateway.rpcPublicAddr per pod (#cross-region per-pod reachability)", func() {
+		c := &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-ord", Namespace: testNamespace},
+			Spec: garagev1beta2.GarageClusterSpec{
+				Storage: &garagev1beta2.StorageSpec{Replicas: 1},
+				Gateway: &garagev1beta2.GatewaySpec{Replicas: 2, RPCPublicAddr: "gw-{ordinal}.example.ts.net:3901"},
+			},
+		}
+		// Each pod ordinal advertises its own address, so remote regions can reach
+		// every gateway pod (a single shared addr can route to only one).
+		n0, err := reconciler.buildAutoModeGatewayNode(c, 0, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n0.Spec.Network).NotTo(BeNil())
+		Expect(n0.Spec.Network.RPCPublicAddr).To(Equal("gw-0.example.ts.net:3901"))
+
+		n1, err := reconciler.buildAutoModeGatewayNode(c, 1, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n1.Spec.Network.RPCPublicAddr).To(Equal("gw-1.example.ts.net:3901"))
+
+		// An address without the placeholder is used verbatim (single-replica tiers).
+		c.Spec.Gateway.RPCPublicAddr = "shared.example.ts.net:3901"
+		n2, err := reconciler.buildAutoModeGatewayNode(c, 1, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n2.Spec.Network.RPCPublicAddr).To(Equal("shared.example.ts.net:3901"))
+	})
 })

--- a/internal/controller/garagecluster_health.go
+++ b/internal/controller/garagecluster_health.go
@@ -41,16 +41,25 @@ const remoteStaleThreshold = time.Hour
 const peerUnreachableThreshold = 10 * time.Minute
 
 // computeUnreachablePeers returns "<shortId> (down <duration>)" descriptions for
-// peers that are not up and were last seen longer ago than the threshold. A peer
-// with no lastSeenSecsAgo (never seen) is flagged only when it holds a layout
-// role — i.e. an expected member that never joined; a never-seen roleless peer
-// is bootstrap/federation discovery noise and is skipped so the condition does
-// not flap during startup.
+// peers that are not up and were last seen longer ago than the threshold. Only
+// peers that matter are flagged: a peer that holds a role in the CURRENT layout
+// (n.Role != nil) or one that is draining (held a capacity role in a prior layout
+// version and is being removed — Garage reports such a node with role==nil +
+// draining==true). A roleless, non-draining down peer is NOT an actionable member:
+// it is either bootstrap/federation discovery noise (never seen) or a discarded
+// identity Garage still remembers (e.g. a gateway whose metadata PVC was recreated,
+// leaving the old node ID in the peer list) — the ConnectClusterNodes recovery
+// nudge can never reconnect it, so flagging it is misleading noise. Keeping draining
+// nodes preserves visibility into a STUCK drain (node dead, drain not completing),
+// which is exactly when an operator wants the warning.
 func computeUnreachablePeers(nodes []garage.NodeInfo) []string {
 	var out []string
 	for _, n := range nodes {
 		if n.IsUp {
 			continue
+		}
+		if n.Role == nil && !n.Draining {
+			continue // roleless and not draining: discovery noise or a discarded identity — not actionable
 		}
 		secs := uint64(0)
 		if n.LastSeenSecsAgo != nil {
@@ -58,13 +67,6 @@ func computeUnreachablePeers(nodes []garage.NodeInfo) []string {
 			if time.Duration(secs)*time.Second < peerUnreachableThreshold {
 				continue // transient — not yet sustained
 			}
-		} else if n.Role == nil {
-			// Never seen AND not an expected layout member: a peer Garage has
-			// merely discovered (bootstrap / federation gossip) but that never
-			// joined and holds no role. Flagging it would flap PeerUnreachable
-			// during startup. Only a never-seen peer that DOES hold a layout
-			// role is a genuine missing member.
-			continue
 		}
 		short := n.ID
 		if len(short) > 16 {

--- a/internal/controller/garagecluster_health_test.go
+++ b/internal/controller/garagecluster_health_test.go
@@ -160,18 +160,26 @@ func TestSetClusterHealthConditions_NoFederationClearsConditions(t *testing.T) {
 
 func TestComputeUnreachablePeers(t *testing.T) {
 	up := func(secs uint64) *uint64 { return &secs }
+	roled := &garage.NodeAssignedRole{Zone: "z"}
 	nodes := []garage.NodeInfo{
-		{ID: "aaaaaaaaaaaaaaaaaaaa", IsUp: true},                             // up → ignored
-		{ID: "bbbbbbbbbbbbbbbbbbbb", IsUp: false, LastSeenSecsAgo: up(120)},  // 2m down → transient
-		{ID: "cccccccccccccccccccc", IsUp: false, LastSeenSecsAgo: up(1800)}, // 30m down → flagged
+		{ID: "aaaaaaaaaaaaaaaaaaaa", IsUp: true},                                          // up → ignored
+		{ID: "bbbbbbbbbbbbbbbbbbbb", IsUp: false, LastSeenSecsAgo: up(120), Role: roled},  // 2m down → transient
+		{ID: "cccccccccccccccccccc", IsUp: false, LastSeenSecsAgo: up(1800), Role: roled}, // 30m down, roled → flagged
 		// never seen but holds a layout role → expected member, flagged
-		{ID: "dddddddddddddddddddd", IsUp: false, LastSeenSecsAgo: nil, Role: &garage.NodeAssignedRole{Zone: "z"}},
+		{ID: "dddddddddddddddddddd", IsUp: false, LastSeenSecsAgo: nil, Role: roled},
 		// never seen and roleless → bootstrap discovery noise, skipped
 		{ID: "eeeeeeeeeeeeeeeeeeee", IsUp: false, LastSeenSecsAgo: nil},
+		// SUSTAINED down but roleless → a discarded identity Garage still remembers
+		// (e.g. a recreated-PVC gateway orphan); not actionable, must be skipped (#224-class noise).
+		{ID: "ffffffffffffffffffff", IsUp: false, LastSeenSecsAgo: up(70000)},
+		// SUSTAINED down + DRAINING → a storage node mid-removal (role==nil + draining
+		// in a prior layout version); a STUCK drain is exactly when the warning matters,
+		// so it must still be flagged despite role==nil.
+		{ID: "gggggggggggggggggggg", IsUp: false, LastSeenSecsAgo: up(1800), Draining: true},
 	}
 	got := computeUnreachablePeers(nodes)
-	if len(got) != 2 {
-		t.Fatalf("expected 2 unreachable peers, got %d: %v", len(got), got)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 unreachable peers, got %d: %v", len(got), got)
 	}
 	if !strings.Contains(got[0], "cccccccccccccccc") || !strings.Contains(got[0], "down") {
 		t.Fatalf("unexpected first entry: %q", got[0])
@@ -179,8 +187,15 @@ func TestComputeUnreachablePeers(t *testing.T) {
 	if !strings.Contains(got[1], "never seen") {
 		t.Fatalf("expected a never-seen entry, got %q", got[1])
 	}
-	if strings.Contains(strings.Join(got, "|"), "eeeeeeee") {
+	joined := strings.Join(got, "|")
+	if strings.Contains(joined, "eeeeeeee") {
 		t.Fatal("roleless never-seen peer must be skipped")
+	}
+	if strings.Contains(joined, "ffffffff") {
+		t.Fatal("roleless sustained-down peer (discarded identity) must be skipped")
+	}
+	if !strings.Contains(joined, "gggggggggggggggg") {
+		t.Fatal("sustained-down draining node must still be flagged (stuck-drain visibility)")
 	}
 }
 


### PR DESCRIPTION
Two federation signal/reachability fixes found while analyzing a healthy production federated cluster's `PeerUnreachable` condition. Both are signal-quality / per-pod-reachability, **not** availability — neither caused an outage.

## 1. `PeerUnreachable` over-fired on dead roleless identities

`computeUnreachablePeers` only checked layout-role membership on the *never-seen* branch, so a **sustained-down** peer with no current role (e.g. a gateway whose metadata PVC was recreated, leaving the old node ID in Garage's peer list) was flagged — with a remediation message promising a `ConnectClusterNodes` nudge that can never reconnect a discarded identity. On a live cluster this buried the one actionable signal (roled cross-region gateways unreachable) under dead-orphan noise.

**Fix:** flag only peers that hold a **current-layout role** (`n.Role != nil`) **or are draining**. Roleless, non-draining down peers are dropped as noise. The draining carve-out (`n.Role == nil && !n.Draining`) preserves visibility into a **stuck drain** (a storage node mid-removal that's also dead) — upstream reports such a node as `role:nil, draining:true`, and that's exactly when an operator wants the warning. Verified empirically: down roled nodes report `role` present; down roleless orphans report `role:null`.

## 2. Multi-pod gateways unreachable cross-region

`buildAutoModeGatewayNode` stamped the cluster's **single** `gateway.rpcPublicAddr` onto *every* gateway pod, so each advertised the same hostname via HelloMessage and remote regions could reach only one pod — the rest showed "never seen". (Root-caused on the keiretsu federation: ottawa dialed `robbinsdale-gw-0` fine, but Garage handed back the shared addr → unroutable proxy ClusterIP → timeout.)

**Fix:** substitute `{ordinal}` per pod (symmetric with the consumer's `remoteClusters[].gatewayRpcEndpointTemplate`); addresses without the placeholder are used verbatim. A webhook **warning** fires when a unified multi-pod gateway tier sets a shared `rpc_public_addr` with no `{ordinal}`. `autoModeGatewayNodeNeedsUpdate` already compares `RPCPublicAddr`, so adopting an `{ordinal}` template reconciles onto existing nodes.

> Activating #2 in production needs a manifest using an `{ordinal}` template + a gateway-tier restart — deliberately **not** done here (operator-only upgrade; self-heals when a future manifest adopts the template).

## Review

Adversarial review caught one real MEDIUM (the draining-node case above), fixed before this PR. Verified against upstream `src/api/admin/cluster.rs`. Tests cover the role/draining gate, per-ordinal substitution, and the webhook warning. No API/CRD change. Local: build, vet, golangci-lint (0), full envtest suite all green.