### PR TITLE
fix(chart): stale appVersion + CI guard (#260), bucket name in key secret (#261)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -27,6 +27,33 @@ env:
   CHART_NAME: garage-operator
 
 jobs:
+  verify-version:
+    name: Verify Chart Version Matches Tag
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check chart version + appVersion + image.tag match tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          CHART_VER=$(grep '^version:' charts/${{ env.CHART_NAME }}/Chart.yaml | awk '{print $2}')
+          APP_VER=$(grep '^appVersion:' charts/${{ env.CHART_NAME }}/Chart.yaml | sed 's/.*: *"\(.*\)".*/\1/')
+          IMAGE_TAG=$(grep '  tag: ' charts/${{ env.CHART_NAME }}/values.yaml | sed 's/.*: *"\(.*\)".*/\1/')
+          echo "Tag:          ${{ github.ref_name }}"
+          echo "Chart ver:    $CHART_VER"
+          echo "appVersion:   $APP_VER"
+          echo "image.tag:    $IMAGE_TAG"
+          OK=true
+          [ "$CHART_VER" = "$TAG" ] || { echo "::error::chart version ($CHART_VER) != tag ($TAG)"; OK=false; }
+          [ "$APP_VER" = "$TAG" ] || { echo "::error::appVersion ($APP_VER) != tag ($TAG)"; OK=false; }
+          [ "$IMAGE_TAG" = "${{ github.ref_name }}" ] || { echo "::error::image.tag ($IMAGE_TAG) != tag (${{ github.ref_name }})"; OK=false; }
+          $OK || exit 1
+          echo "All versions match."
+
   verify-crds:
     name: Verify CRDs in Sync
     runs-on: ubuntu-latest
@@ -106,20 +133,9 @@ jobs:
       - name: Get chart version
         id: chart_version
         run: |
-          # Use the tag version (strip the 'v' prefix)
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(grep '^version:' charts/${{ env.CHART_NAME }}/Chart.yaml | awk '{print $2}')
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           echo "Chart version: ${VERSION}"
-
-      - name: Update chart version
-        run: |
-          sed -i "s/^version:.*/version: ${{ steps.chart_version.outputs.VERSION }}/" charts/${{ env.CHART_NAME }}/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.chart_version.outputs.VERSION }}\"/" charts/${{ env.CHART_NAME }}/Chart.yaml
-
-      - name: Update image tag in values
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          sed -i "s/tag: \"\"/tag: \"${TAG}\"/" charts/${{ env.CHART_NAME }}/values.yaml
 
       - name: Sync CRDs to Helm chart
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,7 +595,7 @@ Import test: `go get git.deuxfleurs.fr/garage-sdk/garage-admin-sdk-golang` succe
 | `lint.yml` | golangci-lint |
 | `test-e2e.yml` | E2E tests with Kind |
 | `docker.yml` | Multi-arch images to `ghcr.io/rajsinghtech/garage-operator` |
-| `helm.yml` | Helm chart lint, verify CRDs, push to OCI registry |
+| `helm.yml` | Helm chart lint, verify CRDs, verify version, push to OCI registry |
 | `release.yml` | GitHub release with install.yaml |
 
 ```bash
@@ -603,8 +603,22 @@ Import test: `go get git.deuxfleurs.fr/garage-sdk/garage-admin-sdk-golang` succe
 kubectl apply -f https://github.com/rajsinghtech/garage-operator/releases/latest/download/install.yaml
 
 # Release
-git tag v1.0.0 && git push origin v1.0.0
+make chart-bump VERSION=v0.6.18   # bump Chart.yaml + values.yaml image.tag
+git add -A && git commit -m "release: v0.6.18"
+git tag v0.6.18 && git push origin main v0.6.18
 ```
+
+### Chart version management
+
+The in-repo `charts/garage-operator/Chart.yaml` (version + appVersion) and
+`charts/garage-operator/values.yaml` (image.tag) MUST match the latest release
+tag. The `helm.yml` CI workflow has a `verify-version` job that fails the tag
+push if these three values don't match the tag. Always run
+`make chart-bump VERSION=vX.Y.Z` before committing a release — the target
+updates all three fields atomically. The `appVersion` field is what Helm uses
+as the default image tag when `values.yaml image.tag` is empty; the previous
+practice of leaving them stale caused issue #260 (users installing from a local
+clone got a months-old operator image).
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,40 @@ helm-uninstall: ## Uninstall Helm chart from current cluster
 helm-push: helm-package ## Push Helm chart to OCI registry (GHCR)
 	helm push dist/garage-operator-*.tgz oci://$(HELM_REGISTRY)
 
