### PR TITLE
fix(node): reap stale storage role when a node's identity changes in place

### DIFF
--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -1135,6 +1135,24 @@ func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1
 		return fmt.Errorf("node ID not found and could not be discovered")
 	}
 
+	// If the node's identity changed under us (its metadata was wiped — e.g. an
+	// in-place PVC clear — so Garage minted a fresh node_id on restart), the
+	// previous identity is now a dead role in the layout that nothing else
+	// reaps: the gateway tombstone reaper only matches capacity:null roles, and
+	// the -cycle add-before-remove flow is never triggered by an in-place wipe.
+	// Drop the stale role so Garage rebalances its partitions onto live nodes
+	// (including this node's new identity) instead of waiting forever for an
+	// identity that will never return. The wiped node holds no recoverable data
+	// by definition, so this only ever helps a degraded cluster recover.
+	previousNodeID := node.Status.NodeID
+	if previousNodeID != "" && previousNodeID != nodeID {
+		log.Info("Node identity changed; removing stale layout role",
+			"node", node.Name, "previousNodeID", previousNodeID, "newNodeID", nodeID)
+		if err := r.removeStaleNodeRole(ctx, garageClient, previousNodeID); err != nil {
+			return fmt.Errorf("removing stale node role %s after identity change: %w", previousNodeID, err)
+		}
+	}
+
 	node.Status.NodeID = nodeID
 
 	// Get current layout
@@ -1504,6 +1522,86 @@ func captureAdminEndpoint(node *garagev1beta1.GarageNode, cluster *garagev1beta2
 		ref := *cluster.Spec.Admin.AdminTokenSecretRef
 		node.Status.ClusterAdminTokenSecretRef = &ref
 	}
