### PR TITLE
feat(chart): make grafana configmap annotations configurable

### DIFF
--- a/charts/garage-operator/templates/grafana-dashboard.yaml
+++ b/charts/garage-operator/templates/grafana-dashboard.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- with .Values.grafanaDashboard.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- with .Values.grafanaDashboard.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   garage-prometheus.json: |-
     {{ .Files.Get "dashboards/garage-prometheus.json" | nindent 4 }}

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -129,6 +129,8 @@ grafanaDashboard:
   # -- Labels added to the ConfigMap. Set to match your Grafana sidecar's discovery label.
   labels:
     grafana_dashboard: "1"
+  # -- Annotations added to the ConfigMap.
+  annotations: {}
   # -- Namespace to create the ConfigMap in (defaults to release namespace).
   namespace: ""
 
@@ -191,9 +193,9 @@ webhooks:
     # -- Use cert-manager for webhook certificates
     enabled: true
     # -- Duration of webhook certificates
-    duration: 8760h  # 1 year
+    duration: 8760h # 1 year
     # -- Renew certificates before expiry
-    renewBefore: 720h  # 30 days
+    renewBefore: 720h # 30 days
     # -- Issuer kind (Issuer or ClusterIssuer)
     issuerKind: Issuer
     # -- Issuer name (creates self-signed if empty)


### PR DESCRIPTION
## Summary

Add `grafanaDashboard.annotations` option. 

Use case: define for example `grafana_dashboard: <folder_name>` to create the dashboard in the desired folder.

