### PR TITLE
fix(gateway): forward-only edge gateway status (#243) + feat: graceful node cycle (#231)

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -209,6 +209,39 @@ const (
 
 	// ConditionDraining indicates the node is being drained
 	ConditionDraining = "Draining"
+
+	// ConditionCycling indicates a graceful node cycle (garage.rajsingh.info/cycle)
+	// is in progress: a sibling GarageNode has been provisioned and the operator is
+	// driving the add-before-remove swap. The message names the current cycle phase
+	// and the sibling node. Cleared when the cycle completes (this node is deleted).
+	ConditionCycling = "Cycling"
+)
+
+// GarageNode cycle phases recorded on status.cyclePhase to drive the
+// add-before-remove replacement state machine (garage.rajsingh.info/cycle).
+const (
+	// CyclePhaseProvisioning indicates the sibling GarageNode has been (or is being)
+	// created and is waiting for its node ID + StatefulSet to come up.
+	CyclePhaseProvisioning = "Provisioning"
+
+	// CyclePhaseSyncing indicates the sibling is in the layout and the operator is
+	// waiting for its sync tracker to reach the current layout version (all the
+	// partitions it owns are replicated to it).
+	CyclePhaseSyncing = "Syncing"
+
+	// CyclePhaseDraining indicates the sibling is fully synced and this node is being
+	// drained and removed from the layout ahead of deletion.
+	CyclePhaseDraining = "Draining"
+)
+
+// Condition reasons for the node-cycle surface.
+const (
+	// ReasonCycleProvisioning indicates the sibling GarageNode is being provisioned.
+	ReasonCycleProvisioning = "SiblingProvisioning"
+	// ReasonCycleSyncing indicates the operator is waiting for the sibling to sync.
+	ReasonCycleSyncing = "SiblingSyncing"
+	// ReasonCycleDraining indicates this node is being drained and removed.
+	ReasonCycleDraining = "Draining"
 )
 
 // GarageAdminToken condition types
@@ -277,6 +310,13 @@ const (
 	// the external cluster cannot reach the gateway (check publicEndpoint / rpcPublicAddr)
 	ReasonGatewayPartiallyConnected = "PartiallyConnected"
 
+	// ReasonGatewayForwardOnly indicates the gateway reaches the external cluster but
+	// the reverse direction is not establishable because the edge gateway has no
+	// externally-routable RPC address configured (no gateway/network rpcPublicAddr and
+	// no publicEndpoint). A gateway holds no data, so forward-only connectivity is a
+	// healthy steady state rather than a failure to retry — treated as Connected.
+	ReasonGatewayForwardOnly = "ForwardOnly"
+
 	// ReasonGatewayNodesOffline indicates no nodes are connected in either direction
 	ReasonGatewayNodesOffline = "NodesOffline"
 
@@ -325,6 +365,18 @@ const (
 
 	// AnnotationSkipLayout excludes a node from the layout temporarily when set to "true"
 	AnnotationSkipLayout = AnnotationPrefix + "skip-layout"
+
+	// AnnotationCycle triggers a graceful add-before-remove node replacement when
+	// set to "true". The operator provisions a sibling GarageNode (fresh node ID +
+	// PVCs, same zone/capacity/tags), waits for the sibling's layout sync tracker
+	// to reach the current layout version (all partitions it owns are in sync),
+	// then drains and removes this node from the layout and deletes it. The cluster
+	// stays above quorum throughout — unlike a plain delete-then-recreate, which
+	// dips replication. Works for both Auto-owned and Manual GarageNodes. One-shot:
+	// progress is tracked on status.cyclePhase so the state machine resumes on
+	// requeue instead of re-provisioning the sibling. Cleared implicitly when the
+	// node is deleted at the end of the cycle.
+	AnnotationCycle = AnnotationPrefix + "cycle"
 
 	// GarageBucket annotations
 

--- a/api/v1beta1/garagenode_types.go
+++ b/api/v1beta1/garagenode_types.go
@@ -457,6 +457,25 @@ type GarageNodeStatus struct {
 	// +optional
 	ClusterAdminTokenSecretRef *corev1.SecretKeySelector `json:"clusterAdminTokenSecretRef,omitempty"`
 
+	// CyclePhase tracks progress of a graceful node cycle triggered by the
+	// garage.rajsingh.info/cycle annotation. Empty when no cycle is active.
+	// Used to make the add-before-remove state machine resumable/idempotent
+	// across requeues: a non-empty value means a sibling has already been
+	// provisioned, so the operator continues the swap rather than re-provisioning.
+	// +kubebuilder:validation:Enum=Provisioning;Syncing;Draining
+	// +optional
+	CyclePhase string `json:"cyclePhase,omitempty"`
+
+	// CycleSiblingName is the name of the sibling GarageNode provisioned for an
+	// in-progress cycle (the replacement that takes over this node's layout slot).
+	// +optional
+	CycleSiblingName string `json:"cycleSiblingName,omitempty"`
+
+	// CycleSiblingNodeID is the discovered Garage node ID of the cycle sibling,
+	// used to check its layout sync tracker before this node is removed.
+	// +optional
+	CycleSiblingNodeID string `json:"cycleSiblingNodeId,omitempty"`
+
 	// Conditions represent the current state
 	// +listType=map
 	// +listMapKey=type

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
@@ -2594,6 +2594,28 @@ spec:
               connected:
                 description: Connected indicates if the node is currently connected
                 type: boolean
+              cyclePhase:
+                description: |-
+                  CyclePhase tracks progress of a graceful node cycle triggered by the
+                  garage.rajsingh.info/cycle annotation. Empty when no cycle is active.
+                  Used to make the add-before-remove state machine resumable/idempotent
+                  across requeues: a non-empty value means a sibling has already been
+                  provisioned, so the operator continues the swap rather than re-provisioning.
+                enum:
+                - Provisioning
+                - Syncing
+                - Draining
+                type: string
+              cycleSiblingName:
+                description: |-
+                  CycleSiblingName is the name of the sibling GarageNode provisioned for an
+                  in-progress cycle (the replacement that takes over this node's layout slot).
+                type: string
+              cycleSiblingNodeId:
+                description: |-
+                  CycleSiblingNodeID is the discovered Garage node ID of the cycle sibling,
+                  used to check its layout sync tracker before this node is removed.
+                type: string
               dataPartition:
                 description: |-
                   DataPartition contains disk space info for the data partition

--- a/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
@@ -2594,6 +2594,28 @@ spec:
               connected:
                 description: Connected indicates if the node is currently connected
                 type: boolean
+              cyclePhase:
+                description: |-
+                  CyclePhase tracks progress of a graceful node cycle triggered by the
+                  garage.rajsingh.info/cycle annotation. Empty when no cycle is active.
+                  Used to make the add-before-remove state machine resumable/idempotent
+                  across requeues: a non-empty value means a sibling has already been
+                  provisioned, so the operator continues the swap rather than re-provisioning.
+                enum:
+                - Provisioning
+                - Syncing
+                - Draining
+                type: string
+              cycleSiblingName:
+                description: |-
+                  CycleSiblingName is the name of the sibling GarageNode provisioned for an
+                  in-progress cycle (the replacement that takes over this node's layout slot).
+                type: string
+              cycleSiblingNodeId:
+                description: |-
+                  CycleSiblingNodeID is the discovered Garage node ID of the cycle sibling,
+                  used to check its layout sync tracker before this node is removed.
+                type: string
               dataPartition:
                 description: |-
                   DataPartition contains disk space info for the data partition

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -148,6 +148,19 @@ func (r *GarageClusterReconciler) reconcileAutoModeStorageNodes(ctx context.Cont
 			return fmt.Errorf("building desired GarageNode for ordinal %d: %w", i, err)
 		}
 
+		// Graceful node cycle (#231): a cycle for this ordinal provisions a
+		// sibling named "<ordinal>-cycle" which is promoted to an operator-managed
+		// node once the original is drained and deleted. In the brief window after
+		// the original "<cluster>-storage-N" is deleted, the promoted sibling holds
+		// the ordinal's layout slot. Treat the ordinal as satisfied so we don't
+		// recreate a fresh "<cluster>-storage-N" (which would re-replicate from
+		// scratch and undo the cycle). Keep the promoted sibling in the keep-set.
+		siblingName := desired.Name + cycleSiblingSuffix
+		if sib, ok := existing[siblingName]; ok && !isCycleSibling(sib) {
+			desiredByName[siblingName] = true
+			continue
+		}
+
 		current, found := existing[desired.Name]
 		if !found {
 			log.Info("Creating Auto-mode GarageNode", "name", desired.Name)

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3538,6 +3538,15 @@ func (r *GarageClusterReconciler) reconcileGatewayConnection(ctx context.Context
 // external cluster's view. Returns false on any API error or if any node is offline,
 // which triggers a full reconnect via connectGatewayToExternalCluster.
 func (r *GarageClusterReconciler) isExternalGatewayConnected(ctx context.Context, cluster *garagev1beta2.GarageCluster, gatewayClient *garage.Client) bool {
+	// Forward-only edge gateway (#243): the external cluster has no address to dial
+	// the gateway on, so it will never report the gateway as isUp. Probing for reverse
+	// reachability here would always fail and re-drive the full connect loop every
+	// reconcile (re-staging layout churn under autoApply). The forward connection is
+	// the only one that exists or matters for a dataless gateway — treat it as
+	// converged so the reconcile backs off to the long requeue.
+	if edgeGatewayReverseUnroutable(cluster) {
+		return true
+	}
 	externalClient, err := r.getExternalStorageClient(ctx, cluster)
 	if err != nil {
 		return false
@@ -3809,6 +3818,75 @@ func (r *GarageClusterReconciler) externalRPCFallbackAddr(cluster *garagev1beta2
 	return rpcAddr(u.Hostname(), rpcPort)
 }
 
+// edgeGatewayReverseUnroutable reports whether an edge gateway (gateway tier +
+// connectTo, no local storage) has no externally-routable RPC address the external
+// cluster could ever dial back on — none of spec.gateway.rpcPublicAddr,
+// spec.network.rpcPublicAddr, or spec.publicEndpoint is set. This is the bare
+// Docker/TrueNAS/NAT topology in #243: the gateway runs inside Kubernetes, the
+// external Garage lives outside, and the gateway's pod IP is genuinely not reachable
+// from there. The reverse ConnectNode therefore can't succeed and never will —
+// retrying it forever (and re-staging layout churn under autoApply) is pointless.
+//
+// This mirrors the admission webhook predicate that already warns on this exact
+// topology (validateRPCPublicAddr): the maintainer treats it as legitimate-but-
+// degraded, not invalid, so the runtime must not report it as a hard failure.
+func edgeGatewayReverseUnroutable(cluster *garagev1beta2.GarageCluster) bool {
+	return cluster.HasGatewayTier() && !cluster.HasStorageTier() &&
+		cluster.Spec.ConnectTo != nil &&
+		(cluster.Spec.Gateway == nil || cluster.Spec.Gateway.RPCPublicAddr == "") &&
+		cluster.Spec.Network.RPCPublicAddr == "" &&
+		cluster.Spec.PublicEndpoint == nil
+}
+
+// gatewayConnectedCondition decides the GatewayConnected condition from the two
+// connection counts. Pulled out as a pure function so the #243 forward-only case is
+// unit-testable without a live cluster.
+//
+//   - reverse established (connectedToGateway > 0): bidirectional, Connected.
+//   - forward only AND reverse is genuinely unroutable (bare edge gateway, no
+//     rpcPublicAddr/publicEndpoint): a gateway carries no data, so this is a healthy
+//     steady state — report Connected with the ForwardOnly reason so the reconcile
+//     loop converges instead of re-running connect (and churning layout) forever.
+//   - forward only with a routable address configured but reverse still failing: a
+//     real misconfiguration — keep PartiallyConnected so it surfaces and retries.
+//   - neither direction: NodesOffline.
+func gatewayConnectedCondition(cluster *garagev1beta2.GarageCluster, connectedToExternal, connectedToGateway int) metav1.Condition {
+	switch {
+	case connectedToGateway > 0:
+		return metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionTrue,
+			Reason:             garagev1beta1.ReasonGatewayConnected,
+			Message:            fmt.Sprintf("Bidirectional connection established (%d gateway→external, %d external→gateway)", connectedToExternal, connectedToGateway),
+			ObservedGeneration: cluster.Generation,
+		}
+	case connectedToExternal > 0 && edgeGatewayReverseUnroutable(cluster):
+		return metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionTrue,
+			Reason:             garagev1beta1.ReasonGatewayForwardOnly,
+			Message:            fmt.Sprintf("Gateway connected to external cluster (%d gateway→external); reverse connection not configured (no rpcPublicAddr/publicEndpoint). A gateway holds no data, so forward-only is sufficient — set spec.gateway.rpcPublicAddr to make the gateway visible in the external cluster's node list", connectedToExternal),
+			ObservedGeneration: cluster.Generation,
+		}
+	case connectedToExternal > 0:
+		return metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonGatewayPartiallyConnected,
+			Message:            "Gateway can reach external cluster but external cluster cannot reach gateway — check publicEndpoint or network.rpcPublicAddr",
+			ObservedGeneration: cluster.Generation,
+		}
+	default:
+		return metav1.Condition{
+			Type:               garagev1beta1.ConditionGatewayConnected,
+			Status:             metav1.ConditionFalse,
+			Reason:             garagev1beta1.ReasonGatewayNodesOffline,
+			Message:            "No nodes connected between gateway and external cluster",
+			ObservedGeneration: cluster.Generation,
+		}
+	}
+}
+
 func (r *GarageClusterReconciler) loadBalancerServiceAddr(ctx context.Context, namespace, name string, rpcPort int32) string {
 	svc := &corev1.Service{}
 	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, svc); err != nil {
@@ -3940,32 +4018,8 @@ func (r *GarageClusterReconciler) connectGatewayToExternalCluster(ctx context.Co
 			"externalToGateway", connectedToGateway)
 	}
 
-	switch {
-	case connectedToGateway > 0:
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               garagev1beta1.ConditionGatewayConnected,
-			Status:             metav1.ConditionTrue,
-			Reason:             garagev1beta1.ReasonGatewayConnected,
-			Message:            fmt.Sprintf("Bidirectional connection established (%d gateway→external, %d external→gateway)", connectedToExternal, connectedToGateway),
-			ObservedGeneration: cluster.Generation,
-		})
-	case connectedToExternal > 0:
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               garagev1beta1.ConditionGatewayConnected,
-			Status:             metav1.ConditionFalse,
-			Reason:             garagev1beta1.ReasonGatewayPartiallyConnected,
-			Message:            "Gateway can reach external cluster but external cluster cannot reach gateway — check publicEndpoint or network.rpcPublicAddr",
-			ObservedGeneration: cluster.Generation,
-		})
-	default:
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               garagev1beta1.ConditionGatewayConnected,
-			Status:             metav1.ConditionFalse,
-			Reason:             garagev1beta1.ReasonGatewayNodesOffline,
-			Message:            "No nodes connected between gateway and external cluster",
-			ObservedGeneration: cluster.Generation,
-		})
-	}
+	meta.SetStatusCondition(&cluster.Status.Conditions,
+		gatewayConnectedCondition(cluster, connectedToExternal, connectedToGateway))
 }
 
 // reconcileFederation connects this cluster to remote Garage clusters.