+}
+
+// removeStaleNodeRole drops a node_id's role from the layout. It is called from
+// reconcileNode when a managed node's discovered identity no longer matches the
+// last-known status.NodeID — i.e. the node's metadata was wiped and Garage
+// minted a fresh node_id. The previous identity is permanently gone, so its
+// layout role must be removed to let Garage rebalance its partitions off the
+// dead node. Mirrors finalize()'s safety: no-op if the role is already absent
+// or it is the last storage node, and tolerates a replication-constraint
+// rejection (logged; a later reconcile retries once capacity allows). Because
+// the stale role's data is gone, skip-dead-nodes is issued with AllowMissingData
+// so the layout doesn't stall in a draining version waiting for a node that
+// will never ack.
+func (r *GarageNodeReconciler) removeStaleNodeRole(ctx context.Context, garageClient *garage.Client, staleNodeID string) error {
+	log := logf.FromContext(ctx)
+
+	layout, err := garageClient.GetClusterLayout(ctx)
+	if err != nil {
+		return fmt.Errorf("get cluster layout: %w", err)
+	}
+
+	var staleRole *garage.LayoutRole
+	storageNodeCount := 0
+	for i := range layout.Roles {
+		role := &layout.Roles[i]
+		if role.Capacity != nil && *role.Capacity > 0 {
+			storageNodeCount++
+		}
+		if role.ID == staleNodeID {
+			staleRole = role
+		}
+	}
+	if staleRole == nil {
+		return nil
+	}
+
+	isStorageNode := staleRole.Capacity != nil && *staleRole.Capacity > 0
+	if isStorageNode && storageNodeCount <= 1 {
+		log.Info("Refusing to remove last storage node role even though it is stale",
+			"staleNodeID", staleNodeID, "storageNodes", storageNodeCount)
+		return nil
+	}
+
+	updates := []garage.NodeRoleChange{{ID: staleNodeID, Remove: true}}
+	if err := garageClient.UpdateClusterLayout(ctx, updates); err != nil {
+		return fmt.Errorf("stage stale role removal: %w", err)
+	}
+	if err := garageClient.ApplyStagedLayoutChanges(ctx); err != nil {
+		if garage.IsReplicationConstraint(err) {
+			log.Info("Cannot remove stale node role yet: would violate replication constraints; will retry",
+				"staleNodeID", staleNodeID, "storageNodes", storageNodeCount)
+			return nil
+		}
+		return fmt.Errorf("apply stale role removal: %w", err)
+	}
+	log.Info("Removed stale node role from layout", "staleNodeID", staleNodeID)
+
+	// The dead identity will never ack the new layout version, so advance the
+	// ack/sync trackers past it to keep the layout from stalling in a draining
+	// version. AllowMissingData is safe here: the stale node's data is gone with
+	// its wiped metadata, and the partitions rebuild from the surviving replicas.
+	appliedVersion, ok := reReadLayoutVersion(ctx, garageClient)
+	if !ok {
+		return nil
+	}
+	result, err := garageClient.ClusterLayoutSkipDeadNodes(ctx, garage.SkipDeadNodesRequest{
+		Version:          appliedVersion,
+		AllowMissingData: true,
+	})
+	if err != nil {
+		if !garage.IsBadRequest(err) {
+			log.Error(err, "Failed to skip dead node after stale role removal (will be retried)", "staleNodeID", staleNodeID)
+		}
+		return nil
+	}
+	if len(result.AckUpdated) > 0 || len(result.SyncUpdated) > 0 {
+		log.Info("Skipped dead node after stale role removal",
+			"staleNodeID", staleNodeID, "ackUpdated", len(result.AckUpdated), "syncUpdated", len(result.SyncUpdated))
+	}
+	return nil
 }
 
 func (r *GarageNodeReconciler) finalize(ctx context.Context, node *garagev1beta1.GarageNode, garageClient *garage.Client) error {

--- a/internal/controller/garagenode_stale_role_test.go
+++ b/internal/controller/garagenode_stale_role_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
+)
+
+// fakeGarageLayout is a tiny stateful in-memory Garage admin API serving the
+// layout endpoints reconcileNode + removeStaleNodeRole exercise: it tracks the
+// committed roles, staged changes and applies them on ApplyClusterLayout. This
+// lets the test assert what the operator does to the layout (adds, removes)
+// rather than just counting calls.
+type fakeGarageLayout struct {
+	mu        sync.Mutex
+	version   uint64
+	roles     map[string]garage.LayoutNodeRole
+	staged    []garage.NodeRoleChange
+	skipCalls int32
+}
+
+func newFakeGarageLayout(initial ...garage.LayoutNodeRole) *fakeGarageLayout {
+	f := &fakeGarageLayout{version: 1, roles: map[string]garage.LayoutNodeRole{}}
+	for _, r := range initial {
+		f.roles[r.ID] = r
+	}
+	return f
+}
+
+func (f *fakeGarageLayout) server() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/GetClusterLayout", func(w http.ResponseWriter, _ *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		roles := make([]garage.LayoutNodeRole, 0, len(f.roles))
+		for _, r := range f.roles {
+			roles = append(roles, r)
+		}
+		_ = json.NewEncoder(w).Encode(garage.ClusterLayout{
+			Version:           f.version,
+			Roles:             roles,
+			StagedRoleChanges: f.staged,
+		})
+	})
+	mux.HandleFunc("/v2/UpdateClusterLayout", func(w http.ResponseWriter, r *http.Request) {
+		var req garage.UpdateClusterLayoutRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		f.mu.Lock()
+		f.staged = append(f.staged, req.Roles...)
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/ApplyClusterLayout", func(w http.ResponseWriter, _ *http.Request) {
+		f.mu.Lock()
+		for _, c := range f.staged {
+			if c.Remove {
+				delete(f.roles, c.ID)
+				continue
+			}
+			f.roles[c.ID] = garage.LayoutNodeRole{ID: c.ID, Zone: c.Zone, Tags: c.Tags, Capacity: c.Capacity}
+		}
+		f.staged = nil
+		f.version++
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/ClusterLayoutSkipDeadNodes", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&f.skipCalls, 1)
+		_ = json.NewEncoder(w).Encode(garage.SkipDeadNodesResponse{})
+	})
+	return httptest.NewServer(mux)
+}
+
+func (f *fakeGarageLayout) hasRole(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.roles[id]
+	return ok
+}
+
+var _ = Describe("GarageNode stale-role reaping on in-place identity change", func() {
+	const (
+		oldID  = "0f6e73e52a9c7441d0d260e6ff09073a4bf9b963a0489ff1794df111eb9c7bf1"
+		newID  = "73143814f0e608c7737dde755727a45ca9b81414d76da011767fae2b867752fa"
+		liveID = "fa7874a6114eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	var bctx context.Context
+	BeforeEach(func() { bctx = context.Background() })
+
+	storageRole := func(id string) garage.LayoutNodeRole {
+		cap := uint64(700 << 30)
+		return garage.LayoutNodeRole{ID: id, Zone: testZone, Tags: []string{testTierStorageTag}, Capacity: &cap}
+	}
+
+	// This is the bug: asuka's data PVC was wiped, Garage minted a fresh node_id
+	// (newID), but the dead pre-wipe identity (oldID) kept its storage role in
+	// the layout — holding partitions Garage will never rebalance. reconcileNode
+	// must drop the stale role once it observes the node's identity changed.
+	It("removes the previous identity's role when the discovered node_id changed", func() {
+		fake := newFakeGarageLayout(storageRole(oldID), storageRole(liveID))
+		srv := fake.server()
+		defer srv.Close()
+
+		client := garage.NewClient(srv.URL, "test-token")
+
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "ottawa-garage-localpath-asuka", Namespace: fmGarageContainer},
+			Spec: garagev1beta1.GarageNodeSpec{
+				NodeID:   newID, // set so reconcileNode skips pod discovery
+				Zone:     testZone,
+				Capacity: resource.NewQuantity(700<<30, resource.BinarySI),
+				Tags:     []string{testTierStorageTag},
+			},
+			Status: garagev1beta1.GarageNodeStatus{NodeID: oldID},
+		}
+		cluster := &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: fmGarageContainer, Namespace: fmGarageContainer},
+		}
+
+		r := &GarageNodeReconciler{}
+		Expect(r.reconcileNode(bctx, node, cluster, client)).To(Succeed())
+
+		Expect(fake.hasRole(oldID)).To(BeFalse(), "stale pre-wipe identity must be removed from layout")
+		Expect(fake.hasRole(newID)).To(BeTrue(), "fresh identity must be added to layout")
+		Expect(fake.hasRole(liveID)).To(BeTrue(), "unrelated live node must be untouched")
+	})
+
+	It("does not touch the layout when the identity is unchanged", func() {
+		fake := newFakeGarageLayout(storageRole(newID), storageRole(liveID))
+		srv := fake.server()
+		defer srv.Close()
+		client := garage.NewClient(srv.URL, "test-token")
+
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "asuka", Namespace: fmGarageContainer},
+			Spec: garagev1beta1.GarageNodeSpec{
+				NodeID: newID, Zone: testZone,
+				Capacity: resource.NewQuantity(700<<30, resource.BinarySI),
+				Tags:     []string{testTierStorageTag},
+			},
+			Status: garagev1beta1.GarageNodeStatus{NodeID: newID},
+		}
+		cluster := &garagev1beta2.GarageCluster{ObjectMeta: metav1.ObjectMeta{Name: fmGarageContainer, Namespace: fmGarageContainer}}
+
+		r := &GarageNodeReconciler{}
+		Expect(r.reconcileNode(bctx, node, cluster, client)).To(Succeed())
+		Expect(fake.hasRole(newID)).To(BeTrue())
+		Expect(fake.hasRole(liveID)).To(BeTrue())
+	})
+
+	It("refuses to remove the stale role if it is the last storage node", func() {
+		// Only the stale storage role exists (plus a gateway). Dropping it would
+		// leave zero storage nodes — removeStaleNodeRole must no-op instead.
+		gw := garage.LayoutNodeRole{ID: "gw", Zone: testZone, Tags: []string{testTierGatewayTag}}
+		fake := newFakeGarageLayout(storageRole(oldID), gw)
+		srv := fake.server()
+		defer srv.Close()
+		client := garage.NewClient(srv.URL, "test-token")
+
+		r := &GarageNodeReconciler{}
+		Expect(r.removeStaleNodeRole(bctx, client, oldID)).To(Succeed())
+		Expect(fake.hasRole(oldID)).To(BeTrue(), "last storage node must not be removed")
+	})
+})


