### PR TITLE
fix: CRD allOf enum conflict and STS replica drift on unsuspend

### DIFF
--- a/api/v1beta1/garagenode_types.go
+++ b/api/v1beta1/garagenode_types.go
@@ -121,9 +121,8 @@ type NodeVolumeConfig struct {
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
 
-	// Type specifies the volume type. Defaults to PVC.
+	// Type specifies the volume type. Defaults to PersistentVolumeClaim.
 	// Use EmptyDir for ephemeral storage (e.g. testing).
-	// +kubebuilder:validation:Enum=PVC;EmptyDir
 	// +optional
 	Type VolumeType `json:"type,omitempty"`
 

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
@@ -2076,16 +2076,12 @@ spec:
                           Uses the cluster default if not specified.
                         type: string
                       type:
-                        allOf:
-                        - enum:
-                          - PersistentVolumeClaim
-                          - EmptyDir
-                        - enum:
-                          - PVC
-                          - EmptyDir
                         description: |-
-                          Type specifies the volume type. Defaults to PVC.
+                          Type specifies the volume type. Defaults to PersistentVolumeClaim.
                           Use EmptyDir for ephemeral storage (e.g. testing).
+                        enum:
+                        - PersistentVolumeClaim
+                        - EmptyDir
                         type: string
                     type: object
                   dataFsync:
@@ -2155,16 +2151,12 @@ spec:
                             Uses the cluster default if not specified.
                           type: string
                         type:
-                          allOf:
-                          - enum:
-                            - PersistentVolumeClaim
-                            - EmptyDir
-                          - enum:
-                            - PVC
-                            - EmptyDir
                           description: |-
-                            Type specifies the volume type. Defaults to PVC.
+                            Type specifies the volume type. Defaults to PersistentVolumeClaim.
                             Use EmptyDir for ephemeral storage (e.g. testing).
+                          enum:
+                          - PersistentVolumeClaim
+                          - EmptyDir
                           type: string
                       type: object
                     type: array
@@ -2215,16 +2207,12 @@ spec:
                           Uses the cluster default if not specified.
                         type: string
                       type:
-                        allOf:
-                        - enum:
-                          - PersistentVolumeClaim
-                          - EmptyDir
-                        - enum:
-                          - PVC
-                          - EmptyDir
                         description: |-
-                          Type specifies the volume type. Defaults to PVC.
+                          Type specifies the volume type. Defaults to PersistentVolumeClaim.
                           Use EmptyDir for ephemeral storage (e.g. testing).
+                        enum:
+                        - PersistentVolumeClaim
+                        - EmptyDir
                         type: string
                     type: object
                   metadataAutoSnapshotInterval:

--- a/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
@@ -2076,16 +2076,12 @@ spec:
                           Uses the cluster default if not specified.
                         type: string
                       type:
-                        allOf:
-                        - enum:
-                          - PersistentVolumeClaim
-                          - EmptyDir
-                        - enum:
-                          - PVC
-                          - EmptyDir
                         description: |-
-                          Type specifies the volume type. Defaults to PVC.
+                          Type specifies the volume type. Defaults to PersistentVolumeClaim.
                           Use EmptyDir for ephemeral storage (e.g. testing).
+                        enum:
+                        - PersistentVolumeClaim
+                        - EmptyDir
                         type: string
                     type: object
                   dataFsync:
@@ -2155,16 +2151,12 @@ spec:
                             Uses the cluster default if not specified.
                           type: string
                         type:
-                          allOf:
-                          - enum:
-                            - PersistentVolumeClaim
-                            - EmptyDir
-                          - enum:
-                            - PVC
-                            - EmptyDir
                           description: |-
-                            Type specifies the volume type. Defaults to PVC.
+                            Type specifies the volume type. Defaults to PersistentVolumeClaim.
                             Use EmptyDir for ephemeral storage (e.g. testing).
+                          enum:
+                          - PersistentVolumeClaim
+                          - EmptyDir
                           type: string
                       type: object
                     type: array
@@ -2215,16 +2207,12 @@ spec:
                           Uses the cluster default if not specified.
                         type: string
                       type:
-                        allOf:
-                        - enum:
-                          - PersistentVolumeClaim
-                          - EmptyDir
-                        - enum:
-                          - PVC
-                          - EmptyDir
                         description: |-
-                          Type specifies the volume type. Defaults to PVC.
+                          Type specifies the volume type. Defaults to PersistentVolumeClaim.
                           Use EmptyDir for ephemeral storage (e.g. testing).
+                        enum:
+                        - PersistentVolumeClaim
+                        - EmptyDir
                         type: string
                     type: object
                   metadataAutoSnapshotInterval:

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -597,12 +597,18 @@ func (r *GarageNodeReconciler) reconcileStatefulSet(ctx context.Context, node *g
 			needsUpdate = true
 		}
 	}