@@ -5237,6 +5291,15 @@ const labelTier = "garage.rajsingh.info/tier"
 // independent of the StatefulSet's pod-name convention, so it's the right
 // selector for per-pod Services (e.g. per-node LoadBalancer RPC).
 const labelGarageNode = "garage.rajsingh.info/node"
+
+// labelCycleSibling marks a GarageNode that was provisioned by the graceful
+// node-cycle state machine (#231) as the in-progress replacement for another
+// node. While set, the cluster's Auto-mode scale loop must NOT manage the node
+// as one of its ordinals — listAutoModeStorageNodes deliberately filters it out
+// (the sibling carries no labelAppManagedBy=operator until it is promoted at the
+// end of the cycle). Cleared when the original node is drained and the sibling
+// takes over the layout slot.
+const labelCycleSibling = "garage.rajsingh.info/cycle-sibling"
 
 // labelsForTier returns operator-managed labels scoped to a single tier. Use this
 // when labelling tier-owned resources (StatefulSet / Deployment / per-tier service /

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -404,6 +404,23 @@ func (r *GarageClusterReconciler) reconcileGatewayTombstones(ctx context.Context
 		return
 	}
 
+	// Forward-only edge gateway (#243): the external cluster cannot dial back to the
+	// gateway pods (no rpcPublicAddr/publicEndpoint), so it permanently reports the
+	// gateway's role as not isUp. The reaper keys staleness off isUp and edge gateways
+	// have no claimed-set protection, so it would reap the gateway's own live role
+	// every cycle — and under autoApply the gateway immediately re-registers, yielding
+	// the infinite add/remove layout churn. The role is not actually stale; skip the
+	// reaper for this topology. (A real removal still happens via the GarageNode/STS
+	// finalizer path on delete.)
+	if edgeGatewayReverseUnroutable(cluster) {
+		log.V(1).Info("Skipping gateway tombstone cleanup (forward-only edge gateway; reverse reachability not configured)")
+		if len(cluster.Status.PendingGatewayTombstones) > 0 {
+			cluster.Status.PendingGatewayTombstones = nil
+		}
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, garagev1beta1.ConditionGatewayTombstones)
+		return
+	}
+
 	layoutClient, err := r.gatewayLayoutClient(ctx, cluster)
 	if err != nil {
 		log.V(1).Info("Skipping gateway tombstone cleanup (admin client not ready)", "error", err)

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -142,7 +142,12 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Auto mode in #190) are allowed regardless of policy. Storage nodes honor the
 	// per-tier effective policy (spec.storage.layoutPolicy), so a cluster can be
 	// Manual-storage + Auto-gateway; gateway nodes follow the cluster policy.
-	isOperatorOwned := metav1.IsControlledBy(node, cluster)
+	//
+	// A cycle sibling (#231) is operator-generated — owned by the GarageNode it is
+	// replacing, not by the cluster — so it is exempt from the Manual-only gate the
+	// same way an Auto ordinal is; otherwise an Auto cluster's sibling would be
+	// rejected before it could ever join and sync.
+	isOperatorOwned := metav1.IsControlledBy(node, cluster) || isCycleSibling(node)
 	tierPolicy := effectiveStorageLayoutPolicy(cluster)
 	tierName := "storage"
 	if node.Spec.Gateway {
@@ -243,8 +248,14 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Clear Suspended condition when not suspended.
 	meta.RemoveStatusCondition(&node.Status.Conditions, "Suspended")
 
-	// TODO(#190): per-node `garage.rajsingh.info/cycle: true` annotation —
-	// provision sibling GarageNode, wait for sync_map_min, swap. Deferred from #190.
+	// Graceful node cycle (#231): the garage.rajsingh.info/cycle annotation does an
+	// add-before-remove swap — provision a sibling, wait for it to sync, then drain
+	// + remove this node. Resumable via status.cyclePhase. When a cycle is active or
+	// requested, reconcileCycle owns the rest of this reconcile (it may delete this
+	// node when the swap completes), so return on its result.
+	if isCycleRequested(node) || node.Status.CyclePhase != "" {
+		return r.reconcileCycle(ctx, node, cluster)
+	}
 
 	// Reconcile per-node RPC service when publicEndpoint is configured
 	if node.Spec.External == nil && node.Spec.PublicEndpoint != nil {

--- a/internal/controller/garagenode_cycle.go
+++ b/internal/controller/garagenode_cycle.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+// cycleSiblingSuffix is appended to a GarageNode name to derive its cycle
+// sibling's name. The sibling is a transient replacement that takes over the
+// original's layout slot; once the swap completes the original is deleted and
+// the sibling lives on under this name (it is NOT renamed back — renaming a
+// GarageNode would churn its StatefulSet identity and PVCs).
+const cycleSiblingSuffix = "-cycle"
+
+// isCycleRequested reports whether the garage.rajsingh.info/cycle annotation is
+// set to "true" on this node.
+func isCycleRequested(node *garagev1beta1.GarageNode) bool {
+	return node.Annotations[garagev1beta1.AnnotationCycle] == annotationTrue
+}
+
+// isCycleSibling reports whether this GarageNode is itself a cycle sibling
+// (provisioned by reconcileCycle for another node). Sibling nodes must never
+// start their own cycle, and the cluster's Auto-mode loop must not manage them
+// as ordinals — both are enforced by the dedicated name suffix + the absence of
+// the operator managed-by/tier labels carried by Auto-owned ordinals.
+func isCycleSibling(node *garagev1beta1.GarageNode) bool {
+	return node.Labels[labelCycleSibling] == annotationTrue
+}
+
+// reconcileCycle drives the add-before-remove node replacement state machine for
+// a GarageNode carrying the garage.rajsingh.info/cycle annotation. It is
+// resumable and idempotent: progress lives on status.cyclePhase + the existence
+// of the sibling GarageNode, so a requeue mid-cycle continues from where it left
+// off rather than re-provisioning.
+//
+// Phases:
+//
+//	(start) -> Provisioning : create the sibling GarageNode (fresh node ID + PVCs,
+//	                          same zone/capacity/tags/storage). Wait for it to come
+//	                          up and discover its node ID.
+//	Provisioning -> Syncing : sibling has a node ID and is in the layout; wait for
+//	                          its layout sync tracker to reach the current version
+//	                          (all partitions it owns are in sync).
+//	Syncing -> Draining     : sibling is fully synced; delete this node, whose
+//	                          finalizer drains + removes it from the layout and
+//	                          reaps its StatefulSet/PVCs. The sibling lives on.
+//
+// A cycle sibling never cycles itself (guarded by the caller resolving the
+// annotation only on non-sibling nodes plus the isCycleSibling check here).
+func (r *GarageNodeReconciler) reconcileCycle(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	// A sibling node must never run a cycle of its own — that would recurse
+	// endlessly. Clear any stray annotation and fall back to normal reconcile.
+	if isCycleSibling(node) {
+		if isCycleRequested(node) {
+			delete(node.Annotations, garagev1beta1.AnnotationCycle)
+			if err := r.Update(ctx, node); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	siblingName := node.Name + cycleSiblingSuffix
+	if node.Status.CycleSiblingName != "" {
+		siblingName = node.Status.CycleSiblingName
+	}
+
+	// Look up the sibling; absent means we are at the start of the cycle (or a
+	// prior provision attempt was lost) and must (re)create it.
+	sibling := &garagev1beta1.GarageNode{}
+	err := r.Get(ctx, types.NamespacedName{Name: siblingName, Namespace: node.Namespace}, sibling)
+	switch {
+	case errors.IsNotFound(err):
+		return r.cycleProvisionSibling(ctx, node, siblingName)
+	case err != nil:
+		return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("getting cycle sibling %s: %w", siblingName, err))
+	}
+
+	// Sibling exists. Resume the state machine from its observed state. If the
+	// sibling has not yet discovered its node ID, it is still coming up.
+	if sibling.Status.NodeID == "" {
+		return r.cycleSetPhase(ctx, node, garagev1beta1.CyclePhaseProvisioning, siblingName, "",
+			garagev1beta1.ReasonCycleProvisioning,
+			fmt.Sprintf("sibling %s provisioning; waiting for node ID", siblingName))
+	}
+
+	// Sibling has a node ID — check whether it has synced to the current layout
+	// version. We need the cluster admin API for the layout history.
+	garageClient, err := GetGarageClient(ctx, r.Client, cluster, r.ClusterDomain)
+	if err != nil {
+		return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("cycle: failed to create garage client: %w", err))
+	}
+
+	history, err := garageClient.GetClusterLayoutHistory(ctx)
+	if err != nil {
+		return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("cycle: failed to get layout history: %w", err))
+	}
+
+	if !history.NodeSyncedToCurrent(sibling.Status.NodeID) {
+		log.V(1).Info("Cycle sibling not yet synced to current layout version",
+			"node", node.Name, "sibling", siblingName, "siblingNodeID", sibling.Status.NodeID,
+			"currentVersion", history.CurrentVersion)
+		return r.cycleSetPhase(ctx, node, garagev1beta1.CyclePhaseSyncing, siblingName, sibling.Status.NodeID,
+			garagev1beta1.ReasonCycleSyncing,
+			fmt.Sprintf("sibling %s syncing to layout version %d", siblingName, history.CurrentVersion))
+	}
+
+	// Sibling is fully synced. The cluster is now safe to lose this node without
+	// dipping replication. Record the Draining phase, then delete this node — its
+	// finalizer drains + removes it from the layout and reaps its StatefulSet/PVCs.
+	log.Info("Cycle sibling synced; draining and removing original node",
+		"node", node.Name, "sibling", siblingName, "siblingNodeID", sibling.Status.NodeID)
+
+	if node.Status.CyclePhase != garagev1beta1.CyclePhaseDraining {
+		if _, err := r.cycleSetPhase(ctx, node, garagev1beta1.CyclePhaseDraining, siblingName, sibling.Status.NodeID,
+			garagev1beta1.ReasonCycleDraining,
+			fmt.Sprintf("sibling %s synced; draining and removing this node", siblingName)); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Promote the sibling out of cycle-sibling status so the cluster Auto-mode
+	// loop (or a human, for Manual nodes) treats it as a first-class node going
+	// forward, and so it never gets mistaken for an orphaned sibling.
+	if err := r.cyclePromoteSibling(ctx, node, sibling); err != nil {
+		return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("cycle: promoting sibling %s: %w", siblingName, err))
+	}
+
+	if err := r.Delete(ctx, node); err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("cycle: deleting drained node %s: %w", node.Name, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// cycleProvisionSibling creates the sibling GarageNode that will replace this
+// node. The sibling clones the layout-relevant spec (zone, capacity, tags,
+// storage) but gets a fresh node ID and fresh PVCs (no existingClaim / no
+// NodeID), so it re-replicates into the cluster cleanly. It is owned by the
+// original node (controller ref) so a stuck cycle is garbage-collected with the
+// original, and it is labelled as a cycle sibling so the cluster's Auto-mode
+// scale loop leaves it alone.
+func (r *GarageNodeReconciler) cycleProvisionSibling(ctx context.Context, node *garagev1beta1.GarageNode, siblingName string) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	sibling := &garagev1beta1.GarageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      siblingName,
+			Namespace: node.Namespace,
+			Labels:    cycleSiblingLabels(node),
+		},
+		Spec: cloneCycleNodeSpec(node),
+	}
+	if err := controllerutil.SetControllerReference(node, sibling, r.Scheme); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cycle: setting owner ref on sibling %s: %w", siblingName, err)
+	}
+
+	if err := r.Create(ctx, sibling); err != nil && !errors.IsAlreadyExists(err) {
+		return r.updateStatus(ctx, node, PhaseFailed, fmt.Errorf("cycle: creating sibling %s: %w", siblingName, err))
+	}
+	log.Info("Provisioned cycle sibling GarageNode", "node", node.Name, "sibling", siblingName)
+
+	return r.cycleSetPhase(ctx, node, garagev1beta1.CyclePhaseProvisioning, siblingName, "",
+		garagev1beta1.ReasonCycleProvisioning,
+		fmt.Sprintf("provisioned sibling %s; waiting for it to join and sync", siblingName))
+}
+
+// cyclePromoteSibling rewrites the sibling so it survives as a first-class node
+// once the original is gone. It strips the cycle-sibling marker label, drops the
+// controller owner ref to the (about-to-be-deleted) original node, and — for
+// Auto-owned cycles — stamps the Auto-mode managed-by/tier labels so the cluster
+// loop adopts it. For Manual cycles the sibling simply becomes a standalone node.
+func (r *GarageNodeReconciler) cyclePromoteSibling(ctx context.Context, node, sibling *garagev1beta1.GarageNode) error {
+	changed := false
+
+	if sibling.Labels != nil && sibling.Labels[labelCycleSibling] != "" {
+		delete(sibling.Labels, labelCycleSibling)
+		changed = true
+	}
+
+	// Drop the owner ref to the original so deleting the original doesn't cascade
+	// to the sibling.
+	if owner := metav1.GetControllerOf(sibling); owner != nil && owner.Name == node.Name && owner.Kind == "GarageNode" {
+		filtered := sibling.OwnerReferences[:0]
+		for _, ref := range sibling.OwnerReferences {
+			if ref.Kind == "GarageNode" && ref.Name == node.Name {
+				continue
+			}
+			filtered = append(filtered, ref)
+		}
+		sibling.OwnerReferences = filtered
+		changed = true
+	}
+
+	// If the original was an Auto-owned ordinal, hand the sibling the same
+	// managed-by/tier labels so the cluster loop sees it as a managed storage
+	// node. (Auto-owned nodes carry labelAppManagedBy=operator + labelTier.)
+	if node.Labels[labelAppManagedBy] == managedByOperatorValue && node.Labels[labelTier] != "" {
+		if sibling.Labels == nil {
+			sibling.Labels = map[string]string{}
+		}
+		if sibling.Labels[labelAppManagedBy] != managedByOperatorValue {
+			sibling.Labels[labelAppManagedBy] = managedByOperatorValue
+			changed = true
+		}
+		if sibling.Labels[labelTier] != node.Labels[labelTier] {
+			sibling.Labels[labelTier] = node.Labels[labelTier]
+			changed = true
+		}
+		if sibling.Labels[labelCluster] != node.Labels[labelCluster] {
+			sibling.Labels[labelCluster] = node.Labels[labelCluster]
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+	return r.Update(ctx, sibling)
+}
+
+// cycleSetPhase records cycle progress on status (phase + sibling identity) and
+// sets the Cycling condition, then requeues so the state machine advances on the
+// next reconcile.
+func (r *GarageNodeReconciler) cycleSetPhase(ctx context.Context, node *garagev1beta1.GarageNode, phase, siblingName, siblingNodeID, reason, message string) (ctrl.Result, error) {
+	apply := func() {
+		node.Status.CyclePhase = phase
+		node.Status.CycleSiblingName = siblingName
+		if siblingNodeID != "" {
+			node.Status.CycleSiblingNodeID = siblingNodeID
+		}
+		meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
+			Type:               garagev1beta1.ConditionCycling,
+			Status:             metav1.ConditionTrue,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: node.Generation,
+		})
+	}
+	apply()
+	if err := UpdateStatusWithRetry(ctx, r.Client, node, apply); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
+}
+
+// cloneCycleNodeSpec returns a GarageNodeSpec for a cycle sibling: the same
+// layout-relevant + pod-config fields as the original, but with a fresh node ID
+// (empty) and freshly provisioned storage (existingClaim stripped) so the
+// sibling re-replicates rather than adopting the original's data. The cycle
+// annotation is intentionally NOT carried over.
+func cloneCycleNodeSpec(node *garagev1beta1.GarageNode) garagev1beta1.GarageNodeSpec {
+	spec := *node.Spec.DeepCopy()
+	// Fresh identity + storage: the whole point of a cycle is a new node ID and
+	// new PVCs (hardware swap, storageClass migration, etc.).
+	spec.NodeID = ""
+	if spec.Storage != nil {
+		if spec.Storage.Metadata != nil {
+			spec.Storage.Metadata.ExistingClaim = ""
+		}
+		if spec.Storage.Data != nil {
+			spec.Storage.Data.ExistingClaim = ""
+		}
+		for i := range spec.Storage.DataPaths {
+			spec.Storage.DataPaths[i].ExistingClaim = ""
+		}
+	}
+	return spec
+}
+
+// cycleSiblingLabels builds the label set for a cycle sibling: it inherits the
+// original's cluster label for selector/observability parity but is explicitly
+// marked as a cycle sibling and withheld the Auto-mode managed-by label so the
+// cluster's Auto-mode scale loop does not manage it as an ordinal mid-cycle.
+func cycleSiblingLabels(node *garagev1beta1.GarageNode) map[string]string {
+	labels := map[string]string{
+		labelCycleSibling: annotationTrue,
+	}
+	if c := node.Labels[labelCluster]; c != "" {
+		labels[labelCluster] = c
+	}
+	return labels
+}

