### PR TITLE
fix: proactively reap dead remote gateway roles; skip gateways from PeerUnreachable; allow GarageKey on Degraded

### DIFF
--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -852,6 +852,88 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 			Expect(staged[0].ID).To(Equal(staleID))
 			Expect(staged[0].Remove).To(BeTrue())
 		})
+
+		It("removes dead remote gateway roles beyond peerUnreachableThreshold (#237)", func() {
+			var staged []garage.NodeRoleChange
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case pathGetClusterLayout:
+					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{Version: 5})
+				case pathUpdateLayout:
+					var req garage.UpdateClusterLayoutRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					staged = req.Roles
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+			localClient := garage.NewClient(server.URL, adminToken)
+
+			remote := garagev1beta2.RemoteClusterConfig{Name: testTagRemoteCluster, Zone: testZoneRemote}
+			deadGatewayID := "deadgw0000000000deadgw000000dead"
+			liveGatewayID := "livegw0000000000livegw000000live"
+			// Local layout has both old (dead) and new (live) imported gateway roles.
+			layout := &garage.ClusterLayout{
+				Version: 4,
+				Roles: []garage.LayoutNodeRole{
+					{ID: deadGatewayID, Zone: testZoneRemote, Tags: remoteImportTags(remote, cluster.Namespace, nil)},
+					{ID: liveGatewayID, Zone: testZoneRemote, Tags: remoteImportTags(remote, cluster.Namespace, nil)},
+				},
+			}
+			deadSecs := uint64(peerUnreachableThreshold.Seconds()) + 60
+			liveSecs := uint64(0)
+			remoteStatus := &garage.ClusterStatus{Nodes: []garage.NodeInfo{
+				// Old identity: still in Garage's peer list but down beyond threshold.
+				{ID: deadGatewayID, IsUp: false, LastSeenSecsAgo: &deadSecs},
+				// New pod: running with new identity.
+				{ID: liveGatewayID, IsUp: true, LastSeenSecsAgo: &liveSecs},
+			}}
+
+			err := reconciler.removeStaleRemoteNodes(ctx, localClient, layout, remoteStatus, remote)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(staged).To(HaveLen(1), "only dead gateway role should be removed")
+			Expect(staged[0].ID).To(Equal(deadGatewayID))
+			Expect(staged[0].Remove).To(BeTrue())
+		})
+
+		It("does not remove dead remote storage roles even beyond threshold (#237 safeguard)", func() {
+			var staged []garage.NodeRoleChange
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case pathGetClusterLayout:
+					_ = json.NewEncoder(w).Encode(garage.ClusterLayout{Version: 5})
+				case pathUpdateLayout:
+					var req garage.UpdateClusterLayoutRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					staged = req.Roles
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+			localClient := garage.NewClient(server.URL, adminToken)
+
+			remote := garagev1beta2.RemoteClusterConfig{Name: testTagRemoteCluster, Zone: testZoneRemote}
+			deadStorageID := "deadst0000000000deadst000000dead"
+			cap1 := uint64(1 << 30)
+			layout := &garage.ClusterLayout{
+				Version: 4,
+				Roles: []garage.LayoutNodeRole{
+					{ID: deadStorageID, Zone: testZoneRemote, Capacity: &cap1, Tags: remoteImportTags(remote, cluster.Namespace, &cap1)},
+				},
+			}
+			deadSecs := uint64(peerUnreachableThreshold.Seconds()) + 3600
+			remoteStatus := &garage.ClusterStatus{Nodes: []garage.NodeInfo{
+				{ID: deadStorageID, IsUp: false, LastSeenSecsAgo: &deadSecs},
+			}}
+
+			err := reconciler.removeStaleRemoteNodes(ctx, localClient, layout, remoteStatus, remote)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(staged).To(BeNil(), "storage roles with data must never be speculatively removed")
+		})
 	})
 })
 

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -939,6 +939,28 @@ func buildConfigContext(ctx context.Context, cl client.Client, cluster *garagev1
 						}
 					}
 				}