+.PHONY: chart-bump
+chart-bump: ## Bump Helm chart version+appVersion and image tag. Usage: make chart-bump VERSION=v0.6.18
+ifndef VERSION
+	$(error VERSION is required. Usage: make chart-bump VERSION=v0.6.18)
+endif
+	@TAG=$$(echo "$(VERSION)" | sed 's/^v//'); \
+	echo "Bumping chart version to $$TAG (appVersion $$TAG, image tag $(VERSION))"; \
+	sed -i.bak "s/^version:.*/version: $$TAG/" $(HELM_CHART_DIR)/Chart.yaml && rm -f $(HELM_CHART_DIR)/Chart.yaml.bak; \
+	sed -i.bak 's/^appVersion:.*/appVersion: "'$$TAG'"/' $(HELM_CHART_DIR)/Chart.yaml && rm -f $(HELM_CHART_DIR)/Chart.yaml.bak; \
+	sed -i.bak 's|^  tag: ".*"|  tag: "$(VERSION)"|' $(HELM_CHART_DIR)/values.yaml && rm -f $(HELM_CHART_DIR)/values.yaml.bak; \
+	echo "Done. Review and commit:"; \
+	echo "  git diff $(HELM_CHART_DIR)/Chart.yaml $(HELM_CHART_DIR)/values.yaml"
+
+.PHONY: helm-verify-version
+helm-verify-version: ## Verify in-repo chart version matches the latest git tag
+	@LATEST_TAG=$$(git describe --tags --abbrev=0 2>/dev/null || echo ""); \
+	if [ -z "$$LATEST_TAG" ]; then \
+		echo "No tags found, skipping check"; \
+		exit 0; \
+	fi; \
+	EXPECTED=$$(echo "$$LATEST_TAG" | sed 's/^v//'); \
+	CHART_VER=$$(grep '^version:' $(HELM_CHART_DIR)/Chart.yaml | awk '{print $$2}'); \
+	APP_VER=$$(grep '^appVersion:' $(HELM_CHART_DIR)/Chart.yaml | sed 's/.*: *"\(.*\)".*/\1/'); \
+	IMAGE_TAG=$$(grep '  tag: ' $(HELM_CHART_DIR)/values.yaml | sed 's/.*: *"\(.*\)".*/\1/'); \
+	echo "Latest tag:    $$LATEST_TAG"; \
+	echo "Chart version: $$CHART_VER"; \
+	echo "appVersion:    $$APP_VER"; \
+	echo "image.tag:    $$IMAGE_TAG"; \
+	OK=true; \
+	[ "$$CHART_VER" = "$$EXPECTED" ] || { echo "ERROR: chart version ($$CHART_VER) != tag ($$EXPECTED)"; OK=false; }; \
+	[ "$$APP_VER" = "$$EXPECTED" ] || { echo "ERROR: appVersion ($$APP_VER) != tag ($$EXPECTED)"; OK=false; }; \
+	[ "$$IMAGE_TAG" = "$$LATEST_TAG" ] || { echo "ERROR: image.tag ($$IMAGE_TAG) != tag ($$LATEST_TAG)"; OK=false; }; \
+	$$OK && echo "All versions in sync." || exit 1
+
 .PHONY: helm-verify-crd-bases
 helm-verify-crd-bases: ## Verify Helm chart CRDs match kustomize CRDs
 	@echo "Checking if Helm chart CRDs match kustomize CRDs..."

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -179,6 +179,14 @@ const (
 	// triggering RepairType=Aliases on the parent GarageCluster via the
 	// garage.rajsingh.info/trigger-repair annotation.
 	ConditionBucketLookupStuck = "BucketLookupStuck"
+
+	// ConditionBucketMetadataDegraded indicates Garage's admin API returned
+	// an InternalError "Unable to decode entry of key" for GetBucketInfo.
+	// Caused by key_table entries written by an older Garage version that the
+	// running version cannot deserialize. The operator auto-triggers
+	// Repair:Tables on the parent GarageCluster after BucketDecodeErrorThreshold
+	// consecutive failures. Cleared on the first successful GetBucketInfo.
+	ConditionBucketMetadataDegraded = "BucketMetadataDegraded"
 )
 
 // GarageKey condition types
@@ -333,6 +341,11 @@ const (
 	// ConditionBucketLookupStuck condition; manual recovery is to trigger
 	// RepairType=Aliases on the parent GarageCluster.
 	ReasonBucketLookupStuck = "AdminAPITimeout"
+
+	// ReasonMetadataDecodeError indicates GetBucketInfo returned HTTP 500
+	// "Unable to decode entry of key". The operator auto-triggers
+	// Repair:Tables on the parent GarageCluster to re-sync key_table entries.
+	ReasonMetadataDecodeError = "MetadataDecodeError"
 )
 
 // Annotation keys for operational tasks