--- a/internal/controller/garagenode_cycle_test.go
+++ b/internal/controller/garagenode_cycle_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
+)
+
+// Graceful node cycle (#231) — add-before-remove replacement state machine.
+var _ = Describe("GarageNode graceful cycle", func() {
+	const (
+		ns          = "cycle-ns"
+		clusterName = "cyc"
+		nodeName    = "cyc-storage-0"
+		siblingName = "cyc-storage-0-cycle"
+		siblingID   = "1111111111111111111111111111111111111111111111111111111111111111"
+	)
+
+	var (
+		bctx   context.Context
+		scheme *runtime.Scheme
+		cap    resource.Quantity
+		dataSz resource.Quantity
+	)
+
+	BeforeEach(func() {
+		bctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(garagev1beta2.AddToScheme(scheme)).To(Succeed())
+		cap = resource.MustParse("100Gi")
+		dataSz = resource.MustParse("100Gi")
+	})
+
+	// mkCluster returns an Auto cluster CR (no admin endpoint wired — tests that
+	// need the layout-history call drive the predicate directly).
+	mkCluster := func() *garagev1beta2.GarageCluster {
+		return &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: ns, UID: "cyc-uid"},
+			Spec: garagev1beta2.GarageClusterSpec{
+				LayoutPolicy: LayoutPolicyAuto,
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas: 1,
+					Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+				},
+				Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+			},
+		}
+	}
+
+	// mkNode returns an Auto-owned storage GarageNode carrying the cycle
+	// annotation, with the finalizer already set so the reconcile skips the
+	// add-finalizer requeue and reaches the cycle handler.
+	mkNode := func(annotated bool) *garagev1beta1.GarageNode {
+		ann := map[string]string{}
+		if annotated {
+			ann[garagev1beta1.AnnotationCycle] = annotationTrue
+		}
+		// Auto-owned: the cluster is the controller owner, which is what marks the
+		// node operator-owned (metav1.IsControlledBy) and lets it bypass the
+		// Manual-only policy gate.
+		owner := mkCluster()
+		return &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        nodeName,
+				Namespace:   ns,
+				Annotations: ann,
+				Finalizers:  []string{garageNodeFinalizer},
+				Labels: map[string]string{
+					labelCluster:      clusterName,
+					labelTier:         tierStorage,
+					labelAppManagedBy: managedByOperatorValue,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         garagev1beta2.GroupVersion.String(),
+					Kind:               "GarageCluster",
+					Name:               owner.Name,
+					UID:                "cyc-uid",
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				}},
+			},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &cap,
+				Tags:       []string{"role:hot"},
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Size: &dataSz},
+					Data:     &garagev1beta1.NodeVolumeConfig{Size: &dataSz},
+				},
+			},
+			Status: garagev1beta1.GarageNodeStatus{NodeID: "deadbeef"},
+		}
+	}
+
+	It("creates a sibling and records the Provisioning phase when the cycle annotation is set", func() {
+		node := mkNode(true)
+		fc := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(mkCluster(), node).
+			WithStatusSubresource(&garagev1beta1.GarageNode{}).
+			Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		res, err := r.Reconcile(bctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nodeName, Namespace: ns}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+		By("creating the sibling GarageNode with fresh identity + cloned layout spec")
+		sib := &garagev1beta1.GarageNode{}
+		Expect(fc.Get(bctx, types.NamespacedName{Name: siblingName, Namespace: ns}, sib)).To(Succeed())
+		Expect(sib.Spec.Zone).To(Equal(testNodeZone))
+		Expect(sib.Spec.Capacity.Cmp(cap)).To(Equal(0))
+		Expect(sib.Spec.Tags).To(ConsistOf("role:hot"))
+		Expect(sib.Spec.NodeID).To(BeEmpty(), "sibling must get a fresh node ID")
+		Expect(isCycleSibling(sib)).To(BeTrue(), "sibling must be marked so the cluster loop ignores it")
+		Expect(sib.Labels).NotTo(HaveKey(labelAppManagedBy), "sibling must not be Auto-managed until promoted")
+
+		By("recording cycle progress on the original's status")
+		got := &garagev1beta1.GarageNode{}
+		Expect(fc.Get(bctx, types.NamespacedName{Name: nodeName, Namespace: ns}, got)).To(Succeed())
+		Expect(got.Status.CyclePhase).To(Equal(garagev1beta1.CyclePhaseProvisioning))
+		Expect(got.Status.CycleSiblingName).To(Equal(siblingName))
+		Expect(meta.IsStatusConditionTrue(got.Status.Conditions, garagev1beta1.ConditionCycling)).To(BeTrue())
+	})
+
+	It("resumes an in-progress cycle without re-provisioning when the sibling already exists (idempotency)", func() {
+		node := mkNode(true)
+		node.Status.CyclePhase = garagev1beta1.CyclePhaseProvisioning
+		node.Status.CycleSiblingName = siblingName
+
+		// Sibling exists but has not yet discovered its node ID — still coming up.
+		sibling := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      siblingName,
+				Namespace: ns,
+				Labels:    map[string]string{labelCycleSibling: annotationTrue, labelCluster: clusterName},
+			},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &cap,
+			},
+		}
+		fc := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(mkCluster(), node, sibling).
+			WithStatusSubresource(&garagev1beta1.GarageNode{}).
+			Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		res, err := r.Reconcile(bctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nodeName, Namespace: ns}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+		By("the original node is NOT deleted while the sibling is unsynced")
+		got := &garagev1beta1.GarageNode{}
+		Expect(fc.Get(bctx, types.NamespacedName{Name: nodeName, Namespace: ns}, got)).To(Succeed())
+		Expect(got.Status.CyclePhase).To(Equal(garagev1beta1.CyclePhaseProvisioning))
+
+		By("no duplicate sibling is created")
+		list := &garagev1beta1.GarageNodeList{}
+		Expect(fc.List(bctx, list)).To(Succeed())
+		count := 0
+		for i := range list.Items {
+			if list.Items[i].Name == siblingName {
+				count++
+			}
+		}
+		Expect(count).To(Equal(1))
+	})
+
+	It("does not remove the original until the sibling reaches the replication-factor sync (predicate gate)", func() {
+		// The drain+remove step is gated on LayoutHistoryResponse.NodeSyncedToCurrent.
+		// Below the current layout version → not synced → original kept.
+		hist := &garage.LayoutHistoryResponse{
+			CurrentVersion: 5,
+			UpdateTrackers: map[string]garage.NodeUpdateTrackers{
+				siblingID: {Ack: 5, Sync: 4, SyncAck: 4},
+			},
+		}
+		Expect(hist.NodeSyncedToCurrent(siblingID)).To(BeFalse(), "sync tracker behind current version")
+
+		// A node with no tracker entry at all is never considered synced.
+		Expect(hist.NodeSyncedToCurrent("nope")).To(BeFalse())
+
+		// Caught up to the current version → safe to remove the original.
+		hist.UpdateTrackers[siblingID] = garage.NodeUpdateTrackers{Ack: 5, Sync: 5, SyncAck: 5}
+		Expect(hist.NodeSyncedToCurrent(siblingID)).To(BeTrue())
+	})
+
+	It("supports the cycle on a non-Auto (Manual) node — sibling is plain, not Auto-managed", func() {
+		// Manual cluster + user-created node (no operator managed-by/tier labels).
+		cluster := mkCluster()
+		cluster.Spec.LayoutPolicy = LayoutPolicyManual
+		cluster.Spec.Storage.LayoutPolicy = LayoutPolicyManual
+
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "manual-node",
+				Namespace:   ns,
+				Annotations: map[string]string{garagev1beta1.AnnotationCycle: annotationTrue},
+				Finalizers:  []string{garageNodeFinalizer},
+			},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &cap,
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Size: &dataSz},
+					Data:     &garagev1beta1.NodeVolumeConfig{Size: &dataSz},
+				},
+			},
+			Status: garagev1beta1.GarageNodeStatus{NodeID: "cafe"},
+		}
+		fc := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(cluster, node).
+			WithStatusSubresource(&garagev1beta1.GarageNode{}).
+			Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		_, err := r.Reconcile(bctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "manual-node", Namespace: ns}})
+		Expect(err).NotTo(HaveOccurred())
+
+		sib := &garagev1beta1.GarageNode{}
+		Expect(fc.Get(bctx, types.NamespacedName{Name: "manual-node" + cycleSiblingSuffix, Namespace: ns}, sib)).To(Succeed())
+		Expect(isCycleSibling(sib)).To(BeTrue())
+		Expect(sib.Spec.Zone).To(Equal(testNodeZone))
+	})
+
+	It("never starts a cycle on a sibling node, clearing a stray annotation", func() {
+		sibling := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        siblingName,
+				Namespace:   ns,
+				Annotations: map[string]string{garagev1beta1.AnnotationCycle: annotationTrue},
+				Finalizers:  []string{garageNodeFinalizer},
+				Labels:      map[string]string{labelCycleSibling: annotationTrue, labelCluster: clusterName},
+			},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Capacity:   &cap,
+			},
+		}
+		fc := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(mkCluster(), sibling).
+			WithStatusSubresource(&garagev1beta1.GarageNode{}).
+			Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		_, err := r.Reconcile(bctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: siblingName, Namespace: ns}})
+		Expect(err).NotTo(HaveOccurred())
+
+		got := &garagev1beta1.GarageNode{}
+		Expect(fc.Get(bctx, types.NamespacedName{Name: siblingName, Namespace: ns}, got)).To(Succeed())
+		Expect(got.Annotations).NotTo(HaveKey(garagev1beta1.AnnotationCycle))
+
+		By("a sibling-of-a-sibling is never created")
+		nested := &garagev1beta1.GarageNode{}
+		err = fc.Get(bctx, types.NamespacedName{Name: siblingName + cycleSiblingSuffix, Namespace: ns}, nested)
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+})
+
+// cloneCycleNodeSpec / promotion unit coverage (no client).
+var _ = Describe("cycle spec helpers", func() {
+	It("cloneCycleNodeSpec strips identity + existingClaim but keeps layout fields", func() {
+		sz := resource.MustParse("50Gi")
+		node := &garagev1beta1.GarageNode{
+			Spec: garagev1beta1.GarageNodeSpec{
+				NodeID:   "abc",
+				Zone:     "z1",
+				Capacity: &sz,
+				Tags:     []string{"a", "b"},
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata:  &garagev1beta1.NodeVolumeConfig{ExistingClaim: "meta-pvc", Size: &sz},
+					DataPaths: []garagev1beta1.NodeVolumeConfig{{ExistingClaim: "d0", Size: &sz}, {ExistingClaim: "d1", Size: &sz}},
+				},
+			},
+		}
+		got := cloneCycleNodeSpec(node)
+		Expect(got.NodeID).To(BeEmpty())
+		Expect(got.Zone).To(Equal("z1"))
+		Expect(got.Tags).To(ConsistOf("a", "b"))
+		Expect(got.Storage.Metadata.ExistingClaim).To(BeEmpty())
+		Expect(got.Storage.Metadata.Size.Cmp(sz)).To(Equal(0))
+		for _, dp := range got.Storage.DataPaths {
+			Expect(dp.ExistingClaim).To(BeEmpty())
+			Expect(dp.Size.Cmp(sz)).To(Equal(0))
+		}
+		// Original is untouched (deep copy).
+		Expect(node.Spec.NodeID).To(Equal("abc"))
+		Expect(node.Spec.Storage.Metadata.ExistingClaim).To(Equal("meta-pvc"))
+	})
+
+	It("isCycleRequested only fires on the literal \"true\" value", func() {
+		n := &garagev1beta1.GarageNode{}
+		Expect(isCycleRequested(n)).To(BeFalse())
+		n.Annotations = map[string]string{garagev1beta1.AnnotationCycle: "yes"}
+		Expect(isCycleRequested(n)).To(BeFalse())
+		n.Annotations[garagev1beta1.AnnotationCycle] = annotationTrue
+		Expect(isCycleRequested(n)).To(BeTrue())
+	})
+})

