### PR TITLE
fix: publicEndpoint.loadBalancer.perNode works for gateway-only clusters

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -939,6 +939,28 @@ func buildConfigContext(ctx context.Context, cl client.Client, cluster *garagev1
 						}
 					}
 				}
+			} else if !cluster.HasStorageTier() && cluster.HasGatewayTier() {
+				// Edge-gateway (gateway-only) cluster with perNode=true: derive
+				// rpc_public_addr from the ordinal-0 per-node service. All pods share
+				// a single cluster-level ConfigMap, so ordinal 0's IP is used as a
+				// best-effort address for single-replica gateways; multi-replica edge
+				// gateways with perNode would need per-pod ConfigMaps to be exact.
+				svc := &corev1.Service{}
+				if err := cl.Get(ctx, types.NamespacedName{
+					Name:      perNodeRPCServiceName(cluster.Name, 0),
+					Namespace: cluster.Namespace,
+				}, svc); err == nil {
+					for _, ing := range svc.Status.LoadBalancer.Ingress {
+						addr := ing.IP
+						if addr == "" {
+							addr = ing.Hostname
+						}
+						if addr != "" {
+							cfgCtx.RPCPublicAddr = fmt.Sprintf("%s:%d", addr, rpcPort)
+							break
+						}
+					}
+				}
 			}
 		case publicEndpointTypeNodePort:
 			if ep := cluster.Spec.PublicEndpoint.NodePort; ep != nil && len(ep.ExternalAddresses) > 0 {
@@ -1925,42 +1947,70 @@ func (r *GarageClusterReconciler) reconcilePerNodeLoadBalancerServices(ctx conte
 		return err
 	}
 
-	// Honor an explicit replicas=0 so operators can pause the storage tier
-	// without removing the tier definition (PVCs, capacity, etc. are preserved).
-	replicas := cluster.StorageReplicas()
-	desired := make(map[string]struct{}, replicas)
+	// Determine replicas and pod selectors based on which tier is present.
+	// Storage clusters use the GarageNode-controller-written label; edge-gateway
+	// clusters (no storage tier) use the Kubernetes-added pod-name label on the
+	// cluster-level gateway StatefulSet.
+	type perNodeEntry struct {
+		svcName  string
+		podLabel string // value for the per-pod selector key
+		selector map[string]string
+	}
+	var entries []perNodeEntry
 
-	// Per-#190, storage pods are owned by per-GarageNode StatefulSets named
-	// `<cluster>-storage-<i>` with pod `<cluster>-storage-<i>-0`. Select pods via
-	// the stable `garage.rajsingh.info/node` label written by the GarageNode
-	// controller — this avoids hard-coding the pod-name convention and works
-	// regardless of GarageNode renames or single-pod STS naming.
-	for i := int32(0); i < replicas; i++ {
-		nodeName := autoModeGarageNodeName(cluster.Name, i)
-		svcName := perNodeRPCServiceName(cluster.Name, i)
-		desired[svcName] = struct{}{}
-
-		selector := map[string]string{
-			labelCluster:    cluster.Name,
-			labelGarageNode: nodeName,
+	if cluster.HasStorageTier() {
+		// Per-#190, storage pods live behind per-GarageNode StatefulSets named
+		// `<cluster>-storage-<i>`. Select via the stable `garage.rajsingh.info/node`
+		// label written by the GarageNode controller.
+		replicas := cluster.StorageReplicas()
+		for i := int32(0); i < replicas; i++ {
+			nodeName := autoModeGarageNodeName(cluster.Name, i)
+			entries = append(entries, perNodeEntry{
+				svcName:  perNodeRPCServiceName(cluster.Name, i),
+				podLabel: nodeName,
+				selector: map[string]string{
+					labelCluster:    cluster.Name,
+					labelGarageNode: nodeName,
+				},
+			})
 		}
+	} else if cluster.HasGatewayTier() {
+		// Edge-gateway (gateway-only) cluster: the gateway StatefulSet pods carry
+		// the Kubernetes-added `statefulset.kubernetes.io/pod-name` label, which
+		// is the only stable per-pod handle available without per-GarageNode CRs.
+		replicas := cluster.GatewayReplicas()
+		stsName := gatewayWorkloadName(cluster)
+		for i := int32(0); i < replicas; i++ {
+			podName := fmt.Sprintf("%s-%d", stsName, i)
+			entries = append(entries, perNodeEntry{
+				svcName:  perNodeRPCServiceName(cluster.Name, i),
+				podLabel: podName,
+				selector: map[string]string{
+					labelCluster:                         cluster.Name,
+					"statefulset.kubernetes.io/pod-name": podName,
+				},
+			})
+		}
+	}
 
+	desired := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		desired[e.svcName] = struct{}{}
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        svcName,
+				Name:        e.svcName,
 				Namespace:   cluster.Namespace,
 				Labels:      mergeLabels(r.labelsForCluster(cluster), svcMeta.Labels),
 				Annotations: svcMeta.Annotations,
 			},
 			Spec: corev1.ServiceSpec{
 				Type:                     corev1.ServiceTypeLoadBalancer,
-				Selector:                 selector,
+				Selector:                 e.selector,
 				Ports:                    []corev1.ServicePort{rpcServicePort(rpcPort, 0)},
 				PublishNotReadyAddresses: true,
 			},
 		}
-
-		log.Info("Reconciling per-node public endpoint RPC service", "name", svcName, "node", nodeName, "type", corev1.ServiceTypeLoadBalancer)
+		log.Info("Reconciling per-node public endpoint RPC service", "name", e.svcName, "pod", e.podLabel, "type", corev1.ServiceTypeLoadBalancer)
 		if err := reconcileService(ctx, r.Client, svc, cluster, r.Scheme); err != nil {
 			return err
 		}

--- a/internal/controller/publicendpoint_test.go
+++ b/internal/controller/publicendpoint_test.go
@@ -240,6 +240,100 @@ var _ = Describe("publicEndpoint reconciliation", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
 
+		It("creates per-node LoadBalancer RPC services for gateway-only (edge-gateway) cluster", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 1},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+					ConnectTo: &garagev1beta2.ConnectToConfig{
+						AdminAPIEndpoint: "http://192.168.0.10:3903",
+						AdminTokenSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "ext-admin-token"},
+							Key:                  "token",
+						},
+						RPCSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: peClusterName + "-rpc-secret"},
+							Key:                  RPCSecretKey,
+						},
+					},
+					PublicEndpoint: &garagev1beta2.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+						LoadBalancer: &garagev1beta2.LoadBalancerEndpointConfig{
+							PerNode: true,
+							ServiceMeta: garagev1beta2.ServiceMeta{
+								Annotations: map[string]string{"lbipam.cilium.io/ips": "10.0.40.105"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			// Shared RPC service must not be created for perNode=true.
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, &corev1.Service{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			// Per-node service for ordinal 0 must exist and select gateway pod via
+			// statefulset.kubernetes.io/pod-name (Kubernetes auto-adds this label).
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-0-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			Expect(rpcSvc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+			Expect(rpcSvc.Spec.Selector).To(HaveKeyWithValue("statefulset.kubernetes.io/pod-name", peClusterName+"-gateway-0"))
+			Expect(rpcSvc.Spec.Selector).To(HaveKeyWithValue(labelCluster, peClusterName))
+			Expect(rpcSvc.Spec.Ports).To(ContainElement(HaveField("Port", int32(3901))))
+			Expect(rpcSvc.Annotations).To(HaveKeyWithValue("lbipam.cilium.io/ips", "10.0.40.105"))
+
+			updated := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+			cond := findCondition(updated.Status.Conditions, garagev1beta1.ConditionPublicEndpointReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Message).To(ContainSubstring("Per-node LoadBalancer RPC services are reconciled"))
+		})
+
+		It("populates rpc_public_addr in config once the gateway per-node LB service has an IP", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 1},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+					ConnectTo: &garagev1beta2.ConnectToConfig{
+						AdminAPIEndpoint: "http://192.168.0.10:3903",
+						AdminTokenSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "ext-admin-token"},
+							Key:                  "token",
+						},
+						RPCSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: peClusterName + "-rpc-secret"},
+							Key:                  RPCSecretKey,
+						},
+					},
+					PublicEndpoint: &garagev1beta2.PublicEndpointConfig{
+						Type:         publicEndpointTypeLoadBalancer,
+						LoadBalancer: &garagev1beta2.LoadBalancerEndpointConfig{PerNode: true},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			// Simulate LB IP assignment on the per-node service.
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-0-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			rpcSvc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.0.40.105"}}
+			Expect(k8sClient.Status().Update(ctx, rpcSvc)).To(Succeed())
+
+			reconciler2 := &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler2.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-config", Namespace: peNamespace}, cm)).To(Succeed())
+			Expect(cm.Data["garage.toml"]).To(ContainSubstring(`rpc_public_addr = "10.0.40.105:3901"`))
+		})
+
 		It("surfaces per-node cluster public endpoints as unsupported in Manual layout mode", func() {
 			cluster := &garagev1beta2.GarageCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},


### PR DESCRIPTION
## Summary

- `reconcilePerNodeLoadBalancerServices` iterated `StorageReplicas()` (= 0 for edge-gateway clusters), so `perNode: true` on a `connectTo`-only cluster created zero services but still set `PublicEndpointReady=True`
- `buildConfigContext` skipped the perNode LB case for gateway-only clusters entirely, so `rpc_public_addr` was never written to `garage.toml` — pods advertised unroutable pod IPs and `GatewayConnected` stayed `False`

For gateway-only clusters, `reconcilePerNodeLoadBalancerServices` now iterates `GatewayReplicas()` and selects pods via `statefulset.kubernetes.io/pod-name` (auto-added by Kubernetes to all StatefulSet pods, since edge-gateway pods have no `garage.rajsingh.info/node` label). `buildConfigContext` reads the LB ingress IP from the ordinal-0 per-node service to populate `rpc_public_addr` in the shared cluster ConfigMap.

## Test plan

- [x] `creates per-node LoadBalancer RPC services for gateway-only (edge-gateway) cluster` — verifies service created, correct `statefulset.kubernetes.io/pod-name` selector, `PublicEndpointReady=True`
- [x] `populates rpc_public_addr in config once the gateway per-node LB service has an IP` — verifies `garage.toml` gets the LB IP after service status update
- [x] All 174 existing tests pass

Fixes #236