+			} else if !cluster.HasStorageTier() && cluster.HasGatewayTier() {
+				// Edge-gateway (gateway-only) cluster with perNode=true: derive
+				// rpc_public_addr from the ordinal-0 per-node service. All pods share
+				// a single cluster-level ConfigMap, so ordinal 0's IP is used as a
+				// best-effort address for single-replica gateways; multi-replica edge
+				// gateways with perNode would need per-pod ConfigMaps to be exact.
+				svc := &corev1.Service{}
+				if err := cl.Get(ctx, types.NamespacedName{
+					Name:      perNodeRPCServiceName(cluster.Name, 0),
+					Namespace: cluster.Namespace,
+				}, svc); err == nil {
+					for _, ing := range svc.Status.LoadBalancer.Ingress {
+						addr := ing.IP
+						if addr == "" {
+							addr = ing.Hostname
+						}
+						if addr != "" {
+							cfgCtx.RPCPublicAddr = fmt.Sprintf("%s:%d", addr, rpcPort)
+							break
+						}
+					}
+				}
 			}
 		case publicEndpointTypeNodePort:
 			if ep := cluster.Spec.PublicEndpoint.NodePort; ep != nil && len(ep.ExternalAddresses) > 0 {
@@ -1925,42 +1947,70 @@ func (r *GarageClusterReconciler) reconcilePerNodeLoadBalancerServices(ctx conte
 		return err
 	}
 
-	// Honor an explicit replicas=0 so operators can pause the storage tier
-	// without removing the tier definition (PVCs, capacity, etc. are preserved).
-	replicas := cluster.StorageReplicas()
-	desired := make(map[string]struct{}, replicas)
+	// Determine replicas and pod selectors based on which tier is present.
+	// Storage clusters use the GarageNode-controller-written label; edge-gateway
+	// clusters (no storage tier) use the Kubernetes-added pod-name label on the
+	// cluster-level gateway StatefulSet.
+	type perNodeEntry struct {
+		svcName  string
+		podLabel string // value for the per-pod selector key
+		selector map[string]string
+	}
+	var entries []perNodeEntry
 
-	// Per-#190, storage pods are owned by per-GarageNode StatefulSets named
-	// `<cluster>-storage-<i>` with pod `<cluster>-storage-<i>-0`. Select pods via
-	// the stable `garage.rajsingh.info/node` label written by the GarageNode
-	// controller — this avoids hard-coding the pod-name convention and works
-	// regardless of GarageNode renames or single-pod STS naming.
-	for i := int32(0); i < replicas; i++ {
-		nodeName := autoModeGarageNodeName(cluster.Name, i)
-		svcName := perNodeRPCServiceName(cluster.Name, i)
-		desired[svcName] = struct{}{}
-
-		selector := map[string]string{
-			labelCluster:    cluster.Name,
-			labelGarageNode: nodeName,
+	if cluster.HasStorageTier() {
+		// Per-#190, storage pods live behind per-GarageNode StatefulSets named
+		// `<cluster>-storage-<i>`. Select via the stable `garage.rajsingh.info/node`
+		// label written by the GarageNode controller.
+		replicas := cluster.StorageReplicas()
+		for i := int32(0); i < replicas; i++ {
+			nodeName := autoModeGarageNodeName(cluster.Name, i)
+			entries = append(entries, perNodeEntry{
+				svcName:  perNodeRPCServiceName(cluster.Name, i),
+				podLabel: nodeName,
+				selector: map[string]string{
+					labelCluster:    cluster.Name,
+					labelGarageNode: nodeName,
+				},
+			})
 		}
+	} else if cluster.HasGatewayTier() {
+		// Edge-gateway (gateway-only) cluster: the gateway StatefulSet pods carry
+		// the Kubernetes-added `statefulset.kubernetes.io/pod-name` label, which
+		// is the only stable per-pod handle available without per-GarageNode CRs.
+		replicas := cluster.GatewayReplicas()
+		stsName := gatewayWorkloadName(cluster)
+		for i := int32(0); i < replicas; i++ {
+			podName := fmt.Sprintf("%s-%d", stsName, i)
+			entries = append(entries, perNodeEntry{
+				svcName:  perNodeRPCServiceName(cluster.Name, i),
+				podLabel: podName,
+				selector: map[string]string{
+					labelCluster:                         cluster.Name,
+					"statefulset.kubernetes.io/pod-name": podName,
+				},
+			})
+		}
+	}
 
+	desired := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		desired[e.svcName] = struct{}{}
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        svcName,
+				Name:        e.svcName,
 				Namespace:   cluster.Namespace,
 				Labels:      mergeLabels(r.labelsForCluster(cluster), svcMeta.Labels),
 				Annotations: svcMeta.Annotations,
 			},
 			Spec: corev1.ServiceSpec{
 				Type:                     corev1.ServiceTypeLoadBalancer,
-				Selector:                 selector,
+				Selector:                 e.selector,
 				Ports:                    []corev1.ServicePort{rpcServicePort(rpcPort, 0)},
 				PublishNotReadyAddresses: true,
 			},
 		}
-
-		log.Info("Reconciling per-node public endpoint RPC service", "name", svcName, "node", nodeName, "type", corev1.ServiceTypeLoadBalancer)
+		log.Info("Reconciling per-node public endpoint RPC service", "name", e.svcName, "pod", e.podLabel, "type", corev1.ServiceTypeLoadBalancer)
 		if err := reconcileService(ctx, r.Client, svc, cluster, r.Scheme); err != nil {
 			return err
 		}

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -4636,13 +4636,19 @@ func (r *GarageClusterReconciler) removeStaleRemoteNodes(
 ) error {
 	log := logf.FromContext(ctx)
 
-	// Build set of node IDs that exist in remote cluster
+	// Build map of remote node status for both existence and liveness checks.
 	remoteNodeIDs := make(map[string]bool)
-	for _, node := range remoteStatus.Nodes {
-		remoteNodeIDs[node.ID] = true
+	remoteNodeByID := make(map[string]*garage.NodeInfo, len(remoteStatus.Nodes))
+	for i := range remoteStatus.Nodes {
+		n := &remoteStatus.Nodes[i]
+		remoteNodeIDs[n.ID] = true
+		remoteNodeByID[n.ID] = n
 	}
 
-	// Find nodes in local layout that are tagged with remote cluster name but don't exist in remote
+	// Find nodes in local layout that are tagged with remote cluster name but don't exist in remote,
+	// OR are dead gateway roles (capacity=nil) that have been down beyond the reachability threshold.
+	// Gateway roles carry no data, so removal is always safe — the replacement pod re-imports itself
+	// automatically once it reports IsUp. Storage roles are never speculatively removed.
 	var staleNodes []garage.NodeRoleChange
 	for _, role := range layout.Roles {
 		// Check if this node is tagged as belonging to the remote cluster
@@ -4653,15 +4659,35 @@ func (r *GarageClusterReconciler) removeStaleRemoteNodes(
 				break
 			}
 		}
+		if !isFromRemote {
+			continue
+		}
 
-		if isFromRemote && !remoteNodeIDs[role.ID] {
+		if !remoteNodeIDs[role.ID] {
+			// Node no longer exists in remote Garage's peer list at all.
 			log.Info("Found stale remote node in layout (no longer exists in remote cluster)",
 				"nodeID", shortID(role.ID), "remoteCluster", remote.Name, "zone", role.Zone)
-			staleNodes = append(staleNodes, garage.NodeRoleChange{
-				ID:     role.ID,
-				Remove: true,
-			})
+			staleNodes = append(staleNodes, garage.NodeRoleChange{ID: role.ID, Remove: true})
+			continue
 		}
+
+		// Node is in remote status but may be a dead gateway role (capacity=nil).
+		// Garage keeps dead peers in its node list indefinitely, so a replaced gateway
+		// identity never disappears from remoteNodeIDs — we need the sustained-down check.
+		remoteNode := remoteNodeByID[role.ID]
+		if remoteNode.IsUp || role.Capacity != nil {
+			continue // alive, or a storage role (data-bearing — never speculative-remove)
+		}
+		if remoteNode.LastSeenSecsAgo == nil {
+			continue // never seen = bootstrap noise, not a replaced gateway
+		}
+		if time.Duration(*remoteNode.LastSeenSecsAgo)*time.Second < peerUnreachableThreshold {
+			continue // transient blip
+		}
+		log.Info("Found dead remote gateway role beyond reachability threshold, removing",
+			"nodeID", shortID(role.ID), "remoteCluster", remote.Name,
+			"downSeconds", *remoteNode.LastSeenSecsAgo)
+		staleNodes = append(staleNodes, garage.NodeRoleChange{ID: role.ID, Remove: true})
 	}
 
 	if len(staleNodes) == 0 {

--- a/internal/controller/garagecluster_health.go
+++ b/internal/controller/garagecluster_health.go
@@ -42,16 +42,14 @@ const peerUnreachableThreshold = 10 * time.Minute
 
 // computeUnreachablePeers returns "<shortId> (down <duration>)" descriptions for
 // peers that are not up and were last seen longer ago than the threshold. Only
-// peers that matter are flagged: a peer that holds a role in the CURRENT layout
-// (n.Role != nil) or one that is draining (held a capacity role in a prior layout
-// version and is being removed — Garage reports such a node with role==nil +
-// draining==true). A roleless, non-draining down peer is NOT an actionable member:
-// it is either bootstrap/federation discovery noise (never seen) or a discarded
-// identity Garage still remembers (e.g. a gateway whose metadata PVC was recreated,
-// leaving the old node ID in the peer list) — the ConnectClusterNodes recovery
-// nudge can never reconnect it, so flagging it is misleading noise. Keeping draining
-// nodes preserves visibility into a STUCK drain (node dead, drain not completing),
-// which is exactly when an operator wants the warning.
+// storage peers that matter are flagged: a peer that holds a capacity role in the
+// CURRENT layout (n.Role != nil && n.Role.Capacity != nil) or one that is draining
+// (held a capacity role in a prior layout version — Garage reports such a node with
+// role==nil + draining==true). Gateway peers (capacity==nil) are excluded: dead
+// gateway identities are reaped by reconcileGatewayTombstones, and ConnectClusterNodes
+// can't reconnect a replaced identity anyway, so flagging them is misleading noise.
+// Roleless, non-draining down peers are also excluded (discovery noise / discarded
+// identity with no data responsibility).
 func computeUnreachablePeers(nodes []garage.NodeInfo) []string {
 	var out []string
 	for _, n := range nodes {
@@ -60,6 +58,12 @@ func computeUnreachablePeers(nodes []garage.NodeInfo) []string {
 		}
 		if n.Role == nil && !n.Draining {
 			continue // roleless and not draining: discovery noise or a discarded identity — not actionable
+		}
+		// Gateway peers (capacity=nil) are reaped by reconcileGatewayTombstones.
+		// ConnectClusterNodes can't reconnect a replaced gateway identity, so
+		// PeerUnreachable for them is actionable noise.
+		if n.Role != nil && n.Role.Capacity == nil && !n.Draining {
+			continue
 		}
 		secs := uint64(0)
 		if n.LastSeenSecsAgo != nil {

--- a/internal/controller/garagecluster_health_test.go
+++ b/internal/controller/garagecluster_health_test.go
@@ -160,22 +160,27 @@ func TestSetClusterHealthConditions_NoFederationClearsConditions(t *testing.T) {
 
 func TestComputeUnreachablePeers(t *testing.T) {
 	up := func(secs uint64) *uint64 { return &secs }
-	roled := &garage.NodeAssignedRole{Zone: "z"}
+	cap1 := uint64(1 << 30)
+	storageRole := &garage.NodeAssignedRole{Zone: "z", Capacity: &cap1} // storage (capacity != nil)
+	gatewayRole := &garage.NodeAssignedRole{Zone: "z"}                  // gateway (capacity == nil)
 	nodes := []garage.NodeInfo{
-		{ID: "aaaaaaaaaaaaaaaaaaaa", IsUp: true},                                          // up → ignored
-		{ID: "bbbbbbbbbbbbbbbbbbbb", IsUp: false, LastSeenSecsAgo: up(120), Role: roled},  // 2m down → transient
-		{ID: "cccccccccccccccccccc", IsUp: false, LastSeenSecsAgo: up(1800), Role: roled}, // 30m down, roled → flagged
-		// never seen but holds a layout role → expected member, flagged
-		{ID: "dddddddddddddddddddd", IsUp: false, LastSeenSecsAgo: nil, Role: roled},
+		{ID: "aaaaaaaaaaaaaaaaaaaa", IsUp: true},                                                // up → ignored
+		{ID: "bbbbbbbbbbbbbbbbbbbb", IsUp: false, LastSeenSecsAgo: up(120), Role: storageRole},  // 2m down → transient
+		{ID: "cccccccccccccccccccc", IsUp: false, LastSeenSecsAgo: up(1800), Role: storageRole}, // 30m down, storage → flagged
+		// never seen but holds a storage layout role → expected member, flagged
+		{ID: "dddddddddddddddddddd", IsUp: false, LastSeenSecsAgo: nil, Role: storageRole},
 		// never seen and roleless → bootstrap discovery noise, skipped
 		{ID: "eeeeeeeeeeeeeeeeeeee", IsUp: false, LastSeenSecsAgo: nil},
-		// SUSTAINED down but roleless → a discarded identity Garage still remembers
-		// (e.g. a recreated-PVC gateway orphan); not actionable, must be skipped (#224-class noise).
+		// SUSTAINED down but roleless → a discarded identity Garage still remembers;
+		// not actionable, must be skipped (#224-class noise).
 		{ID: "ffffffffffffffffffff", IsUp: false, LastSeenSecsAgo: up(70000)},
 		// SUSTAINED down + DRAINING → a storage node mid-removal (role==nil + draining
 		// in a prior layout version); a STUCK drain is exactly when the warning matters,
 		// so it must still be flagged despite role==nil.
 		{ID: "gggggggggggggggggggg", IsUp: false, LastSeenSecsAgo: up(1800), Draining: true},
+		// SUSTAINED down gateway peer (capacity==nil) → reaped by reconcileGatewayTombstones,
+		// not ConnectClusterNodes; must be skipped to avoid misleading noise (#237).
+		{ID: "hhhhhhhhhhhhhhhhhhhh", IsUp: false, LastSeenSecsAgo: up(1800), Role: gatewayRole},
 	}
 	got := computeUnreachablePeers(nodes)
 	if len(got) != 3 {
@@ -196,6 +201,9 @@ func TestComputeUnreachablePeers(t *testing.T) {
 	}
 	if !strings.Contains(joined, "gggggggggggggggg") {
 		t.Fatal("sustained-down draining node must still be flagged (stuck-drain visibility)")
+	}
+	if strings.Contains(joined, "hhhhhhhhhhhhhhhh") {
+		t.Fatal("sustained-down gateway peer (capacity=nil) must be skipped — tombstone reaper handles them")
 	}
 }
 

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -102,12 +102,17 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.updateStatus(ctx, key, PhaseFailed, fmt.Errorf("cluster not found: %w", clusterErr))
 	}
 
-	// Guard against calling the Garage API before the cluster layout has converged,
-	// or when the cluster is being deleted (avoids "connection refused" from a dying admin API).
+	// Guard against calling the Garage API before the cluster has any pods at all
+	// (Pending = all pods down, admin API unreachable) or when the cluster has failed.
+	// Degraded (readyReplicas < desired but > 0) is intentionally allowed: the admin
+	// API is still reachable via running pods, so key provisioning succeeds. Blocking
+	// on Phase != Running prevents key operations during routine rolling restarts or
+	// when dead gateway peers cause a cosmetic Degraded (gateway peers don't affect
+	// write quorum or the admin API).
 	if !key.DeletionTimestamp.IsZero() {
 		// Allow deletions to proceed regardless of cluster health.
-	} else if !cluster.DeletionTimestamp.IsZero() || cluster.Status.Phase != PhaseRunning {
-		msg := "waiting for cluster to reach Running phase"
+	} else if !cluster.DeletionTimestamp.IsZero() || cluster.Status.Phase == PhasePending || cluster.Status.Phase == PhaseFailed {
+		msg := "waiting for cluster to start (phase: " + cluster.Status.Phase + ")"
 		if !cluster.DeletionTimestamp.IsZero() {
 			msg = "garage cluster is being deleted"
 		}

--- a/internal/controller/publicendpoint_test.go
+++ b/internal/controller/publicendpoint_test.go
@@ -240,6 +240,100 @@ var _ = Describe("publicEndpoint reconciliation", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
 
+		It("creates per-node LoadBalancer RPC services for gateway-only (edge-gateway) cluster", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 1},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+					ConnectTo: &garagev1beta2.ConnectToConfig{
+						AdminAPIEndpoint: "http://192.168.0.10:3903",
+						AdminTokenSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "ext-admin-token"},
+							Key:                  "token",
+						},
+						RPCSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: peClusterName + "-rpc-secret"},
+							Key:                  RPCSecretKey,
+						},
+					},
+					PublicEndpoint: &garagev1beta2.PublicEndpointConfig{
+						Type: publicEndpointTypeLoadBalancer,
+						LoadBalancer: &garagev1beta2.LoadBalancerEndpointConfig{
+							PerNode: true,
+							ServiceMeta: garagev1beta2.ServiceMeta{
+								Annotations: map[string]string{"lbipam.cilium.io/ips": "10.0.40.105"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			// Shared RPC service must not be created for perNode=true.
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-rpc", Namespace: peNamespace}, &corev1.Service{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			// Per-node service for ordinal 0 must exist and select gateway pod via
+			// statefulset.kubernetes.io/pod-name (Kubernetes auto-adds this label).
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-0-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			Expect(rpcSvc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+			Expect(rpcSvc.Spec.Selector).To(HaveKeyWithValue("statefulset.kubernetes.io/pod-name", peClusterName+"-gateway-0"))
+			Expect(rpcSvc.Spec.Selector).To(HaveKeyWithValue(labelCluster, peClusterName))
+			Expect(rpcSvc.Spec.Ports).To(ContainElement(HaveField("Port", int32(3901))))
+			Expect(rpcSvc.Annotations).To(HaveKeyWithValue("lbipam.cilium.io/ips", "10.0.40.105"))
+
+			updated := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+			cond := findCondition(updated.Status.Conditions, garagev1beta1.ConditionPublicEndpointReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Message).To(ContainSubstring("Per-node LoadBalancer RPC services are reconciled"))
+		})
+
+		It("populates rpc_public_addr in config once the gateway per-node LB service has an IP", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 1},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+					ConnectTo: &garagev1beta2.ConnectToConfig{
+						AdminAPIEndpoint: "http://192.168.0.10:3903",
+						AdminTokenSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "ext-admin-token"},
+							Key:                  "token",
+						},
+						RPCSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: peClusterName + "-rpc-secret"},
+							Key:                  RPCSecretKey,
+						},
+					},
+					PublicEndpoint: &garagev1beta2.PublicEndpointConfig{
+						Type:         publicEndpointTypeLoadBalancer,
+						LoadBalancer: &garagev1beta2.LoadBalancerEndpointConfig{PerNode: true},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			reconcileTwice()
+
+			// Simulate LB IP assignment on the per-node service.
+			rpcSvc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-0-rpc", Namespace: peNamespace}, rpcSvc)).To(Succeed())
+			rpcSvc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.0.40.105"}}
+			Expect(k8sClient.Status().Update(ctx, rpcSvc)).To(Succeed())
+
+			reconciler2 := &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler2.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-config", Namespace: peNamespace}, cm)).To(Succeed())
+			Expect(cm.Data["garage.toml"]).To(ContainSubstring(`rpc_public_addr = "10.0.40.105:3901"`))
+		})
+
 		It("surfaces per-node cluster public endpoints as unsupported in Manual layout mode", func() {
 			cluster := &garagev1beta2.GarageCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: peClusterName, Namespace: peNamespace},


### PR DESCRIPTION
## Summary

Fixes #237 — three related bugs hit during a federation incident where gateway StatefulSets restarted with new node IDs.

- **`removeStaleRemoteNodes`**: also removes dead remote gateway roles (capacity=nil) that have been down beyond `peerUnreachableThreshold`. Garage keeps replaced gateway identities in its peer list indefinitely, so the existing "not-in-remote-status" check never fires for them. Gateway roles carry no data, so threshold-based removal is always safe; a replacement pod re-imports itself once it reports `IsUp`.

- **`computeUnreachablePeers`**: skip peers with `Role.Capacity == nil` (gateway role). Dead gateway identities are reaped by `reconcileGatewayTombstones` and `removeStaleRemoteNodes`. `ConnectClusterNodes` can't reconnect a replaced gateway identity, so `PeerUnreachable` for them is noise that suggests a recovery action that doesn't work.

- **`garagekey_controller`**: gate key provisioning on `Phase == Pending || Phase == Failed` instead of `Phase != Running`. A Degraded cluster (`readyReplicas < desired` but `> 0`) still has a reachable admin API; blocking `GarageKey` on cosmetic Degraded (e.g. dead gateway peers before tombstone cleanup) prevented credential issuance during a healthy data plane — blocking 20 volsync GarageKeys during a data-recovery incident.

## Test plan

- Updated `TestComputeUnreachablePeers` to use explicit storage (capacity≠nil) roles for flagged cases and adds a gateway-role case that must be skipped
- Added `removeStaleRemoteNodes` test: dead gateway role beyond threshold is removed; live gateway role is kept
- Added storage-role safeguard test: a dead storage role beyond threshold is NOT speculatively removed
- `go test ./internal/controller/...` passes