--- a/internal/controller/gateway_rpcaddr_test.go
+++ b/internal/controller/gateway_rpcaddr_test.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
 )
 
@@ -73,5 +76,91 @@ func TestDeriveGatewayExternalAddr_PrefersGatewayRPCPublicAddr(t *testing.T) {
 	}
 	if got := r.deriveGatewayExternalAddr(context.TODO(), cluster); got != testGatewayRPCAddr {
 		t.Fatalf("expected gateway.rpcPublicAddr to win, got %q", got)
+	}
+}
+
+// bareEdgeGateway is the #243 topology: a gateway-only CR pointing at an external
+// (non-k8s) Garage via adminApiEndpoint, with no rpcPublicAddr and no publicEndpoint —
+// the external cluster has no way to dial back to the in-cluster gateway pods.
+func bareEdgeGateway() *garagev1beta2.GarageCluster {
+	return &garagev1beta2.GarageCluster{
+		Spec: garagev1beta2.GarageClusterSpec{
+			Gateway:   &garagev1beta2.GatewaySpec{Replicas: 1},
+			ConnectTo: &garagev1beta2.ConnectToConfig{AdminAPIEndpoint: "http://192.168.1.50:3903"},
+		},
+	}
+}
+
+// TestEdgeGatewayReverseUnroutable covers the predicate that classifies the #243
+// topology: bare edge gateway (no routable RPC address) is unroutable; any of the
+// three accepted address fields, or the presence of a storage tier, flips it off.
+func TestEdgeGatewayReverseUnroutable(t *testing.T) {
+	if !edgeGatewayReverseUnroutable(bareEdgeGateway()) {
+		t.Fatal("bare edge gateway (no rpcPublicAddr/publicEndpoint) must be unroutable")
+	}
+
+	withGatewayAddr := bareEdgeGateway()
+	withGatewayAddr.Spec.Gateway.RPCPublicAddr = testGatewayRPCAddr
+	if edgeGatewayReverseUnroutable(withGatewayAddr) {
+		t.Fatal("gateway.rpcPublicAddr set must NOT be unroutable")
+	}
+
+	withNetworkAddr := bareEdgeGateway()
+	withNetworkAddr.Spec.Network.RPCPublicAddr = "net.example.com:3901"
+	if edgeGatewayReverseUnroutable(withNetworkAddr) {
+		t.Fatal("network.rpcPublicAddr set must NOT be unroutable")
+	}
+
+	withPublicEndpoint := bareEdgeGateway()
+	withPublicEndpoint.Spec.PublicEndpoint = &garagev1beta2.PublicEndpointConfig{}
+	if edgeGatewayReverseUnroutable(withPublicEndpoint) {
+		t.Fatal("publicEndpoint set must NOT be unroutable")
+	}
+
+	// Unified cluster (gateway + storage): not an edge gateway, the reverse path is
+	// in-cluster, so the relaxation must not apply even with no rpcPublicAddr.
+	unified := bareEdgeGateway()
+	unified.Spec.Storage = &garagev1beta2.StorageSpec{Replicas: 3}
+	if edgeGatewayReverseUnroutable(unified) {
+		t.Fatal("unified gateway+storage cluster must NOT be classified unroutable")
+	}
+}
+
+// TestGatewayConnectedCondition_ForwardOnly is the #243 regression: a functional bare
+// edge gateway connects gateway→external but the reverse ConnectNode is skipped
+// (no routable address), so connectedToGateway stays 0. Before the fix this stuck at
+// PartiallyConnected/False forever; now it must report Connected/True so the reconcile
+// converges and autoApply stops churning layout.
+func TestGatewayConnectedCondition_ForwardOnly(t *testing.T) {
+	bare := bareEdgeGateway()
+
+	// Forward connected, reverse impossible -> Connected (ForwardOnly).
+	cond := gatewayConnectedCondition(bare, 1, 0)
+	if cond.Status != metav1.ConditionTrue {
+		t.Fatalf("bare edge gateway with forward-only connectivity must be True, got %s/%s", cond.Status, cond.Reason)
+	}
+	if cond.Reason != garagev1beta1.ReasonGatewayForwardOnly {
+		t.Fatalf("expected reason %q, got %q", garagev1beta1.ReasonGatewayForwardOnly, cond.Reason)
+	}
+
+	// Bidirectional always wins regardless of routability.
+	if cond := gatewayConnectedCondition(bare, 1, 1); cond.Status != metav1.ConditionTrue ||
+		cond.Reason != garagev1beta1.ReasonGatewayConnected {
+		t.Fatalf("bidirectional must be Connected, got %s/%s", cond.Status, cond.Reason)
+	}
+
+	// Nothing connected -> NodesOffline.
+	if cond := gatewayConnectedCondition(bare, 0, 0); cond.Status != metav1.ConditionFalse ||
+		cond.Reason != garagev1beta1.ReasonGatewayNodesOffline {
+		t.Fatalf("no connectivity must be NodesOffline/False, got %s/%s", cond.Status, cond.Reason)
+	}
+
+	// A gateway WITH a routable address but reverse still failing is a real
+	// misconfiguration: keep surfacing PartiallyConnected, do not relax to True.
+	routable := bareEdgeGateway()
+	routable.Spec.Gateway.RPCPublicAddr = testGatewayRPCAddr
+	if cond := gatewayConnectedCondition(routable, 1, 0); cond.Status != metav1.ConditionFalse ||
+		cond.Reason != garagev1beta1.ReasonGatewayPartiallyConnected {
+		t.Fatalf("forward-only WITH routable addr must stay PartiallyConnected/False, got %s/%s", cond.Status, cond.Reason)
 	}
 }

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -587,6 +587,21 @@ func (c *Client) GetClusterLayoutHistory(ctx context.Context) (*LayoutHistoryRes
 	return &history, nil
 }
 
