### PR TITLE
fix(garagenode): heal immutable-StatefulSet-selector mismatch (orphan-recreate)

### DIFF
--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -25,6 +25,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -540,6 +541,33 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 	}
 	if err != nil {
 		return err
+	}
+
+	// The StatefulSet selector is immutable. An STS created by an older operator
+	// with a different selector label scheme can never be Updated in place — every
+	// reconcile fails with "selector does not match template labels", wedging the
+	// STS (config-hash never converges, the pod can't be rolled for config
+	// changes). Heal it by orphan-deleting (PropagationPolicy: Orphan keeps the
+	// running pod and its RWO metadata/data PVCs) and recreating with the current
+	// spec. The new STS adopts the still-running pod in place — the pod's labels
+	// are a superset of the new selector — so node_key identity and data are
+	// preserved with no downtime and no PVC rebind.
+	if existing.Spec.Selector != nil && existing.Spec.Selector.MatchLabels != nil &&
+		!equality.Semantic.DeepEqual(existing.Spec.Selector.MatchLabels, sts.Spec.Selector.MatchLabels) {
+		if !existing.DeletionTimestamp.IsZero() {
+			// Already orphan-deleting from a prior reconcile; wait for it to clear,
+			// then the create branch above (IsNotFound) recreates it.
+			return nil
+		}
+		log.Info("StatefulSet selector scheme changed (immutable) — orphan-recreating to heal",
+			"name", stsName, "oldSelector", existing.Spec.Selector.MatchLabels, "newSelector", sts.Spec.Selector.MatchLabels)
+		orphan := metav1.DeletePropagationOrphan
+		if err := r.Delete(ctx, existing, &client.DeleteOptions{PropagationPolicy: &orphan}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("orphan-deleting selector-mismatched StatefulSet %s: %w", stsName, err)
+		}
+		// Recreated on the next reconcile (the StatefulSet delete event re-triggers
+		// this controller); the orphaned pod keeps serving until then.
+		return nil
 	}
 
 	// Check if update is needed

--- a/internal/controller/sts_selector_heal_test.go
+++ b/internal/controller/sts_selector_heal_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+// An STS created by an older operator carries an immutable selector with a
+// different label scheme; an in-place Update fails forever ("selector does not
+// match template labels"). reconcileStatefulSet must heal it by orphan-recreate.
+var _ = Describe("reconcileStatefulSet heals an immutable-selector mismatch (orphan-recreate)", func() {
+	const (
+		clusterName = "sel-heal-cluster"
+		nodeName    = "sel-heal-node"
+	)
+	r := func() *GarageNodeReconciler {
+		return &GarageNodeReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+	}
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace}})
+		n := &garagev1beta1.GarageNode{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, n); err == nil {
+			n.Finalizers = nil
+			_ = k8sClient.Update(ctx, n)
+			_ = k8sClient.Delete(ctx, n)
+		}
+		c := &garagev1beta2.GarageCluster{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: testNamespace}, c); err == nil {
+			c.Finalizers = nil
+			_ = k8sClient.Update(ctx, c)
+			_ = k8sClient.Delete(ctx, c)
+		}
+	})
+
+	It("orphan-deletes the old-scheme STS and recreates it with the current selector", func() {
+		cluster := &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace},
+			Spec: garagev1beta2.GarageClusterSpec{
+				LayoutPolicy: LayoutPolicyManual,
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas: 1,
+					Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+				},
+				Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+		capacity := resource.MustParse("10Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &capacity,
+				Storage:    &garagev1beta1.NodeStorageConfig{Data: &garagev1beta1.NodeVolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+
+		// Pre-create an STS with the OLD operator's selector scheme.
+		oldSelector := map[string]string{
+			labelAppName:     "garagenode",
+			labelAppInstance: nodeName,
+			labelGarageNode:  nodeName,
+		}
+		one := int32(1)
+		oldSTS := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: clusterName + "-headless",
+				Replicas:    &one,
+				Selector:    &metav1.LabelSelector{MatchLabels: oldSelector},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: oldSelector},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "garage", Image: "dxflrs/garage:test"}}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, oldSTS)).To(Succeed())
+
+		By("first reconcile detects the immutable-selector mismatch and orphan-deletes the STS")
+		Expect(r().reconcileStatefulSet(ctx, node, cluster)).To(Succeed())
+		// envtest has no garbage collector, so the Orphan delete leaves the STS
+		// terminating with the apiserver's "orphan" finalizer (in a real cluster
+		// the GC orphans the pod and removes it). Confirm the delete was issued,
+		// then simulate the GC so the recreate path can run.
+		sts := &appsv1.StatefulSet{}
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, sts)).To(Succeed())
+			g.Expect(sts.DeletionTimestamp).NotTo(BeNil(), "orphan-delete should have been issued")
+		}).Should(Succeed())
+		sts.Finalizers = nil
+		_ = k8sClient.Update(ctx, sts)
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, &appsv1.StatefulSet{})
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue(), "old-scheme STS should be gone after GC")
+
+		By("subsequent reconcile recreates the STS with the CURRENT selector scheme")
+		Eventually(func(g Gomega) {
+			g.Expect(r().reconcileStatefulSet(ctx, node, cluster)).To(Succeed())
+			sts := &appsv1.StatefulSet{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: testNamespace}, sts)).To(Succeed())
+			g.Expect(sts.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelAppManagedBy, operatorName))
+			g.Expect(sts.Spec.Selector.MatchLabels).To(HaveKeyWithValue(labelGarageNode, nodeName))
+			// the old node-scoped instance/name keys are gone from the selector
+			g.Expect(sts.Spec.Selector.MatchLabels).NotTo(HaveKey(labelAppName))
+		}).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## Problem
A per-node storage StatefulSet created by an older operator carries an **immutable** selector with a different label scheme (`{name:garagenode, instance:<node>, node:<node>}`) than the current operator emits (`{managed-by, node}`). Since STS selectors can't be changed, `reconcileStatefulSet`'s in-place Update fails **every reconcile** with `selector does not match template labels`. The STS is wedged: the config-hash never converges and the pod can't be rolled for config changes.

This was the residual "config-hash thrash" observed on the recovered keiretsu federation (generation frozen at 3, `Updating StatefulSet` logged every cycle but nothing lands). Determinism/idempotency fixes (#229) didn't touch it because the root cause is selector immutability, not config rendering.

## Fix
Orphan-recreate: when the existing selector differs from the desired one, `Delete` the STS with `PropagationPolicy=Orphan` (the running pod keeps its RWO metadata/data PVCs) and recreate with the current spec on the next reconcile. The new STS **adopts the still-running pod in place** (the pod's labels are a superset of the new selector) → **zero downtime, identity (`node_key`) + data preserved, no PVC rebind**. Verified against upstream Garage (NodeID = ed25519 key from `metadata_dir/node_key`; layout role keyed by Uuid, survives the STS swap).

## Test
envtest regression test (GC simulated — envtest has no garbage collector to complete an Orphan delete). `make test` + `make lint` green.