### PR TITLE
feat(monitoring): support metricRelabelings on the cluster ServiceMonitor

### DIFF
--- a/api/v1beta1/garagecluster_conversion_test.go
+++ b/api/v1beta1/garagecluster_conversion_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,7 @@ const (
 	testStoreCR = "store"
 	test10Gi    = "10Gi"
 	testConsist = "consistent"
+	testRelabel = "rpc_duration_.*"
 )
 
 // TestConvertTo_StorageCluster: v1beta1 storage CR -> v1beta2 storage tier.
@@ -139,6 +141,53 @@ func TestConvert_StorageRPCPublicAddrRoundTrip(t *testing.T) {
 	}
 	if down.Spec.Storage.LayoutPolicy != layoutPolicyManual {
 		t.Fatalf("round-trip lost storage.layoutPolicy: got %q want Manual", down.Spec.Storage.LayoutPolicy)
+	}
+}
+
+// TestConvert_MonitoringMetricRelabelingsRoundTrip: monitoring.metricRelabelings
+// must survive a v1beta1 -> v1beta2 -> v1beta1 round-trip (the JSON-copy
+// conversion preserves it because both versions carry the field).
+func TestConvert_MonitoringMetricRelabelingsRoundTrip(t *testing.T) {
+	src := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: testStoreCR, Namespace: testNS},
+		Spec: GarageClusterSpec{
+			Replicas: 3,
+			Zone:     testZone,
+			Storage: StorageConfig{
+				Metadata: &VolumeConfig{Size: ptrQuantity(resource.MustParse(test10Gi))},
+				Data:     &VolumeConfig{Size: ptrQuantity(resource.MustParse("100Gi"))},
+			},
+			Monitoring: &MonitoringSpec{
+				Enabled: ptrBool(true),
+				MetricRelabelings: []monitoringv1.RelabelConfig{{
+					Action:       "drop",
+					SourceLabels: []monitoringv1.LabelName{"__name__"},
+					Regex:        testRelabel,
+				}},
+			},
+		},
+	}
+
+	up := &v1beta2.GarageCluster{}
+	if err := src.ConvertTo(up); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	if up.Spec.Monitoring == nil || len(up.Spec.Monitoring.MetricRelabelings) != 1 {
+		t.Fatalf("v1beta2 monitoring.metricRelabelings missing after ConvertTo")
+	}
+	if up.Spec.Monitoring.MetricRelabelings[0].Regex != testRelabel {
+		t.Fatalf("v1beta2 metricRelabelings regex: got %q", up.Spec.Monitoring.MetricRelabelings[0].Regex)
+	}
+
+	down := &GarageCluster{}
+	if err := down.ConvertFrom(up); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if down.Spec.Monitoring == nil || len(down.Spec.Monitoring.MetricRelabelings) != 1 {
+		t.Fatalf("round-trip lost monitoring.metricRelabelings")
+	}
+	if down.Spec.Monitoring.MetricRelabelings[0].Regex != testRelabel {
+		t.Errorf("round-trip metricRelabelings regex: got %q want rpc_duration_.*", down.Spec.Monitoring.MetricRelabelings[0].Regex)
 	}
 }
 

--- a/api/v1beta1/garagecluster_types.go
+++ b/api/v1beta1/garagecluster_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -266,6 +267,14 @@ type MonitoringSpec struct {
 	// AdditionalLabels are added to the ServiceMonitor metadata.
 	// +optional
 	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
+
+	// MetricRelabelings are applied to samples scraped from the admin /metrics
+	// endpoint before ingestion (set as the ServiceMonitor endpoint's
+	// metricRelabelings). Use them to drop high-cardinality series that nothing
+	// queries — e.g. the per-method rpc_duration_* histograms, which dominate a
+	// Garage node's metric series count.
+	// +optional
+	MetricRelabelings []monitoringv1.RelabelConfig `json:"metricRelabelings,omitempty"`
 }
 
 // WorkersConfig configures Garage background worker behavior.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -2328,6 +2329,13 @@ func (in *MonitoringSpec) DeepCopyInto(out *MonitoringSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.MetricRelabelings != nil {