+// NodeSyncedToCurrent reports whether the named node has caught its layout sync
+// tracker up to the current layout version — i.e. all partitions it owns under
+// the current layout are in sync on it. This is the per-node equivalent of
+// Garage's sync_map_min reaching the active version: a node is safe to rely on
+// for replication (and safe to swap a peer out behind) only once its sync
+// tracker is no longer behind the current version. Returns false when the node
+// has no tracker entry yet (not joined / never synced).
+func (h *LayoutHistoryResponse) NodeSyncedToCurrent(nodeID string) bool {
+	t, ok := h.UpdateTrackers[nodeID]
+	if !ok {
+		return false
+	}
+	return t.Sync >= h.CurrentVersion
+}
+
 // GetDrainingVersions returns all layout versions currently in Draining status
 func (h *LayoutHistoryResponse) GetDrainingVersions() []LayoutVersion {
 	var draining []LayoutVersion

--- a/schemas/garagenode_v1beta1.json
+++ b/schemas/garagenode_v1beta1.json
@@ -2182,6 +2182,23 @@
           "description": "Connected indicates if the node is currently connected",
           "type": "boolean"
         },
+        "cyclePhase": {
+          "description": "CyclePhase tracks progress of a graceful node cycle triggered by the\ngarage.rajsingh.info/cycle annotation. Empty when no cycle is active.\nUsed to make the add-before-remove state machine resumable/idempotent\nacross requeues: a non-empty value means a sibling has already been\nprovisioned, so the operator continues the swap rather than re-provisioning.",
+          "enum": [
+            "Provisioning",
+            "Syncing",
+            "Draining"
+          ],
+          "type": "string"
+        },
+        "cycleSiblingName": {
+          "description": "CycleSiblingName is the name of the sibling GarageNode provisioned for an\nin-progress cycle (the replacement that takes over this node's layout slot).",
+          "type": "string"
+        },
+        "cycleSiblingNodeId": {
+          "description": "CycleSiblingNodeID is the discovered Garage node ID of the cycle sibling,\nused to check its layout sync tracker before this node is removed.",
+          "type": "string"
+        },
         "dataPartition": {
           "description": "DataPartition contains disk space info for the data partition\nNote: Garage reports a single partition even with multiple data paths",
           "properties": {


### PR DESCRIPTION
Closes #243, closes #231.

Two independent gateway/node fixes verified together (build, vet, golangci-lint 0 issues, unit suites green, e2e compiles, no manifest drift).

## #243 — forward-only edge gateway stuck `PartiallyConnected`

A `gateway` cluster with `connectTo` pointing at an external (Docker/TrueNAS/NAT) Garage instance got stuck reporting `GatewayConnected: False/PartiallyConnected` forever even with healthy S3, and with `autoApply: true` churned the layout in a loop.

Root cause: the reverse dial-back address derivation returns `""` when there's no `rpcPublicAddr`/`publicEndpoint`, so the external→gateway `ConnectNode` is skipped, `connectedToGateway` stays 0, and the status switch reports `PartiallyConnected`. That false-negative kept the reconcile from short-circuiting (reconnect spam) and let the tombstone reaper churn the live gateway role under `autoApply`.

A gateway holds no data, and the in-cluster pod IP is genuinely unreachable from the external side, so inventing an address would be wrong. Fix treats a *genuinely unroutable* reverse direction as a correct steady state:

- new `edgeGatewayReverseUnroutable` predicate (mirrors the admission webhook's existing warning posture)
- status decision extracted into a pure `gatewayConnectedCondition` that reports `True`/`ForwardOnly` only when reverse is truly unroutable — a routable-but-failing address still reports `PartiallyConnected`
- short-circuits `isExternalGatewayConnected` and `reconcileGatewayTombstones` for this topology to stop the reconnect spam and the `autoApply` churn

Tests: `TestEdgeGatewayReverseUnroutable`, `TestGatewayConnectedCondition_ForwardOnly`.

## #231 — graceful node cycle (add-before-remove, no quorum dip)

`garage.rajsingh.info/cycle: "true"` does an add-before-remove swap instead of remove-then-add, keeping the cluster above quorum during planned maintenance. Resumable/idempotent state machine (replaces the TODO at `garagenode_controller.go:246`):

1. **Provisioning** — create sibling `<node>-cycle` (fresh node ID/PVCs, cloned zone/capacity/tags), owned by the original and labelled so the Auto scale loop ignores it
2. **Syncing** — gate on `LayoutHistoryResponse.NodeSyncedToCurrent(siblingID)` (per-node `sync_map_min` reaching the current layout version)
3. **Draining** — promote sibling, delete original; the existing finalizer drains it from layout and reaps STS/PVCs

New `GarageNodeStatus` fields `cyclePhase`/`cycleSiblingName`/`cycleSiblingNodeId` and a `Cycling` condition track progress. Works for Auto and Manual nodes. CRD/Helm/schema regenerated. Tests in `garagenode_cycle_test.go`.

Follow-up: full sync→drain drive-through belongs in the e2e suite (the admin endpoint is derived from the cluster Service FQDN and can't be pointed at httptest from the fake-client harness).