+	// Restore replicas if the STS was scaled to 0 externally (e.g. during maintenance).
+	if existing.Spec.Replicas == nil || *existing.Spec.Replicas != replicas {
+		log.Info("StatefulSet replicas diverged, restoring", "current", existing.Spec.Replicas, "desired", replicas)
+		needsUpdate = true
+	}
 
 	if !needsUpdate {
 		return nil
 	}
 
 	existing.Spec.Template = sts.Spec.Template
+	existing.Spec.Replicas = &replicas
 	log.Info("Updating StatefulSet for GarageNode", "name", stsName)
 	return r.Update(ctx, existing)
 }

--- a/schemas/garagenode_v1beta1.json
+++ b/schemas/garagenode_v1beta1.json
@@ -1750,21 +1750,11 @@
                   "type": "string"
                 },
                 "type": {
-                  "allOf": [
-                    {
-                      "enum": [
-                        "PersistentVolumeClaim",
-                        "EmptyDir"
-                      ]
-                    },
-                    {
-                      "enum": [
-                        "PVC",
-                        "EmptyDir"
-                      ]
-                    }
+                  "description": "Type specifies the volume type. Defaults to PersistentVolumeClaim.\nUse EmptyDir for ephemeral storage (e.g. testing).",
+                  "enum": [
+                    "PersistentVolumeClaim",
+                    "EmptyDir"
                   ],
-                  "description": "Type specifies the volume type. Defaults to PVC.\nUse EmptyDir for ephemeral storage (e.g. testing).",
                   "type": "string"
                 }
               },
@@ -1817,21 +1807,11 @@
                     "type": "string"
                   },
                   "type": {
-                    "allOf": [
-                      {
-                        "enum": [
-                          "PersistentVolumeClaim",
-                          "EmptyDir"
-                        ]
-                      },
-                      {
-                        "enum": [
-                          "PVC",
-                          "EmptyDir"
-                        ]
-                      }
+                    "description": "Type specifies the volume type. Defaults to PersistentVolumeClaim.\nUse EmptyDir for ephemeral storage (e.g. testing).",
+                    "enum": [
+                      "PersistentVolumeClaim",
+                      "EmptyDir"
                     ],
-                    "description": "Type specifies the volume type. Defaults to PVC.\nUse EmptyDir for ephemeral storage (e.g. testing).",
                     "type": "string"
                   }
                 },
@@ -1880,21 +1860,11 @@
                   "type": "string"
                 },
                 "type": {
-                  "allOf": [
-                    {
-                      "enum": [
-                        "PersistentVolumeClaim",
-                        "EmptyDir"
-                      ]
-                    },
-                    {
-                      "enum": [
-                        "PVC",
-                        "EmptyDir"
-                      ]
-                    }
+                  "description": "Type specifies the volume type. Defaults to PersistentVolumeClaim.\nUse EmptyDir for ephemeral storage (e.g. testing).",
+                  "enum": [
+                    "PersistentVolumeClaim",
+                    "EmptyDir"
                   ],
-                  "description": "Type specifies the volume type. Defaults to PVC.\nUse EmptyDir for ephemeral storage (e.g. testing).",
                   "type": "string"
                 }
               },


### PR DESCRIPTION
## Summary

- **Fixes #253** — `NodeVolumeConfig.Type` had a field-level `+kubebuilder:validation:Enum=PVC;EmptyDir` that conflicted with the `VolumeType` type-level enum (`PersistentVolumeClaim;EmptyDir`). kubebuilder generates an `allOf` combining both, making every value impossible to satisfy simultaneously. Removed the incorrect field-level marker; CRDs regenerated.
- **Fixes #252** — `reconcileNodeStatefulSet` only patched `existing.Spec.Template`, never `.Spec.Replicas`. A STS manually scaled to 0 during maintenance stayed at 0 after unsuspend. Added a replicas drift check and unconditionally restores `replicas=1` in the update path.

## Test plan

- [ ] `go test ./...` passes (verified locally)
- [ ] CRD no longer contains `allOf` for `NodeVolumeConfig.type`; accepted values are `PersistentVolumeClaim` and `EmptyDir`
- [ ] Unsuspending a GarageNode whose STS is at 0 replicas results in the controller scaling it back to 1