+		in, out := &in.MetricRelabelings, &out.MetricRelabelings
+		*out = make([]monitoringv1.RelabelConfig, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/api/v1beta2/garagecluster_types.go
+++ b/api/v1beta2/garagecluster_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -397,6 +398,14 @@ type MonitoringSpec struct {
 	// AdditionalLabels are added to the ServiceMonitor metadata.
 	// +optional
 	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
+
+	// MetricRelabelings are applied to samples scraped from the admin /metrics
+	// endpoint before ingestion (set as the ServiceMonitor endpoint's
+	// metricRelabelings). Use them to drop high-cardinality series that nothing
+	// queries — e.g. the per-method rpc_duration_* histograms, which dominate a
+	// Garage node's metric series count.
+	// +optional
+	MetricRelabelings []monitoringv1.RelabelConfig `json:"metricRelabelings,omitempty"`
 }
 
 // WorkersConfig configures Garage background worker behavior.

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -1094,6 +1095,13 @@ func (in *MonitoringSpec) DeepCopyInto(out *MonitoringSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.MetricRelabelings != nil {
+		in, out := &in.MetricRelabelings, &out.MetricRelabelings
+		*out = make([]monitoringv1.RelabelConfig, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -1792,6 +1792,98 @@ spec:
                       Interval is the Prometheus scrape interval (e.g. "30s", "1m").
                       Defaults to the Prometheus global scrape interval when unset.
                     type: string
+                  metricRelabelings:
+                    description: |-
+                      MetricRelabelings are applied to samples scraped from the admin /metrics
+                      endpoint before ingestion (set as the ServiceMonitor endpoint's
+                      metricRelabelings). Use them to drop high-cardinality series that nothing
+                      queries — e.g. the per-method rpc_duration_* histograms, which dominate a
+                      Garage node's metric series count.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: regex defines the regular expression against
+                            which the extracted value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: separator defines the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            sourceLabels defines the source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name.
+                              For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                              For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            targetLabel defines the label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               network:
                 description: Network configures RPC and API networking
@@ -8060,6 +8152,98 @@ spec:
                     description: Interval is the Prometheus scrape interval (e.g.
                       "30s", "1m").
                     type: string
+                  metricRelabelings:
+                    description: |-
+                      MetricRelabelings are applied to samples scraped from the admin /metrics
+                      endpoint before ingestion (set as the ServiceMonitor endpoint's
+                      metricRelabelings). Use them to drop high-cardinality series that nothing
+                      queries — e.g. the per-method rpc_duration_* histograms, which dominate a
+                      Garage node's metric series count.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: regex defines the regular expression against
+                            which the extracted value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: separator defines the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            sourceLabels defines the source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name.
+                              For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                              For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            targetLabel defines the label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               network:
                 description: Network configures RPC and API networking

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -1792,6 +1792,98 @@ spec:
                       Interval is the Prometheus scrape interval (e.g. "30s", "1m").
                       Defaults to the Prometheus global scrape interval when unset.
                     type: string
+                  metricRelabelings:
+                    description: |-
+                      MetricRelabelings are applied to samples scraped from the admin /metrics
+                      endpoint before ingestion (set as the ServiceMonitor endpoint's
+                      metricRelabelings). Use them to drop high-cardinality series that nothing
+                      queries — e.g. the per-method rpc_duration_* histograms, which dominate a
+                      Garage node's metric series count.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: regex defines the regular expression against
+                            which the extracted value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: separator defines the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            sourceLabels defines the source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name.
+                              For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                              For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            targetLabel defines the label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               network:
                 description: Network configures RPC and API networking
@@ -8060,6 +8152,98 @@ spec:
                     description: Interval is the Prometheus scrape interval (e.g.
                       "30s", "1m").
                     type: string
+                  metricRelabelings:
+                    description: |-
+                      MetricRelabelings are applied to samples scraped from the admin /metrics
+                      endpoint before ingestion (set as the ServiceMonitor endpoint's
+                      metricRelabelings). Use them to drop high-cardinality series that nothing
+                      queries — e.g. the per-method rpc_duration_* histograms, which dominate a
+                      Garage node's metric series count.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: regex defines the regular expression against
+                            which the extracted value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: separator defines the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            sourceLabels defines the source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name.
+                              For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                              For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            targetLabel defines the label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               network:
                 description: Network configures RPC and API networking

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -87,6 +87,9 @@ func (r *GarageClusterReconciler) buildServiceMonitor(cluster *garagev1beta2.Gar
 	if monitoring.Interval != "" {
 		endpoint.Interval = monitoringv1.Duration(monitoring.Interval)
 	}
+	if len(monitoring.MetricRelabelings) > 0 {
+		endpoint.MetricRelabelConfigs = monitoring.MetricRelabelings
+	}
 	if cluster.Spec.Admin != nil && cluster.Spec.Admin.MetricsTokenSecretRef != nil {
 		ref := cluster.Spec.Admin.MetricsTokenSecretRef
 		key := ref.Key

--- a/schemas/garagecluster_v1beta1.json
+++ b/schemas/garagecluster_v1beta1.json
@@ -1551,6 +1551,75 @@
             "interval": {
               "description": "Interval is the Prometheus scrape interval (e.g. \"30s\", \"1m\").\nDefaults to the Prometheus global scrape interval when unset.",
               "type": "string"
+            },
+            "metricRelabelings": {
+              "description": "MetricRelabelings are applied to samples scraped from the admin /metrics\nendpoint before ingestion (set as the ServiceMonitor endpoint's\nmetricRelabelings). Use them to drop high-cardinality series that nothing\nqueries \u2014 e.g. the per-method rpc_duration_* histograms, which dominate a\nGarage node's metric series count.",
+              "items": {
+                "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                "properties": {
+                  "action": {
+                    "default": "replace",
+                    "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                    "enum": [
+                      "replace",
+                      "Replace",
+                      "keep",
+                      "Keep",
+                      "drop",
+                      "Drop",
+                      "hashmod",
+                      "HashMod",
+                      "labelmap",
+                      "LabelMap",
+                      "labeldrop",
+                      "LabelDrop",
+                      "labelkeep",
+                      "LabelKeep",
+                      "lowercase",
+                      "Lowercase",
+                      "uppercase",
+                      "Uppercase",
+                      "keepequal",
+                      "KeepEqual",
+                      "dropequal",
+                      "DropEqual"
+                    ],
+                    "type": "string"
+                  },
+                  "modulus": {
+                    "description": "modulus to take of the hash of the source label values.\n\nOnly applicable when the action is `HashMod`.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "regex": {
+                    "description": "regex defines the regular expression against which the extracted value is matched.",
+                    "type": "string"
+                  },
+                  "replacement": {
+                    "description": "replacement value against which a Replace action is performed if the\nregular expression matches.\n\nRegex capture groups are available.",
+                    "type": "string"
+                  },
+                  "separator": {
+                    "description": "separator defines the string between concatenated SourceLabels.",
+                    "type": "string"
+                  },
+                  "sourceLabels": {
+                    "description": "sourceLabels defines the source labels select values from existing labels. Their content is\nconcatenated using the configured Separator and matched against the\nconfigured regular expression.",
+                    "items": {
+                      "description": "LabelName is a valid Prometheus label name.\nFor Prometheus 3.x, a label name is valid if it contains UTF-8 characters.\nFor Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "targetLabel": {
+                    "description": "targetLabel defines the label to which the resulting string is written in a replacement.\n\nIt is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,\n`KeepEqual` and `DropEqual` actions.\n\nRegex capture groups are available.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
             }
           },
           "type": "object",

--- a/schemas/garagecluster_v1beta2.json
+++ b/schemas/garagecluster_v1beta2.json
@@ -2906,6 +2906,75 @@
             "interval": {
               "description": "Interval is the Prometheus scrape interval (e.g. \"30s\", \"1m\").",
               "type": "string"
+            },
+            "metricRelabelings": {
+              "description": "MetricRelabelings are applied to samples scraped from the admin /metrics\nendpoint before ingestion (set as the ServiceMonitor endpoint's\nmetricRelabelings). Use them to drop high-cardinality series that nothing\nqueries \u2014 e.g. the per-method rpc_duration_* histograms, which dominate a\nGarage node's metric series count.",
+              "items": {
+                "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                "properties": {
+                  "action": {
+                    "default": "replace",
+                    "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                    "enum": [
+                      "replace",
+                      "Replace",
+                      "keep",
+                      "Keep",
+                      "drop",
+                      "Drop",
+                      "hashmod",
+                      "HashMod",
+                      "labelmap",
+                      "LabelMap",
+                      "labeldrop",
+                      "LabelDrop",
+                      "labelkeep",
+                      "LabelKeep",
+                      "lowercase",
+                      "Lowercase",
+                      "uppercase",
+                      "Uppercase",
+                      "keepequal",
+                      "KeepEqual",
+                      "dropequal",
+                      "DropEqual"
+                    ],
+                    "type": "string"
+                  },
+                  "modulus": {
+                    "description": "modulus to take of the hash of the source label values.\n\nOnly applicable when the action is `HashMod`.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "regex": {
+                    "description": "regex defines the regular expression against which the extracted value is matched.",
+                    "type": "string"
+                  },
+                  "replacement": {
+                    "description": "replacement value against which a Replace action is performed if the\nregular expression matches.\n\nRegex capture groups are available.",
+                    "type": "string"
+                  },
+                  "separator": {
+                    "description": "separator defines the string between concatenated SourceLabels.",
+                    "type": "string"
+                  },
+                  "sourceLabels": {
+                    "description": "sourceLabels defines the source labels select values from existing labels. Their content is\nconcatenated using the configured Separator and matched against the\nconfigured regular expression.",
+                    "items": {
+                      "description": "LabelName is a valid Prometheus label name.\nFor Prometheus 3.x, a label name is valid if it contains UTF-8 characters.\nFor Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "targetLabel": {
+                    "description": "targetLabel defines the label to which the resulting string is written in a replacement.\n\nIt is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,\n`KeepEqual` and `DropEqual` actions.\n\nRegex capture groups are available.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
             }
           },
           "type": "object",


### PR DESCRIPTION
## Problem

`spec.monitoring` only exposes `enabled` / `interval` / `additionalLabels`, so there's no way to apply Prometheus `metricRelabelings` to the ServiceMonitor the operator generates. The admin `/metrics` endpoint is high-cardinality — the per-method `rpc_duration_*` histograms alone are tens of thousands of active series that no standard Garage dashboard or alert queries. The ServiceMonitor can't be hand-edited (the operator reconciles it back), and bypassing the operator with a parallel ServiceMonitor is fragile.

## Fix

Add `spec.monitoring.metricRelabelings` (`[]monitoringv1.RelabelConfig`), wired straight into the generated ServiceMonitor endpoint's `metricRelabelings`, so operators can drop unwanted series at scrape time while keeping monitoring operator-managed.

```yaml
spec:
  monitoring:
    enabled: true
    metricRelabelings:
      - action: drop
        sourceLabels: [__name__]
        regex: .+_duration_(bucket|sum|count)
```

- Added to **both** `v1beta1` and `v1beta2` `MonitoringSpec` so the JSON-copy conversion round-trips losslessly (`v1alpha1` has no monitoring spec).
- Optional field — generated ServiceMonitor is byte-identical when unset.
- Uses the upstream `monitoringv1.RelabelConfig` (already a dependency), so `go.mod`/`go.sum` are untouched. CRDs, deepcopy, and JSON schemas regenerated via `make manifests generate`.

## Tests

- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- `go test ./api/...` — pass, including a new `TestConvert_MonitoringMetricRelabelingsRoundTrip` asserting a `metricRelabelings` drop rule survives a `v1beta1 → v1beta2 → v1beta1` round-trip.
- The envtest-based controller suite is unaffected and runs in CI (its kubebuilder binaries aren't available locally).
