### PR TITLE
fix: add kubebuilder:default=false to bool fields to prevent Terraform config drift

### DIFF
--- a/api/v1beta1/garagebucket_types.go
+++ b/api/v1beta1/garagebucket_types.go
@@ -213,14 +213,17 @@ type KeyPermission struct {
 	// +required
 	KeyRef KeyRef `json:"keyRef"`
 
+	// +kubebuilder:default=false
 	// Read allows reading objects
 	// +optional
 	Read bool `json:"read"`
 
+	// +kubebuilder:default=false
 	// Write allows writing objects
 	// +optional
 	Write bool `json:"write"`
 
+	// +kubebuilder:default=false
 	// Owner allows bucket owner operations
 	// +optional
 	Owner bool `json:"owner"`

--- a/api/v1beta1/garagekey_types.go
+++ b/api/v1beta1/garagekey_types.go
@@ -241,14 +241,17 @@ type BucketPermission struct {
 	// +optional
 	GlobalAlias string `json:"globalAlias,omitempty"`
 
+	// +kubebuilder:default=false
 	// Read allows reading objects from the bucket.
 	// +optional
 	Read bool `json:"read"`
 
+	// +kubebuilder:default=false
 	// Write allows writing objects to the bucket.
 	// +optional
 	Write bool `json:"write"`
 
+	// +kubebuilder:default=false
 	// Owner allows bucket owner operations (delete bucket, configure website, etc.)
 	// +optional
 	Owner bool `json:"owner"`
@@ -256,14 +259,17 @@ type BucketPermission struct {
 
 // AllBucketsPermission grants access to all buckets in the cluster
 type AllBucketsPermission struct {
+	// +kubebuilder:default=false
 	// Read allows reading objects from all buckets
 	// +optional
 	Read bool `json:"read"`
 
+	// +kubebuilder:default=false
 	// Write allows writing objects to all buckets
 	// +optional
 	Write bool `json:"write"`
 
+	// +kubebuilder:default=false
 	// Owner allows bucket owner operations on all buckets
 	// +optional
 	Owner bool `json:"owner"`
@@ -273,6 +279,7 @@ type AllBucketsPermission struct {
 // Note: Garage's Admin API uses separate admin tokens (configured in GarageCluster),
 // not S3 keys. This only controls S3-level permissions for the key.
 type KeyPermissions struct {
+	// +kubebuilder:default=false
 	// CreateBucket allows this key to create new buckets via the S3 CreateBucket API
 	// +optional
 	CreateBucket bool `json:"createBucket"`
@@ -342,14 +349,17 @@ type EffectivePermission struct {
 	// +optional
 	BucketAlias string `json:"bucketAlias,omitempty"`
 
+	// +kubebuilder:default=false
 	// Read permission
 	// +optional
 	Read bool `json:"read"`
 
+	// +kubebuilder:default=false
 	// Write permission
 	// +optional
 	Write bool `json:"write"`
 
+	// +kubebuilder:default=false
 	// Owner permission
 	// +optional
 	Owner bool `json:"owner"`
@@ -373,14 +383,17 @@ type KeyBucketAccess struct {
 	// +optional
 	LocalAlias string `json:"localAlias,omitempty"`
 
+	// +kubebuilder:default=false
 	// Read permission
 	// +optional
 	Read bool `json:"read"`
 
+	// +kubebuilder:default=false
 	// Write permission
 	// +optional
 	Write bool `json:"write"`
 
+	// +kubebuilder:default=false
 	// Owner permission
 	// +optional
 	Owner bool `json:"owner"`

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
@@ -531,12 +531,15 @@ spec:
                       - name
                       type: object
                     owner:
+                      default: false
                       description: Owner allows bucket owner operations
                       type: boolean
                     read:
+                      default: false
                       description: Read allows reading objects
                       type: boolean
                     write:
+                      default: false
                       description: Write allows writing objects
                       type: boolean
                   required:

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
@@ -81,12 +81,15 @@ spec:
                   operator (created directly via the S3 API). Plan accordingly.
                 properties:
                   owner:
+                    default: false
                     description: Owner allows bucket owner operations on all buckets
                     type: boolean
                   read:
+                    default: false
                     description: Read allows reading objects from all buckets
                     type: boolean
                   write:
+                    default: false
                     description: Write allows writing objects to all buckets
                     type: boolean
                 type: object
@@ -134,13 +137,16 @@ spec:
                         alias.
                       type: string
                     owner:
+                      default: false
                       description: Owner allows bucket owner operations (delete bucket,
                         configure website, etc.)
                       type: boolean
                     read:
+                      default: false
                       description: Read allows reading objects from the bucket.
                       type: boolean
                     write:
+                      default: false
                       description: Write allows writing objects to the bucket.
                       type: boolean
                   type: object
@@ -259,6 +265,7 @@ spec:
                   Note: For admin API access, use admin tokens configured in GarageCluster
                 properties:
                   createBucket:
+                    default: false
                     description: CreateBucket allows this key to create new buckets
                       via the S3 CreateBucket API
                     type: boolean
@@ -355,12 +362,15 @@ spec:
                       description: LocalAlias is this key's local alias for the bucket
                       type: string
                     owner:
+                      default: false
                       description: Owner permission
                       type: boolean
                     read:
+                      default: false
                       description: Read permission
                       type: boolean
                     write:
+                      default: false
                       description: Write permission
                       type: boolean
                   type: object
@@ -447,9 +457,11 @@ spec:
                       description: BucketID is the bucket ID
                       type: string
                     owner:
+                      default: false
                       description: Owner permission
                       type: boolean
                     read:
+                      default: false
                       description: Read permission
                       type: boolean
                     source:
@@ -457,6 +469,7 @@ spec:
                         ("bucket", "key", or "both")
                       type: string
                     write:
+                      default: false
                       description: Write permission
                       type: boolean
                   type: object
@@ -476,6 +489,7 @@ spec:
                 description: Permissions shows the current permissions for this key
                 properties:
                   createBucket:
+                    default: false
                     description: CreateBucket allows this key to create new buckets
                       via the S3 CreateBucket API
                     type: boolean

--- a/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
@@ -531,12 +531,15 @@ spec:
                       - name
                       type: object
                     owner:
+                      default: false
                       description: Owner allows bucket owner operations
                       type: boolean
                     read:
+                      default: false
                       description: Read allows reading objects
                       type: boolean
                     write:
+                      default: false
                       description: Write allows writing objects
                       type: boolean
                   required:

--- a/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
@@ -81,12 +81,15 @@ spec:
                   operator (created directly via the S3 API). Plan accordingly.
                 properties:
                   owner:
+                    default: false
                     description: Owner allows bucket owner operations on all buckets
                     type: boolean
                   read:
+                    default: false
                     description: Read allows reading objects from all buckets
                     type: boolean
                   write:
+                    default: false
                     description: Write allows writing objects to all buckets
                     type: boolean
                 type: object
@@ -134,13 +137,16 @@ spec:
                         alias.
                       type: string
                     owner:
+                      default: false
                       description: Owner allows bucket owner operations (delete bucket,
                         configure website, etc.)
                       type: boolean
                     read:
+                      default: false
                       description: Read allows reading objects from the bucket.
                       type: boolean
                     write:
+                      default: false
                       description: Write allows writing objects to the bucket.
                       type: boolean
                   type: object
@@ -259,6 +265,7 @@ spec:
                   Note: For admin API access, use admin tokens configured in GarageCluster
                 properties:
                   createBucket:
+                    default: false
                     description: CreateBucket allows this key to create new buckets
                       via the S3 CreateBucket API
                     type: boolean
@@ -355,12 +362,15 @@ spec:
                       description: LocalAlias is this key's local alias for the bucket
                       type: string
                     owner:
+                      default: false
                       description: Owner permission
                       type: boolean
                     read:
+                      default: false
                       description: Read permission
                       type: boolean
                     write:
+                      default: false
                       description: Write permission
                       type: boolean
                   type: object
@@ -447,9 +457,11 @@ spec:
                       description: BucketID is the bucket ID
                       type: string
                     owner:
+                      default: false
                       description: Owner permission
                       type: boolean
                     read:
+                      default: false
                       description: Read permission
                       type: boolean
                     source:
@@ -457,6 +469,7 @@ spec:
                         ("bucket", "key", or "both")
                       type: string
                     write:
+                      default: false
                       description: Write permission
                       type: boolean
                   type: object
@@ -476,6 +489,7 @@ spec:
                 description: Permissions shows the current permissions for this key
                 properties:
                   createBucket:
+                    default: false
                     description: CreateBucket allows this key to create new buckets
                       via the S3 CreateBucket API
                     type: boolean

--- a/schemas/garagebucket_v1beta1.json
+++ b/schemas/garagebucket_v1beta1.json
@@ -89,14 +89,17 @@
                 "additionalProperties": false
               },
               "owner": {
+                "default": false,
                 "description": "Owner allows bucket owner operations",
                 "type": "boolean"
               },
               "read": {
+                "default": false,
                 "description": "Read allows reading objects",
                 "type": "boolean"
               },
               "write": {
+                "default": false,
                 "description": "Write allows writing objects",
                 "type": "boolean"
               }

--- a/schemas/garagekey_v1beta1.json
+++ b/schemas/garagekey_v1beta1.json
@@ -19,14 +19,17 @@
           "description": "AllBuckets grants this key a baseline permission set on every bucket in the cluster.\nUseful for admin tools, backup agents, or monitoring that need cluster-wide access.\n\nHow it works: the operator calls Garage's allow/deny APIs for every bucket to\nenforce exactly the flags set here \u2014 false actively revokes, not just leaves unset.\nBucketPermissions entries are then applied on top, so you can grant broader access\nvia allBuckets and restrict specific buckets via bucketPermissions.\n\nWarning: this applies to ALL Garage buckets, including buckets not managed by the\noperator (created directly via the S3 API). Plan accordingly.",
           "properties": {
             "owner": {
+              "default": false,
               "description": "Owner allows bucket owner operations on all buckets",
               "type": "boolean"
             },
             "read": {
+              "default": false,
               "description": "Read allows reading objects from all buckets",
               "type": "boolean"
             },
             "write": {
+              "default": false,
               "description": "Write allows writing objects to all buckets",
               "type": "boolean"
             }
@@ -66,14 +69,17 @@
                 "type": "string"
               },
               "owner": {
+                "default": false,
                 "description": "Owner allows bucket owner operations (delete bucket, configure website, etc.)",
                 "type": "boolean"
               },
               "read": {
+                "default": false,
                 "description": "Read allows reading objects from the bucket.",
                 "type": "boolean"
               },
               "write": {
+                "default": false,
                 "description": "Write allows writing objects to the bucket.",
                 "type": "boolean"
               }
@@ -188,6 +194,7 @@
           "description": "Permissions configures key-level permissions\nNote: For admin API access, use admin tokens configured in GarageCluster",
           "properties": {
             "createBucket": {
+              "default": false,
               "description": "CreateBucket allows this key to create new buckets via the S3 CreateBucket API",
               "type": "boolean"
             }
@@ -302,14 +309,17 @@
                 "type": "string"
               },
               "owner": {
+                "default": false,
                 "description": "Owner permission",
                 "type": "boolean"
               },
               "read": {
+                "default": false,
                 "description": "Read permission",
                 "type": "boolean"
               },
               "write": {
+                "default": false,
                 "description": "Write permission",
                 "type": "boolean"
               }
@@ -402,10 +412,12 @@
                 "type": "string"
               },
               "owner": {
+                "default": false,
                 "description": "Owner permission",
                 "type": "boolean"
               },
               "read": {
+                "default": false,
                 "description": "Read permission",
                 "type": "boolean"
               },
@@ -414,6 +426,7 @@
                 "type": "string"
               },
               "write": {
+                "default": false,
                 "description": "Write permission",
                 "type": "boolean"
               }
@@ -441,6 +454,7 @@
           "description": "Permissions shows the current permissions for this key",
           "properties": {
             "createBucket": {
+              "default": false,
               "description": "CreateBucket allows this key to create new buckets via the S3 CreateBucket API",
               "type": "boolean"
             }


### PR DESCRIPTION
## Summary

Adds `+kubebuilder:default=false` to all non-pointer `bool` fields across `api/v1beta1/` CRD types to prevent Terraform/IaC config drift when users explicitly set a boolean permission to `false` (e.g., `write: false`).

## Root Cause

Go's plain `bool` marshals `false` (zero value) in JSON without `omitempty`, but Kubernetes CRD optional booleans *without a default* in the OpenAPI schema are treated as null/absent by tools like Terraform's `kubernetes_manifest` provider. This causes perpetual `write = null -> false` drift detected on every plan.

## What Changed

| Struct | Fields |
|--------|--------|
| `BucketPermission` (GarageKey) | `Read`, `Write`, `Owner` |
| `AllBucketsPermission` (GarageKey) | `Read`, `Write`, `Owner` |
| `KeyPermissions` (GarageKey) | `CreateBucket` |
| `KeyPermission` (GarageBucket) | `Read`, `Write`, `Owner` |
| `EffectivePermission` (GarageKey status) | `Read`, `Write`, `Owner` |
| `KeyBucketAccess` (GarageKey status) | `Read`, `Write`, `Owner` |

## Verification

- `make manifests` → CRD YAMLs regenerated with `default: false` in OpenAPI schema
- `go build ./...` → compiles clean
- `go test ./api/v1beta1/...` → passes

## Related

Fixes #74. Completes the same intent as the prior attempt in PR #75 (commit 94ad0c4 was never merged into main).