### PR TITLE
fix: Auto-mode readyReplicas misses unlabeled Manual-storage GarageNodes, pinning phase Degraded

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -2278,11 +2278,14 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 			storageDesired = cluster.StorageReplicas()
 			gatewayDesired = cluster.GatewayReplicas()
 
+			// Match nodes by spec.clusterRef (like the Manual branch above), NOT by
+			// the operator's cluster label. A per-tier Manual storage policy means
+			// hand-written GarageNode CRs that may not carry the label; selecting on
+			// the label makes those nodes invisible here, pinning readyReplicas
+			// below desired and the phase at Degraded forever — which in turn gated
+			// GarageKey provisioning (#237).
 			gnList := &garagev1beta1.GarageNodeList{}
-			if err := r.List(ctx, gnList,
-				client.InNamespace(cluster.Namespace),
-				client.MatchingLabels(map[string]string{labelCluster: cluster.Name}),
-			); err != nil {
+			if err := r.List(ctx, gnList, client.InNamespace(cluster.Namespace)); err != nil {
 				log.Error(err, "Failed to list child GarageNodes for status aggregation")
 			} else {
 				for _, n := range gnList.Items {

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -394,6 +394,69 @@ var _ = Describe("GarageCluster Controller", func() {
 			Expect(updated.Status.Selector).To(Equal(labelCluster + "=" + resourceName))
 		})
 
+		It("counts unlabeled clusterRef-matched GarageNodes toward readiness in Auto mode (#237)", func() {
+			// Mirrors the robbinsdale incident: cluster-level Auto with a Manual
+			// storage tier. The storage GarageNodes are hand-written and do NOT
+			// carry the operator's cluster label; the gateway nodes (operator-
+			// generated) do. Selecting children by label made the storage nodes
+			// invisible to status aggregation: ready=2(gw) < desired=3 pinned the
+			// phase at Degraded forever, which gated GarageKey provisioning.
+			const cName = "unlabeled-manual-storage-cluster"
+			cNN := types.NamespacedName{Name: cName, Namespace: testNamespace}
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: cName, Namespace: testNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					LayoutPolicy: LayoutPolicyAuto,
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas:     1,
+						LayoutPolicy: LayoutPolicyManual,
+						Metadata:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+						Data:         &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+					},
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 2},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, cluster) })
+
+			mkNode := func(name string, gateway bool, labels map[string]string) {
+				node := &garagev1beta1.GarageNode{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, Labels: labels},
+					Spec: garagev1beta1.GarageNodeSpec{
+						ClusterRef: garagev1beta1.ClusterReference{Name: cName},
+						Gateway:    gateway,
+					},
+				}
+				if !gateway {
+					node.Spec.Capacity = ptrQuantity(resource.MustParse("10Gi"))
+				}
+				Expect(k8sClient.Create(ctx, node)).To(Succeed())
+				DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+				node.Status.Connected = true
+				Expect(k8sClient.Status().Update(ctx, node)).To(Succeed())
+			}
+
+			// Operator-generated gateway nodes carry the cluster label.
+			mkNode(cName+"-gateway-0", true, map[string]string{labelCluster: cName})
+			mkNode(cName+"-gateway-1", true, map[string]string{labelCluster: cName})
+			// Hand-managed Manual storage node: clusterRef matches, no labels.
+			mkNode(cName+"-storage-smb", false, nil)
+
+			reconciler := &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.updateStatusFromCluster(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, cNN, updated)).To(Succeed())
+			Expect(updated.Status.StorageReadyReplicas).To(Equal(int32(1)),
+				"unlabeled storage GarageNode with matching clusterRef must count as ready")
+			Expect(updated.Status.GatewayReadyReplicas).To(Equal(int32(2)))
+			Expect(updated.Status.ReadyReplicas).To(Equal(int32(3)))
+			Expect(updated.Status.Phase).To(Equal(PhaseRunning),
+				"phase must not be pinned Degraded by label-less Manual storage nodes")
+		})
+
 		It("preserves computed status across a status-update conflict", func() {
 			// Unique cluster name so the status computation (which counts this
 			// cluster's GarageNodes) is not contaminated by operator-owned nodes


### PR DESCRIPTION
Complementary to #239; closes the remaining gap in #237.

## root cause (live-debugged on the keiretsu 3-cluster federation)

#237 attributed the Degraded phase to the 4 down gateway peers. Live evidence says otherwise:

- ottawa carried the **same** 4 sustained-down peers in `status.unreachablePeers` and was **Running**. Conditions never drive phase.
- Phase comes from `readyReplicas < desiredReplicas` in `updateStatusFromCluster`. robbinsdale reported `2/3`, stpetersburg `2/4` — with every pod healthy.
- The missing replicas were the hand-managed Manual storage GarageNodes: the Auto branch lists children with a `garage.rajsingh.info/cluster` **label selector**, while the Manual branch matches `spec.clusterRef`. ottawa's storage CR manifests carry the label (added during its 2026-06-04 Auto→Manual migration); robbinsdale's and stpetersburg's don't, so their storage nodes were invisible to status aggregation and the phase pinned Degraded **since that migration** — which then gated the 20 volsync GarageKeys via the phase check #239 relaxes.
- Confirmed live: adding the label to the 7 storage CRs flipped both clusters to Running within one reconcile and the GarageKeys + restic restores proceeded (manifests fix: keiretsu-labs/kubernetes-manifests@3bec560).

Also for the record on #237: the 4 "stale" ids are not orphaned corpses. They are the **live** ottawa/stpetersburg gateway pods' PVC-persisted identities, claimed by `garage-gateway-{0,1}` `.status.nodeId` on those clusters; the GarageNode controllers there re-staged them after the manual layout removal (`"Updating node in layout" reason="node not in layout"` at 06:10:27Z ottawa / 06:11:10Z stpetersburg = layout v206–v209), which is correct behavior. The peers only look dead cross-region because the tailscale `common-egress` data path broke during the fleet restart; that is cluster infra, not operator logic.

## change

- Drop the label selector in Auto-mode status aggregation and filter on `spec.clusterRef` (which the loop already checks), mirroring the Manual branch.
- Regression test mirroring the incident: 2 labeled gateway GarageNodes + 1 unlabeled Manual storage GarageNode, all connected → must report 3/3 Running (fails 2/3 Degraded before the fix).

`make test` green; the new test red on main, green here.