### PR DESCRIPTION
## Problem

When a managed storage `GarageNode`'s metadata is wiped in place (e.g. an operator clears its data/metadata PVC to recover a struggling node), Garage generates a **fresh `node_id`** on restart. `reconcileNode` discovered the new id and added it to the layout, but **never removed the previous identity's role**.

The dead pre-wipe identity stayed in the layout holding partitions Garage will never rebalance — it waits indefinitely for a node that will never return. Nothing reaped it:

- the gateway tombstone reaper (`reconcileGatewayTombstones`) only matches `capacity:null` (gateway) roles and explicitly excludes storage roles;
- the `-cycle` add-before-remove flow is never triggered by an in-place wipe.

Result: the cluster sits `unavailable` with the wiped node's partitions stuck below quorum, and recovery never starts. Observed live on the Ottawa cluster — two `asuka` identities in the same layout version, old one `isUp:false` holding 27 partitions, `GetClusterHealth` reporting 28 partitions without quorum.

## Fix

`reconcileNode` now compares the freshly discovered `node_id` against the last-known `status.NodeID`. When they differ, it removes the stale role via a new `removeStaleNodeRole` helper before adopting the new identity, so Garage rebalances the orphaned partitions onto live nodes (including this node's new identity).

`removeStaleNodeRole` mirrors `finalize()`'s safety:
- no-op if the role is already gone or it's the last storage node;
- tolerates a replication-constraint rejection (logged; a later reconcile retries);
- issues `skip-dead-nodes` with `AllowMissingData` so the layout doesn't stall in a draining version — the wiped node's data is gone with its metadata and rebuilds from surviving replicas.

## Tests

New `garagenode_stale_role_test.go` with a stateful in-memory Garage admin API:
- removes the previous identity's role when the discovered `node_id` changed (and adds the new one, leaving unrelated live nodes untouched);
- no-ops when the identity is unchanged;
- refuses to remove the stale role if it is the last storage node.

Full controller suite (187 specs) green; `golangci-lint` clean.