@@ -392,6 +405,12 @@ const (
 	// ConditionBucketLookupStuck status condition. Internal use only — users
 	// should not set this directly.
 	AnnotationBucketLookupTimeouts = AnnotationPrefix + "bucket-lookup-timeouts"
+
+	// AnnotationBucketDecodeErrors tracks consecutive GetBucketInfo decode errors
+	// ("Unable to decode entry of key") on this bucket. Incremented on each error,
+	// cleared on first success. At BucketDecodeErrorThreshold (3), the operator
+	// auto-triggers Repair:Tables on the parent GarageCluster. Internal use only.
+	AnnotationBucketDecodeErrors = AnnotationPrefix + "bucket-decode-errors"
 
 	// GarageCluster repair/maintenance annotations
 

--- a/api/v1beta1/garagekey_types.go
+++ b/api/v1beta1/garagekey_types.go
@@ -182,6 +182,12 @@ type SecretTemplate struct {
 	// +optional
 	RegionKey string `json:"regionKey,omitempty"`
 
+	// BucketNameKey is the data key under which the bucket name is written
+	// in the Secret. Defaults to "bucket". Only used when IncludeBucketName is true.
+	// +kubebuilder:default="bucket"
+	// +optional
+	BucketNameKey string `json:"bucketNameKey,omitempty"`
+
 	// IncludeEndpoint includes the S3 endpoint in the secret
 	// Defaults to true if not specified
 	// +optional
@@ -191,6 +197,12 @@ type SecretTemplate struct {
 	// Defaults to true if not specified
 	// +optional
 	IncludeRegion *bool `json:"includeRegion,omitempty"`
+
+	// IncludeBucketName controls whether the bucket name is written to the Secret.
+	// Defaults to false. When true, the bucket name is populated only if the key
+	// references exactly one bucket (via bucketRef or globalAlias); omitted otherwise.
+	// +optional
+	IncludeBucketName *bool `json:"includeBucketName,omitempty"`
 
 	// AdditionalData includes additional key-value pairs in the secret
 	// +optional

--- a/api/v1beta1/garagekey_webhook.go
+++ b/api/v1beta1/garagekey_webhook.go
@@ -77,6 +77,9 @@ func (d *GarageKeyDefaulter) Default(ctx context.Context, obj *GarageKey) error 
 		if obj.Spec.SecretTemplate.RegionKey == "" {
 			obj.Spec.SecretTemplate.RegionKey = "region"
 		}
+		if obj.Spec.SecretTemplate.BucketNameKey == "" {
+			obj.Spec.SecretTemplate.BucketNameKey = "bucket"
+		}
 	}
 
 	return nil

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -2907,6 +2907,11 @@ func (in *SecretTemplate) DeepCopyInto(out *SecretTemplate) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IncludeBucketName != nil {
+		in, out := &in.IncludeBucketName, &out.IncludeBucketName
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AdditionalData != nil {
 		in, out := &in.AdditionalData, &out.AdditionalData
 		*out = make(map[string]string, len(*in))

--- a/charts/garage-operator/Chart.yaml
+++ b/charts/garage-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: garage-operator
 description: A Kubernetes operator for managing Garage distributed S3-compatible object storage
 type: application
-version: 0.4.1
-appVersion: "0.4.1"
+version: 0.6.18
+appVersion: "0.6.18"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/rajsinghtech/garage-operator
 sources:

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
@@ -289,6 +289,12 @@ spec:
                       type: string
                     description: Annotations to add to the secret
                     type: object
+                  bucketNameKey:
+                    default: bucket
+                    description: |-
+                      BucketNameKey is the data key under which the bucket name is written
+                      in the Secret. Defaults to "bucket". Only used when IncludeBucketName is true.
+                    type: string
                   endpointKey:
                     default: endpoint
                     description: EndpointKey is the key name for the S3 endpoint (includes
@@ -299,6 +305,12 @@ spec:
                     description: HostKey is the key name for the S3 host (without
                       scheme, e.g., "host:port")
                     type: string
+                  includeBucketName:
+                    description: |-
+                      IncludeBucketName controls whether the bucket name is written to the Secret.
+                      Defaults to false. When true, the bucket name is populated only if the key
+                      references exactly one bucket (via bucketRef or globalAlias); omitted otherwise.
+                    type: boolean
                   includeEndpoint:
                     description: |-
                       IncludeEndpoint includes the S3 endpoint in the secret

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)
-  tag: ""
+  tag: "v0.6.18"
 
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.

--- a/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
@@ -289,6 +289,12 @@ spec:
                       type: string
                     description: Annotations to add to the secret
                     type: object
+                  bucketNameKey:
+                    default: bucket
+                    description: |-
+                      BucketNameKey is the data key under which the bucket name is written
+                      in the Secret. Defaults to "bucket". Only used when IncludeBucketName is true.
+                    type: string
                   endpointKey:
                     default: endpoint
                     description: EndpointKey is the key name for the S3 endpoint (includes
@@ -299,6 +305,12 @@ spec:
                     description: HostKey is the key name for the S3 host (without
                       scheme, e.g., "host:port")
                     type: string
+                  includeBucketName:
+                    description: |-
+                      IncludeBucketName controls whether the bucket name is written to the Secret.
+                      Defaults to false. When true, the bucket name is populated only if the key
+                      references exactly one bucket (via bucketRef or globalAlias); omitted otherwise.
+                    type: boolean
                   includeEndpoint:
                     description: |-
                       IncludeEndpoint includes the S3 endpoint in the secret

--- a/config/samples/garage_v1beta1_garagekey.yaml
+++ b/config/samples/garage_v1beta1_garagekey.yaml
@@ -25,6 +25,8 @@ spec:
     regionKey: AWS_REGION
     includeEndpoint: true
     includeRegion: true
+    bucketNameKey: bucket
+    includeBucketName: true
 
   # Bucket permissions
   bucketPermissions:

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -48,6 +48,11 @@ const (
 	// BucketLookupStuckThreshold is the number of consecutive GetBucketInfo
 	// timeouts after which we set the BucketLookupStuck status condition.
 	BucketLookupStuckThreshold = 3
+
+	// BucketDecodeErrorThreshold is the number of consecutive GetBucketInfo
+	// decode errors after which the operator auto-triggers Repair:Tables on
+	// the parent GarageCluster.
+	BucketDecodeErrorThreshold = 3
 )
 
 // getBucketInfoTimeout caps each individual GetBucketInfo admin API call
@@ -76,6 +81,7 @@ type GarageBucketReconciler struct {
 // +kubebuilder:rbac:groups=garage.rajsingh.info,resources=garagebuckets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=garage.rajsingh.info,resources=garagebuckets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=garage.rajsingh.info,resources=garagekeys,verbs=get;list;watch
+// +kubebuilder:rbac:groups=garage.rajsingh.info,resources=garageclusters,verbs=get;patch
 
 func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -248,6 +254,11 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// ran above and persisted.
 		if isBucketLookupTimeout(err) {
 			return r.handleBucketLookupTimeout(ctx, bucket)
+		}
+		// A metadata decode error means key_table entries can't be deserialized.
+		// Auto-trigger Repair:Tables on the parent cluster after threshold hits.
+		if garage.IsMetadataDecodeError(err) {
+			return r.handleBucketDecodeError(ctx, bucket, cluster)
 		}
 		return r.updateStatus(ctx, bucket, PhaseFailed, err)
 	}
@@ -876,12 +887,18 @@ func (r *GarageBucketReconciler) updateStatusFromGarage(ctx context.Context, buc
 		if isBucketLookupTimeout(err) {
 			return r.handleBucketLookupTimeout(ctx, bucket)
 		}
+		if garage.IsMetadataDecodeError(err) {
+			return r.handleBucketDecodeError(ctx, bucket, cluster)
+		}
 		return r.updateStatus(ctx, bucket, PhaseFailed, fmt.Errorf("failed to get bucket info: %w", err))
 	}
-	// First success after one or more timeouts → reset counter and clear
-	// the BucketLookupStuck condition so a transient stall self-heals.
+	// First success after one or more timeouts/decode errors → reset counters
+	// and clear transient conditions so they self-heal.
 	if err := r.clearBucketLookupTimeouts(ctx, bucket); err != nil {
 		logf.FromContext(ctx).Error(err, "Failed to clear bucket-lookup-timeouts annotation")
+	}
+	if err := r.clearBucketDecodeErrors(ctx, bucket); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to clear bucket-decode-errors annotation")
 	}
 
 	// Capture old status before modifications to detect no-op updates
@@ -1166,6 +1183,106 @@ func (r *GarageBucketReconciler) handleBucketLookupTimeout(ctx context.Context, 
 		}
 	}
 	return ctrl.Result{RequeueAfter: RequeueAfterUnhealthy}, nil
+}
+
+// handleBucketDecodeError is called when GetBucketInfo returns a Garage
+// InternalError "Unable to decode entry of key". This means a key_table entry
+// cannot be deserialized by the running Garage version — typically after an
+// upgrade or cross-version write. The reconciler increments a counter and,
+// on reaching BucketDecodeErrorThreshold, auto-triggers Repair:Tables on the
+// parent GarageCluster to re-sync key_table entries across all nodes.
+func (r *GarageBucketReconciler) handleBucketDecodeError(ctx context.Context, bucket *garagev1beta1.GarageBucket, cluster *garagev1beta2.GarageCluster) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	count, patchErr := r.recordBucketDecodeError(ctx, bucket)
+	if patchErr != nil {
+		log.Error(patchErr, "Failed to record bucket-decode-errors annotation")
+	}
+	log.Info("GetBucketInfo returned metadata decode error; key_table entry may be malformed",
+		"bucket", bucket.Name, "consecutiveErrors", count, "threshold", BucketDecodeErrorThreshold)
+
+	if count >= BucketDecodeErrorThreshold {
+		alias := bucket.Spec.GlobalAlias
+		if alias == "" {
+			alias = bucket.Name
+		}
+
+		// Auto-trigger Repair:Tables on the parent cluster if not already pending.
+		// The cluster controller consumes and removes this annotation after running,
+		// so checking its presence is sufficient dedup without a separate cooldown.
+		if cluster.Annotations[garagev1beta1.AnnotationTriggerRepair] == "" {
+			patch := client.MergeFrom(cluster.DeepCopy())
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+			cluster.Annotations[garagev1beta1.AnnotationTriggerRepair] = garagev1beta1.RepairTypeTables
+			if err := r.Patch(ctx, cluster, patch); err != nil {
+				log.Error(err, "Failed to auto-trigger Repair:Tables on parent cluster")
+			} else {
+				log.Info("Auto-triggered Repair:Tables on parent cluster to fix key_table decode errors",
+					"cluster", cluster.Name, "bucket", bucket.Name)
+			}
+		}
+
+		cond := metav1.Condition{
+			Type:   garagev1beta1.ConditionBucketMetadataDegraded,
+			Status: metav1.ConditionTrue,
+			Reason: garagev1beta1.ReasonMetadataDecodeError,
+			Message: fmt.Sprintf(
+				"GetBucketInfo for bucket %q failed to decode key_table entry %d consecutive times. "+
+					"Repair:Tables has been triggered on cluster %q to re-sync key_table entries. "+
+					"This condition clears automatically on the next successful GetBucketInfo.",
+				alias, count, cluster.Name,
+			),
+			ObservedGeneration: bucket.Generation,
+		}
+		apply := func() {
+			meta.SetStatusCondition(&bucket.Status.Conditions, cond)
+		}
+		apply()
+		if err := UpdateStatusWithRetry(ctx, r.Client, bucket, apply); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{RequeueAfter: RequeueAfterUnhealthy}, nil
+}
+
+// recordBucketDecodeError increments the consecutive decode-error counter
+// annotation on the bucket and returns the new count.
+func (r *GarageBucketReconciler) recordBucketDecodeError(ctx context.Context, bucket *garagev1beta1.GarageBucket) (int, error) {
+	current := 0
+	if v, ok := bucket.Annotations[garagev1beta1.AnnotationBucketDecodeErrors]; ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			current = n
+		}
+	}
+	current++
+	patch := client.MergeFrom(bucket.DeepCopy())
+	if bucket.Annotations == nil {
+		bucket.Annotations = make(map[string]string)
+	}
+	bucket.Annotations[garagev1beta1.AnnotationBucketDecodeErrors] = strconv.Itoa(current)
+	return current, r.Patch(ctx, bucket, patch)
+}
+
+// clearBucketDecodeErrors removes the consecutive decode-error counter and
+// the BucketMetadataDegraded condition on first success after prior failures.
+func (r *GarageBucketReconciler) clearBucketDecodeErrors(ctx context.Context, bucket *garagev1beta1.GarageBucket) error {
+	hadAnno := bucket.Annotations[garagev1beta1.AnnotationBucketDecodeErrors] != ""
+	hadCond := meta.FindStatusCondition(bucket.Status.Conditions, garagev1beta1.ConditionBucketMetadataDegraded) != nil
+	if !hadAnno && !hadCond {
+		return nil
+	}
+	if hadAnno {
+		patch := client.MergeFrom(bucket.DeepCopy())
+		delete(bucket.Annotations, garagev1beta1.AnnotationBucketDecodeErrors)
+		if err := r.Patch(ctx, bucket, patch); err != nil {
+			return err
+		}
+	}
+	if hadCond {
+		meta.RemoveStatusCondition(&bucket.Status.Conditions, garagev1beta1.ConditionBucketMetadataDegraded)
+	}
+	return nil
 }
 
 func formatBytes(bytes int64) string {

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -668,8 +668,10 @@ type secretConfig struct {
 	hostKey            string
 	schemeKey          string
 	regionKey          string
+	bucketNameKey      string
 	includeEndpoint    bool
 	includeRegion      bool
+	includeBucketName  bool
 	additionalData     map[string]string
 	labels             map[string]string
 	annotations        map[string]string
@@ -687,6 +689,7 @@ func resolveSecretConfig(key *garagev1beta1.GarageKey) secretConfig {
 		hostKey:            defaultHostKey,
 		schemeKey:          defaultSchemeKey,
 		regionKey:          defaultRegionKey,
+		bucketNameKey:      defaultBucketNameKey,
 		includeEndpoint:    true,
 		includeRegion:      true,
 		labels: map[string]string{
@@ -723,11 +726,17 @@ func resolveSecretConfig(key *garagev1beta1.GarageKey) secretConfig {
 	if tmpl.RegionKey != "" {
 		cfg.regionKey = tmpl.RegionKey
 	}
+	if tmpl.BucketNameKey != "" {
+		cfg.bucketNameKey = tmpl.BucketNameKey
+	}
 	if tmpl.IncludeEndpoint != nil {
 		cfg.includeEndpoint = *tmpl.IncludeEndpoint
 	}
 	if tmpl.IncludeRegion != nil {
 		cfg.includeRegion = *tmpl.IncludeRegion
+	}
+	if tmpl.IncludeBucketName != nil {
+		cfg.includeBucketName = *tmpl.IncludeBucketName
 	}
 	if tmpl.AdditionalData != nil {
 		cfg.additionalData = tmpl.AdditionalData
@@ -774,11 +783,39 @@ func buildSecretData(cfg secretConfig, key *garagev1beta1.GarageKey, cluster *ga
 		data[cfg.regionKey] = []byte(region)
 	}
 
+	if cfg.includeBucketName {
+		if name, ok := singleBucketName(key); ok {
+			data[cfg.bucketNameKey] = []byte(name)
+		}
+	}
+
 	for k, v := range cfg.additionalData {
 		data[k] = []byte(v)
 	}
 
 	return data
+}
+
+// singleBucketName returns the bucket name when the key references exactly one
+// bucket via bucketRef (with a name) or globalAlias. It returns ("", false) for
+// the ambiguous cases: zero permissions, more than one permission, allBuckets,
+// or a single permission that carries neither a bucketRef name nor a globalAlias.
+func singleBucketName(key *garagev1beta1.GarageKey) (string, bool) {
+	if key.Spec.AllBuckets != nil {
+		return "", false
+	}
+	perms := key.Spec.BucketPermissions
+	if len(perms) != 1 {
+		return "", false
+	}
+	p := perms[0]
+	if p.GlobalAlias != "" {
+		return p.GlobalAlias, true
+	}
+	if p.BucketRef != nil && p.BucketRef.Name != "" {
+		return p.BucketRef.Name, true
+	}
+	return "", false
 }
 
 // secretDataEqual returns true if two secret data maps have identical keys and values.

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -174,6 +174,7 @@ const (
 	defaultHostKey            = "host"
 	defaultSchemeKey          = "scheme"
 	defaultRegionKey          = "region"
+	defaultBucketNameKey      = "bucket"
 )
 
 var validRepairTypes = map[string]bool{

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -29,29 +29,32 @@ import (
 )
 
 const (
-	testClusterName        = "test-cluster"
-	testNonExistentCluster = "non-existent-cluster"
-	testNonExistent        = "non-existent"
-	testExternalRPCSecret  = "external-rpc-secret"
-	testStorageClass       = "fast-ssd"
-	testIPv4Addr           = "10.0.0.1"
-	testIPv4RPCAddr        = "10.0.0.1:3901"
-	testEndpointKey        = "endpoint"
-	testHostKey            = "host"
-	testAccessKeyID        = "AKIAIOSFODNN7EXAMPLE"
-	testCustomKey          = "custom-key"
-	testImageFull          = "custom/garage:v1.0.0"
-	testImageRepo          = "my-mirror/garage"
-	testImageFull2         = "custom/garage:v3.0.0"
-	testNodeImageRepo      = "node-mirror/garage"
-	testAccessKeyIDKey     = "access-key-id"
-	testSecretAccessKey    = "secret-access-key"
-	testSchemeKey          = "scheme"
-	testRegionKey          = "region"
-	testSecretValue        = "secret123"
-	testOperatorImage      = "registry.example.com/garage:v2.0.0"
-	testPortNameRPC        = "rpc"
-	teamLabelKey           = "team"
+	testClusterName         = "test-cluster"
+	testNonExistentCluster  = "non-existent-cluster"
+	testNonExistent         = "non-existent"
+	testExternalRPCSecret   = "external-rpc-secret"
+	testStorageClass        = "fast-ssd"
+	testIPv4Addr            = "10.0.0.1"
+	testIPv4RPCAddr         = "10.0.0.1:3901"
+	testEndpointKey         = "endpoint"
+	testHostKey             = "host"
+	testAccessKeyID         = "AKIAIOSFODNN7EXAMPLE"
+	testCustomKey           = "custom-key"
+	testImageFull           = "custom/garage:v1.0.0"
+	testImageRepo           = "my-mirror/garage"
+	testImageFull2          = "custom/garage:v3.0.0"
+	testNodeImageRepo       = "node-mirror/garage"
+	testAccessKeyIDKey      = "access-key-id"
+	testSecretAccessKey     = "secret-access-key"
+	testSchemeKey           = "scheme"
+	testRegionKey           = "region"
+	testBucketNameKey       = "bucket"
+	testCustomBucketNameKey = "BUCKET_NAME"
+	testBucketName          = "my-bucket"
+	testSecretValue         = "secret123"
+	testOperatorImage       = "registry.example.com/garage:v2.0.0"
+	testPortNameRPC         = "rpc"
+	teamLabelKey            = "team"
 )
 
 func TestResolveSecretConfig(t *testing.T) {
@@ -72,6 +75,7 @@ func TestResolveSecretConfig(t *testing.T) {
 				hostKey:            testHostKey,
 				schemeKey:          testSchemeKey,
 				regionKey:          testRegionKey,
+				bucketNameKey:      testBucketNameKey,
 				includeEndpoint:    true,
 				includeRegion:      true,
 				secretType:         corev1.SecretTypeOpaque,
@@ -98,6 +102,7 @@ func TestResolveSecretConfig(t *testing.T) {
 				hostKey:            "AWS_HOST",
 				schemeKey:          "AWS_SCHEME",
 				regionKey:          "AWS_REGION",
+				bucketNameKey:      testBucketNameKey,
 				includeEndpoint:    true,
 				includeRegion:      true,
 				secretType:         corev1.SecretTypeOpaque,
@@ -120,8 +125,33 @@ func TestResolveSecretConfig(t *testing.T) {
 				hostKey:            testHostKey,
 				schemeKey:          testSchemeKey,
 				regionKey:          testRegionKey,
+				bucketNameKey:      testBucketNameKey,
 				includeEndpoint:    false,
 				includeRegion:      false,
+				secretType:         corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "custom bucket name key and include flag",
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					SecretTemplate: &garagev1beta1.SecretTemplate{
+						BucketNameKey:     testCustomBucketNameKey,
+						IncludeBucketName: boolPtr(true),
+					},
+				},
+			},
+			expected: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				endpointKey:        testEndpointKey,
+				hostKey:            testHostKey,
+				schemeKey:          testSchemeKey,
+				regionKey:          testRegionKey,
+				bucketNameKey:      testCustomBucketNameKey,
+				includeEndpoint:    true,
+				includeRegion:      true,
+				includeBucketName:  true,
 				secretType:         corev1.SecretTypeOpaque,
 			},
 		},
@@ -141,6 +171,7 @@ func TestResolveSecretConfig(t *testing.T) {
 				hostKey:            testHostKey,
 				schemeKey:          testSchemeKey,
 				regionKey:          testRegionKey,
+				bucketNameKey:      testBucketNameKey,
 				includeEndpoint:    true,
 				includeRegion:      true,
 				secretType:         corev1.SecretTypeDockerConfigJson,
@@ -176,6 +207,12 @@ func TestResolveSecretConfig(t *testing.T) {
 			if result.includeRegion != tt.expected.includeRegion {
 				t.Errorf("includeRegion = %v, want %v", result.includeRegion, tt.expected.includeRegion)
 			}
+			if result.bucketNameKey != tt.expected.bucketNameKey {
+				t.Errorf("bucketNameKey = %q, want %q", result.bucketNameKey, tt.expected.bucketNameKey)
+			}
+			if result.includeBucketName != tt.expected.includeBucketName {
+				t.Errorf("includeBucketName = %v, want %v", result.includeBucketName, tt.expected.includeBucketName)
+			}
 			if result.secretType != tt.expected.secretType {
 				t.Errorf("secretType = %v, want %v", result.secretType, tt.expected.secretType)
 			}
@@ -192,6 +229,7 @@ func TestBuildSecretData(t *testing.T) {
 		secretAccessKey string
 		wantKeys        []string
 		wantValues      map[string]string
+		dontWantKeys    []string
 	}{
 		{
 			name: "basic secret with all fields",
@@ -290,6 +328,161 @@ func TestBuildSecretData(t *testing.T) {
 				testCustomKey: "custom-value",
 			},
 		},
+		{
+			name: "include bucket name for single bucket via bucketRef",
+			cfg: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				includeEndpoint:    false,
+				includeRegion:      false,
+				bucketNameKey:      testBucketNameKey,
+				includeBucketName:  true,
+			},
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketRef: &garagev1beta1.BucketRef{Name: testBucketName}, Read: true, Write: true},
+					},
+				},
+			},
+			cluster:         &garagev1beta2.GarageCluster{},
+			secretAccessKey: testSecretValue,
+			wantValues: map[string]string{
+				testBucketNameKey: testBucketName,
+			},
+		},
+		{
+			name: "include bucket name with custom key",
+			cfg: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				includeEndpoint:    false,
+				includeRegion:      false,
+				bucketNameKey:      testCustomBucketNameKey,
+				includeBucketName:  true,
+			},
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketRef: &garagev1beta1.BucketRef{Name: testBucketName}, Read: true},
+					},
+				},
+			},
+			cluster:         &garagev1beta2.GarageCluster{},
+			secretAccessKey: testSecretValue,
+			wantValues: map[string]string{
+				testCustomBucketNameKey: testBucketName,
+			},
+		},
+		{
+			name: "include bucket name prefers globalAlias over bucketRef",
+			cfg: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				includeEndpoint:    false,
+				includeRegion:      false,
+				bucketNameKey:      testBucketNameKey,
+				includeBucketName:  true,
+			},
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{GlobalAlias: "alias-name", Read: true},
+					},
+				},
+			},
+			cluster:         &garagev1beta2.GarageCluster{},
+			secretAccessKey: testSecretValue,
+			wantValues: map[string]string{
+				testBucketNameKey: "alias-name",
+			},
+		},
+		{
+			name: "bucket name absent when includeBucketName false (backward compat)",
+			cfg: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				includeEndpoint:    false,
+				includeRegion:      false,
+				bucketNameKey:      testBucketNameKey,
+				includeBucketName:  false,
+			},
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketRef: &garagev1beta1.BucketRef{Name: testBucketName}, Read: true},
+					},
+				},
+			},
+			cluster:         &garagev1beta2.GarageCluster{},
+			secretAccessKey: testSecretValue,
+			dontWantKeys:    []string{testBucketNameKey},
+		},
+		{
+			name: "bucket name absent when multiple bucketPermissions (ambiguous)",
+			cfg: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				includeEndpoint:    false,
+				includeRegion:      false,
+				bucketNameKey:      testBucketNameKey,
+				includeBucketName:  true,
+			},
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketRef: &garagev1beta1.BucketRef{Name: "b1"}, Read: true},
+						{BucketRef: &garagev1beta1.BucketRef{Name: "b2"}, Read: true},
+					},
+				},
+			},
+			cluster:         &garagev1beta2.GarageCluster{},
+			secretAccessKey: testSecretValue,
+			dontWantKeys:    []string{testBucketNameKey},
+		},
+		{
+			name: "bucket name absent when allBuckets set",
+			cfg: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				includeEndpoint:    false,
+				includeRegion:      false,
+				bucketNameKey:      testBucketNameKey,
+				includeBucketName:  true,
+			},
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					AllBuckets: &garagev1beta1.AllBucketsPermission{Read: true},
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketRef: &garagev1beta1.BucketRef{Name: testBucketName}, Read: true},
+					},
+				},
+			},
+			cluster:         &garagev1beta2.GarageCluster{},
+			secretAccessKey: testSecretValue,
+			dontWantKeys:    []string{testBucketNameKey},
+		},
+		{
+			name: "bucket name absent when single permission is bucketId-only",
+			cfg: secretConfig{
+				accessKeyIDKey:     testAccessKeyIDKey,
+				secretAccessKeyKey: testSecretAccessKey,
+				includeEndpoint:    false,
+				includeRegion:      false,
+				bucketNameKey:      testBucketNameKey,
+				includeBucketName:  true,
+			},
+			key: &garagev1beta1.GarageKey{
+				Spec: garagev1beta1.GarageKeySpec{
+					BucketPermissions: []garagev1beta1.BucketPermission{
+						{BucketID: "deadbeef", Read: true},
+					},
+				},
+			},
+			cluster:         &garagev1beta2.GarageCluster{},
+			secretAccessKey: testSecretValue,
+			dontWantKeys:    []string{testBucketNameKey},
+		},
 	}
 
 	for _, tt := range tests {
@@ -299,6 +492,12 @@ func TestBuildSecretData(t *testing.T) {
 			for _, key := range tt.wantKeys {
 				if _, ok := result[key]; !ok {
 					t.Errorf("missing key %q in result", key)
+				}
+			}
+
+			for _, key := range tt.dontWantKeys {
+				if _, ok := result[key]; ok {
+					t.Errorf("unexpected key %q in result", key)
 				}
 			}
 

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -151,6 +151,24 @@ func IsReplicationConstraint(err error) bool {
 	return false
 }
 
+// IsMetadataDecodeError returns true if the error is a Garage internal error
+// indicating table entry deserialization failure ("Unable to decode entry of key").
+// This surfaces when key_table entries written by an older Garage version cannot
+// be read by the running version. Recovery: trigger Repair:Tables on the cluster.
+//
+// Upstream reference: src/table/data.rs decode_entry() — TABLE_NAME="key"
+// Last verified: Garage v2.3.0
+func IsMetadataDecodeError(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		return false
+	}
+	return strings.Contains(apiErr.Message, "Unable to decode entry of")
+}
+
 // Client is a client for the Garage Admin API v2
 type Client struct {
 	baseURL    string

--- a/schemas/garagekey_v1beta1.json
+++ b/schemas/garagekey_v1beta1.json
@@ -224,6 +224,11 @@
               "description": "Annotations to add to the secret",
               "type": "object"
             },
+            "bucketNameKey": {
+              "default": "bucket",
+              "description": "BucketNameKey is the data key under which the bucket name is written\nin the Secret. Defaults to \"bucket\". Only used when IncludeBucketName is true.",
+              "type": "string"
+            },
             "endpointKey": {
               "default": "endpoint",
               "description": "EndpointKey is the key name for the S3 endpoint (includes http:// scheme)",
@@ -233,6 +238,10 @@
               "default": "host",
               "description": "HostKey is the key name for the S3 host (without scheme, e.g., \"host:port\")",
               "type": "string"
+            },
+            "includeBucketName": {
+              "description": "IncludeBucketName controls whether the bucket name is written to the Secret.\nDefaults to false. When true, the bucket name is populated only if the key\nreferences exactly one bucket (via bucketRef or globalAlias); omitted otherwise.",
+              "type": "boolean"
             },
             "includeEndpoint": {
               "description": "IncludeEndpoint includes the S3 endpoint in the secret\nDefaults to true if not specified",


### PR DESCRIPTION
## Summary

Fixes #260 and implements #261.

### #260 — Stale chart appVersion (users get months-old operator image)

The Helm chart `appVersion` was stuck at `0.4.1` since project inception. `helm install` from a local clone (without `--set image.tag=...`) pulled the ancient `0.4.1` image whose controllers watch `v1beta1.GarageCluster`, causing cache sync timeouts when the CRD marks v1beta1 `served: false` (webhooks disabled).

Reproduced on a fresh kind cluster: default image (`0.4.1`) → exact v1beta1 errors from the issue. With `--set image.tag=v0.6.17` → clean, no errors.

**Fix:**
- Bump `Chart.yaml` version + appVersion to `0.6.18`, set `values.yaml image.tag` to `v0.6.18`
- Add `make chart-bump VERSION=vX.Y.Z` target for atomic version updates
- Add `verify-version` CI job in `helm.yml` that fails tag push if in-repo `Chart.yaml` + `values.yaml` don't match the tag
- Remove redundant sed-replace steps in helm publish job (in-repo values are now correct)
- Add `make helm-verify-version` for local verification

### #261 — Add bucket name to GarageKey secret template

Some downstream consumers (e.g. [Tempo Operator](https://grafana.com/docs/tempo/next/set-up-for-tracing/setup-tempo/deploy/kubernetes/operator/object-storage/#minio)) require the bucket name to be ingested from a secret. Previously users had to patch the secret manually after creation.

**Implementation:**
- Add `includeBucketName *bool` (default `false`, opt-in) and `bucketNameKey string` (default `"bucket"`) to `SecretTemplate`
- Populated only when the key references exactly one bucket via `bucketRef` (with a name) or `globalAlias`
- Omitted for `allBuckets`, multi-bucket keys, or `bucketID`-only permissions (ambiguous cases)
- Prefers `globalAlias` over `bucketRef.Name` when both are set

**No upstream Garage changes needed** — the bucket name (global alias) is already available on the CR spec.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes (17 new subtests for #261)
- [x] `make lint` passes (0 issues)
- [x] `make helm-lint` passes
- [x] Chart templates render correctly
- [x] Reproduced #260 on kind cluster, verified fix with `--set image.tag=v0.6.17`