### PR TITLE
feat(cluster): connectTo-only management handle for existing clusters (#269)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -33,9 +33,9 @@ jobs:
           - name: core
             filter: "gateway || manager || webhooks || external-gateway"
           - name: api
-            filter: "dual-version || manual-mode"
+            filter: "dual-version || manual-mode || management-handle"
           - name: layout
-            filter: "!(gateway || manager || webhooks || external-gateway || dual-version || manual-mode)"
+            filter: "!(gateway || manager || webhooks || external-gateway || dual-version || manual-mode || management-handle)"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,9 +160,10 @@ A `GarageCluster` describes two optional tiers, both reconciled from the same CR
 
 A CR must set at least one of `storage`, `gateway`, or `connectTo`. The webhook
 rejects empty specs and `gateway` without either `storage` (unified cluster) or
-`connectTo` (edge gateway pattern).
+`connectTo` (edge gateway pattern). `connectTo` alongside `storage` (but no
+gateway) is also rejected.
 
-### Three valid shapes
+### Four valid shapes
 
 1. **Unified cluster** — most common, both tiers in one CR:
 
@@ -179,6 +180,50 @@ rejects empty specs and `gateway` without either `storage` (unified cluster) or
 2. **Storage-only** — headless backend, no S3/Admin traffic terminating locally.
 3. **Edge gateway** — gateway pods in a different K8s cluster from the storage
    backend, connected via `connectTo.clusterRef` or `connectTo.adminApiEndpoint`.
+4. **Management handle** — `connectTo` only, no tiers. See below.
+
+### Management handle (connectTo-only, no tiers) — issue #269
+
+A `GarageCluster` with **only** `spec.connectTo` set (no `storage`, no
+`gateway`) is a pure connection handle to an **externally-managed** Garage
+cluster (e.g. one deployed by the upstream Helm chart). The operator provisions
+**no** workload for it — no RPC secret, ConfigMap, Service, StatefulSet, or
+layout. It dials the external cluster's Admin API and manages Admin-API state
+only: `GarageBucket` / `GarageKey` / `GarageAdminToken` CRs that reference the
+handle. This lets you bring a Helm-deployed cluster under declarative control
+incrementally, with zero risk to the running workload.
+
+```yaml
+spec:
+  connectTo:
+    adminApiEndpoint: "http://garage.garage.svc:3903"
+    adminTokenSecretRef: { name: garage-admin, key: admin-token }
+```
+
+Implementation:
+- `IsManagementHandle()` (`api/v1beta2/garagecluster_helpers.go`) = `connectTo != nil && storage == nil && gateway == nil`.
+- The webhook requires an Admin-API path on a handle: `adminApiEndpoint` +
+  `adminTokenSecretRef`, **or** `clusterRef`. `rpcSecretRef`/`bootstrapPeers`
+  alone are rejected (they wire RPC, not the Admin API).
+- `GetGarageClient` (`internal/controller/helpers.go`) routes through
+  `resolveConnectToClient` on a handle — every controller (bucket/key/cluster)
+  then talks to the external cluster transparently.
+- `reconcileManagementHandle` (`garagecluster_controller.go`) probes the Admin
+  API (`GetClusterStatus`) and sets `Status.Phase` Running/Pending plus the
+  `ManagementHandleReady` condition. Buckets/keys gate on `Phase == Running`.
+  Healthy handles requeue at 5m; unreachable at the fast unhealthy interval.
+  `finalize` is a no-op for a handle (nothing owned).
+- **Adoption:** `GarageBucket.spec.bucketId` / `GarageKey.spec.importKey` bind to
+  pre-existing state. Creating a brand-new `GarageKey` without `importKey` needs
+  deterministic key material, which derives from an RPC secret the handle does
+  not auto-create — set `spec.network.rpcSecretRef` to the external cluster's RPC
+  secret, or use `importKey`. The key controller surfaces this as an actionable
+  error. A key's generated Secret derives its S3 endpoint from the
+  `connectTo.adminApiEndpoint` host (not a nonexistent managed Service).
+- **Stage 2 (not implemented):** having the operator adopt the external
+  StatefulSet + PVCs in place and retire Helm. Blocked on PVC-name mismatch
+  (operator `metadata`/`data` vs chart `meta-*`/`data-*`) and the per-node
+  GarageNode architecture; needs a dedicated design.
 
 ### Workload differences
 

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -115,6 +115,14 @@ const (
 	// the affected GarageNode(s) so an operator can force a layout reconcile.
 	ConditionGatewayLayoutDegraded = "GatewayLayoutDegraded"
 
+	// ConditionManagementHandleReady is True when a management-handle cluster
+	// (spec.connectTo only, no tiers — issue #269) can reach the external Garage's
+	// Admin API. The operator owns no workload for such a CR; this condition is the
+	// sole readiness signal, and the cluster's Phase tracks it (Running/Pending) so
+	// dependent GarageBucket/GarageKey CRs gate correctly. False with
+	// Reason=AdminUnreachable when the endpoint cannot be reached.
+	ConditionManagementHandleReady = "ManagementHandleReady"
+
 	// ConditionStorageScaleDownBlocked is True when an Auto-mode storage
 	// scale-down was refused because removing the over-range GarageNodes would
 	// drop the count of live, positive-capacity storage nodes below

--- a/api/v1beta1/garagecluster_conversion.go
+++ b/api/v1beta1/garagecluster_conversion.go
@@ -130,14 +130,19 @@ func (src *GarageCluster) ConvertTo(dstRaw conversion.Hub) error {
 		ContainerSecurityContext:  src.Spec.ContainerSecurityContext,
 	}
 
-	if src.Spec.Gateway {
+	switch {
+	case src.isManagementHandle():
+		// Management handle (#269): connectTo only, no tiers. Leave both
+		// dst.Spec.Storage and dst.Spec.Gateway nil so v1beta2 sees a handle
+		// (dst.Spec.ConnectTo is already populated above).
+	case src.Spec.Gateway:
 		dst.Spec.Gateway = &v1beta2.GatewaySpec{
 			Replicas:    src.Spec.Replicas,
 			PodTemplate: podTemplate,
 		}
 		// Edge gateways (gateway=true) under v1beta1 always require connectTo to be set
 		// (validated by the v1beta1 webhook), so dst.Spec.ConnectTo is already populated.
-	} else {
+	default:
 		storage := &v1beta2.StorageSpec{
 			Replicas:                     src.Spec.Replicas,
 			PodTemplate:                  podTemplate,

--- a/api/v1beta1/garagecluster_conversion_test.go
+++ b/api/v1beta1/garagecluster_conversion_test.go
@@ -26,15 +26,16 @@ func ptrQuantity(q resource.Quantity) *resource.Quantity { return &q }
 
 // Test fixtures shared across the conversion tests. Centralized to keep goconst happy.
 const (
-	testZone    = "us-east-1"
-	testImage   = "dxflrs/garage:v2.3.0"
-	testNS      = "ns"
-	testRole    = "role"
-	testStorage = "storage"
-	testStoreCR = "store"
-	test10Gi    = "10Gi"
-	testConsist = "consistent"
-	testRelabel = "rpc_duration_.*"
+	testZone          = "us-east-1"
+	testImage         = "dxflrs/garage:v2.3.0"
+	testNS            = "ns"
+	testRole          = "role"
+	testStorage       = "storage"
+	testStoreCR       = "store"
+	test10Gi          = "10Gi"
+	testConsist       = "consistent"
+	testRelabel       = "rpc_duration_.*"
+	testAdminEndpoint = "http://garage.garage.svc:3903"
 )
 
 // TestConvertTo_StorageCluster: v1beta1 storage CR -> v1beta2 storage tier.
@@ -506,5 +507,48 @@ func TestConvert_NilHubArg(t *testing.T) {
 	}
 	if err := src.ConvertFrom(nil); err == nil {
 		t.Errorf("ConvertFrom(nil): expected error")
+	}
+}
+
+// A v1beta2 management handle (#269) must project to a v1beta1 handle view
+// (gateway=false, no storage tier, connectTo preserved) and round-trip back to
+// a v1beta2 handle (Storage/Gateway nil), so the operator still sees a handle.
+func TestConvert_ManagementHandleRoundTrip(t *testing.T) {
+	hub := &v1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "handle", Namespace: testNS},
+		Spec: v1beta2.GarageClusterSpec{
+			ConnectTo: &v1beta2.ConnectToConfig{
+				AdminAPIEndpoint:    testAdminEndpoint,
+				AdminTokenSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "admin"}, Key: "admin-token"},
+			},
+		},
+	}
+
+	down := &GarageCluster{}
+	if err := down.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if down.Spec.Gateway {
+		t.Error("v1beta1 view of a handle must have gateway=false")
+	}
+	if !down.isManagementHandle() {
+		t.Errorf("v1beta1 view is not recognized as a management handle: %+v", down.Spec)
+	}
+	if down.Spec.ConnectTo == nil || down.Spec.ConnectTo.AdminAPIEndpoint != testAdminEndpoint {
+		t.Errorf("connectTo not preserved in v1beta1 view: %+v", down.Spec.ConnectTo)
+	}
+
+	up := &v1beta2.GarageCluster{}
+	if err := down.ConvertTo(up); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	if up.Spec.Storage != nil {
+		t.Errorf("round-tripped handle must not gain a storage tier, got %+v", up.Spec.Storage)
+	}
+	if up.Spec.Gateway != nil {
+		t.Errorf("round-tripped handle must not gain a gateway tier, got %+v", up.Spec.Gateway)
+	}
+	if !up.IsManagementHandle() {
+		t.Error("round-tripped object is no longer a v1beta2 management handle")
 	}
 }

--- a/api/v1beta1/garagecluster_webhook.go
+++ b/api/v1beta1/garagecluster_webhook.go
@@ -157,7 +157,9 @@ func (r *GarageCluster) validateGarageCluster() (admission.Warnings, error) {
 		return warnings, err
 	}
 
-	if !r.Spec.Gateway && r.Spec.LayoutPolicy != layoutPolicyManual {
+	// Storage validation applies to a real storage tier only. A management handle
+	// (#269) has gateway=false but no storage tier, so skip it there.
+	if !r.Spec.Gateway && !r.isManagementHandle() && r.Spec.LayoutPolicy != layoutPolicyManual {
 		if err := r.validateStorage(); err != nil {
 			return warnings, err
 		}
@@ -198,6 +200,18 @@ func (r *GarageCluster) isDataEphemeral() bool {
 	return r.Spec.Storage.Data != nil && r.Spec.Storage.Data.Type == VolumeTypeEmptyDir
 }
 
+// isManagementHandle reports whether this v1beta1 view is a connection-only
+// management handle (#269): no gateway, no storage tier, connectTo set. This is
+// the v1beta1 projection of a tier-less v1beta2 handle (the storage version),
+// surfaced here through the conversion webhook.
+func (r *GarageCluster) isManagementHandle() bool {
+	return !r.Spec.Gateway &&
+		r.Spec.ConnectTo != nil &&
+		r.Spec.Replicas == 0 &&
+		r.Spec.Storage.Metadata == nil &&
+		r.Spec.Storage.Data == nil
+}
+
 func (r *GarageCluster) validateGateway() error {
 	if r.Spec.Gateway {
 		if r.Spec.ConnectTo == nil {
@@ -226,16 +240,26 @@ func (r *GarageCluster) validateGateway() error {
 			return fmt.Errorf("capacityReservePercent is not valid on a gateway cluster (only used for Auto storage layout)")
 		}
 	} else {
-		if r.Spec.ConnectTo != nil {
-			return fmt.Errorf("connectTo can only be specified when gateway is true")
+		// connectTo without a gateway is allowed only for a management handle
+		// (no storage tier either): a connection-only CR that manages an external
+		// Garage's Admin-API state. This is the v1beta2 shape (#269) seen here via
+		// the conversion webhook (matchPolicy: Equivalent) — the storage version
+		// is v1beta2, so a handle converts to a v1beta1 view with gateway=false,
+		// no storage, and connectTo set. Anything else with connectTo but no
+		// gateway is still rejected.
+		if r.Spec.ConnectTo != nil && !r.isManagementHandle() {
+			return fmt.Errorf("connectTo can only be specified when gateway is true, or on a tier-less management handle")
 		}
 	}
 
 	if r.Spec.ConnectTo != nil {
+		// A management handle needs an Admin-API path; a gateway needs an RPC path.
+		// adminApiEndpoint is a valid handle path (the common Helm-adoption case).
 		if r.Spec.ConnectTo.ClusterRef == nil &&
 			r.Spec.ConnectTo.RPCSecretRef == nil &&
-			len(r.Spec.ConnectTo.BootstrapPeers) == 0 {
-			return fmt.Errorf("connectTo must specify clusterRef, rpcSecretRef, or bootstrapPeers")
+			len(r.Spec.ConnectTo.BootstrapPeers) == 0 &&
+			r.Spec.ConnectTo.AdminAPIEndpoint == "" {
+			return fmt.Errorf("connectTo must specify clusterRef, rpcSecretRef, bootstrapPeers, or adminApiEndpoint")
 		}
 	}
 

--- a/api/v1beta1/webhook_test.go
+++ b/api/v1beta1/webhook_test.go
@@ -1111,3 +1111,43 @@ func TestGarageClusterValidator_RejectsManualToAutoTransition_v1beta1(t *testing
 		t.Fatalf("ValidateUpdate rejected Auto→Manual on v1beta1: %v", err)
 	}
 }
+
+// A v1beta1 view of a management handle (#269) — gateway=false, no storage
+// tier, connectTo set — must be accepted (it reaches this webhook via the
+// conversion webhook for a v1beta2 handle, matchPolicy: Equivalent).
+func TestGarageClusterV1beta1_AcceptsManagementHandle(t *testing.T) {
+	// clusterRef form
+	h := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "handle", Namespace: "default"},
+		Spec: GarageClusterSpec{
+			ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: "store"}},
+		},
+	}
+	if _, err := h.validateGarageCluster(); err != nil {
+		t.Fatalf("v1beta1 rejected clusterRef management handle: %v", err)
+	}
+
+	// adminApiEndpoint form (the Helm-adoption path)
+	h.Spec.ConnectTo = &ConnectToConfig{
+		AdminAPIEndpoint:    testAdminEndpoint,
+		AdminTokenSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "admin"}, Key: "admin-token"},
+	}
+	if _, err := h.validateGarageCluster(); err != nil {
+		t.Fatalf("v1beta1 rejected adminApiEndpoint management handle: %v", err)
+	}
+}
+
+// connectTo without gateway AND with a storage tier is still rejected — only a
+// tier-less handle earns the exception.
+func TestGarageClusterV1beta1_RejectsConnectToWithStorageNoGateway(t *testing.T) {
+	c := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "default"},
+		Spec: GarageClusterSpec{
+			Replicas:  1, // a storage tier (replicas>0) => not a handle => rejected
+			ConnectTo: &ConnectToConfig{ClusterRef: &ClusterReference{Name: "store"}},
+		},
+	}
+	if _, err := c.validateGarageCluster(); err == nil {
+		t.Fatal("v1beta1 accepted connectTo with a storage tier and no gateway, want error")
+	}
+}

--- a/api/v1beta2/garagecluster_helpers.go
+++ b/api/v1beta2/garagecluster_helpers.go
@@ -36,6 +36,15 @@ func (g *GarageCluster) EffectiveStorageLayoutPolicy() string {
 	return g.Spec.LayoutPolicy
 }
 
+// IsManagementHandle returns true when this cluster is a pure connection handle
+// to an external Garage cluster: only spec.connectTo is set, with neither a
+// storage nor a gateway tier. The operator reconciles no workload for such a CR;
+// it only manages Admin-API state (buckets, keys, layout) against the endpoint
+// resolved from spec.connectTo. See issue #269.
+func (g *GarageCluster) IsManagementHandle() bool {
+	return g != nil && g.Spec.Storage == nil && g.Spec.Gateway == nil && g.Spec.ConnectTo != nil
+}
+
 // IsEdgeGateway returns true when this cluster is a gateway-only cluster that
 // connects to a remote storage cluster (no local storage tier, but `connectTo`
 // references an external Garage cluster).

--- a/api/v1beta2/garagecluster_helpers_test.go
+++ b/api/v1beta2/garagecluster_helpers_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import "testing"
+
+func TestIsManagementHandle(t *testing.T) {
+	tests := []struct {
+		name string
+		spec GarageClusterSpec
+		want bool
+	}{
+		{
+			name: "connectTo only",
+			spec: GarageClusterSpec{ConnectTo: &ConnectToConfig{AdminAPIEndpoint: "http://x:3903"}},
+			want: true,
+		},
+		{
+			name: "connectTo + storage (edge/unified, not a handle)",
+			spec: GarageClusterSpec{Storage: &StorageSpec{}, ConnectTo: &ConnectToConfig{}},
+			want: false,
+		},
+		{
+			name: "connectTo + gateway (edge gateway, not a handle)",
+			spec: GarageClusterSpec{Gateway: &GatewaySpec{}, ConnectTo: &ConnectToConfig{}},
+			want: false,
+		},
+		{
+			name: "storage only",
+			spec: GarageClusterSpec{Storage: &StorageSpec{}},
+			want: false,
+		},
+		{
+			name: "no connectTo",
+			spec: GarageClusterSpec{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GarageCluster{Spec: tt.spec}
+			if got := g.IsManagementHandle(); got != tt.want {
+				t.Errorf("IsManagementHandle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/v1beta2/garagecluster_webhook.go
+++ b/api/v1beta2/garagecluster_webhook.go
@@ -285,10 +285,13 @@ func (r *GarageCluster) validateTiers() error {
 		return fmt.Errorf("spec.gateway without spec.storage requires spec.connectTo (edge gateway pattern)")
 	}
 
-	// connectTo without a gateway tier is meaningless — connectTo's only job is to wire
-	// gateway pods to a remote storage backend.
-	if hasConnect && !hasGateway {
-		return fmt.Errorf("spec.connectTo is only valid alongside spec.gateway")
+	// connectTo without a gateway tier is allowed in exactly one case: a pure
+	// management handle (no storage, no gateway) that manages an external Garage's
+	// Admin-API state only — buckets, keys, layout — while some other system owns
+	// the workload (e.g. the upstream Helm chart). See issue #269. connectTo with a
+	// storage tier but no gateway remains meaningless.
+	if hasConnect && !hasGateway && hasStorage {
+		return fmt.Errorf("spec.connectTo is only valid alongside spec.gateway (edge gateway) or on a tier-less management handle")
 	}
 
 	if hasGateway {
@@ -323,6 +326,16 @@ func (r *GarageCluster) validateConnectTo() error {
 	c := r.Spec.ConnectTo
 	if c.ClusterRef == nil && c.RPCSecretRef == nil && len(c.BootstrapPeers) == 0 && c.AdminAPIEndpoint == "" {
 		return fmt.Errorf("connectTo must specify clusterRef, rpcSecretRef, bootstrapPeers, or adminApiEndpoint")
+	}
+	// A management handle (connectTo only, no tiers) must carry an Admin-API path
+	// so the operator has something to dial: an external endpoint + token, or a
+	// clusterRef to a sibling GarageCluster. rpcSecretRef/bootstrapPeers alone
+	// only wire RPC and give no Admin API to manage buckets/keys/layout (#269).
+	if r.IsManagementHandle() {
+		hasEndpoint := c.AdminAPIEndpoint != "" && c.AdminTokenSecretRef != nil
+		if !hasEndpoint && c.ClusterRef == nil {
+			return fmt.Errorf("management handle (spec.connectTo without storage/gateway) requires clusterRef, or adminApiEndpoint together with adminTokenSecretRef")
+		}
 	}
 	return nil
 }

--- a/api/v1beta2/garagecluster_webhook_test.go
+++ b/api/v1beta2/garagecluster_webhook_test.go
@@ -21,10 +21,12 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const testNamespace = "default"
+const storeClusterRefName = "store"
 
 func TestGarageClusterDefaulter_PreservesExplicitZeroReplicas(t *testing.T) {
 	d := &GarageClusterDefaulter{}
@@ -212,7 +214,7 @@ func TestGarageClusterValidator_RejectsGatewayMetadataEmptyDirMisconfig(t *testi
 					StorageClassName: &sc,
 				},
 			},
-			ConnectTo:   &ConnectToConfig{ClusterRef: &ClusterReference{Name: "store"}},
+			ConnectTo:   &ConnectToConfig{ClusterRef: &ClusterReference{Name: storeClusterRefName}},
 			Replication: &ReplicationConfig{Factor: 1},
 		},
 	}
@@ -233,7 +235,7 @@ func TestGarageClusterValidator_WarnsGatewayMetadataEmptyDir(t *testing.T) {
 				Replicas: 2,
 				Metadata: &VolumeConfig{Type: VolumeTypeEmptyDir},
 			},
-			ConnectTo:   &ConnectToConfig{ClusterRef: &ClusterReference{Name: "store"}},
+			ConnectTo:   &ConnectToConfig{ClusterRef: &ClusterReference{Name: storeClusterRefName}},
 			Replication: &ReplicationConfig{Factor: 1},
 		},
 	}
@@ -325,5 +327,61 @@ func TestGarageClusterValidator_WarnsSharedGatewayRPCAddr(t *testing.T) {
 	// Per-ordinal template → no warning.
 	if hasSharedWarning(t, mk("gw-{ordinal}.example.ts.net:3901")) {
 		t.Fatal("did not expect the warning when rpcPublicAddr uses an {ordinal} placeholder")
+	}
+}
+
+func TestGarageClusterValidator_AcceptsManagementHandle(t *testing.T) {
+	cluster := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "handle", Namespace: testNamespace},
+		Spec: GarageClusterSpec{
+			ConnectTo: &ConnectToConfig{
+				AdminAPIEndpoint:    "http://garage.garage.svc:3903",
+				AdminTokenSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "garage-admin"}, Key: "admin-token"},
+			},
+		},
+	}
+	if _, err := cluster.validateGarageCluster(); err != nil {
+		t.Fatalf("validateGarageCluster rejected management handle: %v", err)
+	}
+
+	// clusterRef is also a valid Admin-API path.
+	cluster.Spec.ConnectTo = &ConnectToConfig{ClusterRef: &ClusterReference{Name: storeClusterRefName}}
+	if _, err := cluster.validateGarageCluster(); err != nil {
+		t.Fatalf("validateGarageCluster rejected clusterRef management handle: %v", err)
+	}
+}
+
+func TestGarageClusterValidator_RejectsHandleWithoutAdminPath(t *testing.T) {
+	// connectTo with only rpcSecretRef / bootstrapPeers gives no Admin API.
+	cluster := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "handle", Namespace: testNamespace},
+		Spec: GarageClusterSpec{
+			ConnectTo: &ConnectToConfig{
+				RPCSecretRef:   &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "rpc"}},
+				BootstrapPeers: []string{"deadbeef@1.2.3.4:3901"},
+			},
+		},
+	}
+	if _, err := cluster.validateGarageCluster(); err == nil {
+		t.Fatal("validateGarageCluster accepted a handle with no Admin-API path, want error")
+	}
+
+	// adminApiEndpoint without a token is not enough.
+	cluster.Spec.ConnectTo = &ConnectToConfig{AdminAPIEndpoint: "http://x:3903"}
+	if _, err := cluster.validateGarageCluster(); err == nil {
+		t.Fatal("validateGarageCluster accepted adminApiEndpoint without adminTokenSecretRef, want error")
+	}
+}
+
+func TestGarageClusterValidator_PreservesEdgeGatewayRule(t *testing.T) {
+	// gateway without storage AND without connectTo is still rejected.
+	cluster := &GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: testNamespace},
+		Spec: GarageClusterSpec{
+			Gateway: &GatewaySpec{Replicas: 1},
+		},
+	}
+	if _, err := cluster.validateGarageCluster(); err == nil {
+		t.Fatal("validateGarageCluster accepted gateway-only cluster without connectTo, want error")
 	}
 }

--- a/config/samples/garage_v1beta2_garagecluster_management_handle.yaml
+++ b/config/samples/garage_v1beta2_garagecluster_management_handle.yaml
@@ -1,0 +1,71 @@
+# Management handle — declaratively manage an EXISTING Garage cluster (#269)
+#
+# A GarageCluster with ONLY `spec.connectTo` set (no `storage`, no `gateway`) is
+# a pure connection handle: the operator provisions NO workload for it. It dials
+# the external cluster's Admin API and manages Admin-API state only — buckets,
+# keys, permissions, layout. Some other system (e.g. the upstream Helm chart)
+# keeps owning the pods, so there is zero risk to the running workload.
+#
+# Use this to bring a Helm-deployed (or otherwise externally-managed) Garage
+# under declarative control incrementally: GarageBucket / GarageKey /
+# GarageAdminToken CRs reference this handle by name exactly as they would a
+# fully operator-owned cluster.
+#
+# Requirements (enforced by the validating webhook):
+#   - connectTo must carry an Admin-API path: either `adminApiEndpoint` +
+#     `adminTokenSecretRef`, OR `clusterRef` to a sibling GarageCluster.
+#   - The handle's Phase becomes Running once the Admin API is reachable; only
+#     then do dependent buckets/keys begin reconciling.
+#
+# Adopting existing buckets/keys: set `bucketId` on a GarageBucket and
+# `importKey` on a GarageKey to bind to what already exists rather than creating
+# anew. Creating a BRAND-NEW GarageKey without `importKey` needs deterministic
+# key material — on a handle, either use `importKey`, or set
+# `spec.network.rpcSecretRef` here to the external cluster's RPC secret.
+---
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: existing-garage
+  namespace: garage
+spec:
+  connectTo:
+    # Reachable Admin API of the existing cluster (in-cluster Service FQDN,
+    # LoadBalancer, Tailscale, VPN, …).
+    adminApiEndpoint: "http://garage.garage.svc:3903"
+    adminTokenSecretRef:
+      name: garage-admin
+      key: admin-token
+  # No `storage`, no `gateway` — the operator owns no pods, PVCs, or Services.
+---
+# Example: a bucket managed on the existing cluster via the handle above.
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: photos
+  namespace: garage
+spec:
+  clusterRef:
+    name: existing-garage
+  # To adopt a bucket that already exists in Garage, pin its id:
+  # bucketId: "<existing-bucket-id>"
+  quotas:
+    maxSize: "10Gi"
+---
+# Example: adopt an existing access key via importKey (no RPC secret needed).
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: photos-app
+  namespace: garage
+spec:
+  clusterRef:
+    name: existing-garage
+  importKey:
+    secretRef:
+      name: photos-app-existing-creds
+      # keys default to access_key_id / secret_access_key
+  bucketPermissions:
+    - globalAlias: photos
+      read: true
+      write: true

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
 - garage_v1beta1_garagereferencegrant.yaml
 - garage_v1beta2_garagecluster_auto_per_node.yaml
 - garage_v1beta2_garagecluster_eject_to_manual.yaml
+- garage_v1beta2_garagecluster_management_handle.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/docs/superpowers/specs/2026-07-02-connectto-management-handle-design.md
+++ b/docs/superpowers/specs/2026-07-02-connectto-management-handle-design.md
@@ -1,0 +1,137 @@
+# connectTo-only management handle (Stage 1 of issue #269)
+
+## Problem
+
+A user runs Garage deployed by the upstream Helm chart and wants the operator
+to manage cluster config declaratively — buckets, keys, permissions, layout —
+without the operator owning the workload. Federation is operator-to-operator,
+so it does not fit a cluster that has no operator on it yet.
+
+Today there is no CR shape for "manage an external Garage's Admin-API state
+only." Three blockers exist in the code:
+
+1. `GetGarageClient` (`internal/controller/helpers.go`) always builds the admin
+   endpoint from the managed Service (`svcFQDN(cluster.Name, …)`) and reads the
+   token from `cluster.Spec.Admin`. `connectTo` is consulted only on the
+   gateway-layout path (`gatewayLayoutClient` → `getExternalStorageClient`).
+2. The validating webhook rejects the natural shape: `validateTiers` errors with
+   *"spec.connectTo is only valid alongside spec.gateway"* whenever `connectTo`
+   is set without a gateway tier.
+3. `GarageBucket`/`GarageKey` gate on `cluster.Status.Phase == Running`, and the
+   phase machinery derives Running only from storage/gateway pod readiness — a
+   tier-less handle never reaches it.
+
+## Chosen shape
+
+A `GarageCluster` with **only** `spec.connectTo` set (no storage, no gateway) —
+a pure management handle. Inferred, no new API field.
+
+```yaml
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: existing-garage
+spec:
+  connectTo:
+    adminApiEndpoint: http://garage.garage.svc:3903
+    adminTokenSecretRef:
+      name: garage-admin
+      key: admin-token
+```
+
+`GarageBucket`/`GarageKey` reference this cluster exactly as they would any
+other. Helm keeps owning the pods; the operator touches only Admin-API state.
+
+## Changes
+
+### 1. `IsManagementHandle()` — `api/v1beta2/garagecluster_helpers.go`
+
+```go
+func (g *GarageCluster) IsManagementHandle() bool {
+    return g != nil && g.Spec.Storage == nil && g.Spec.Gateway == nil && g.Spec.ConnectTo != nil
+}
+```
+
+### 2. Webhook — `api/v1beta2/garagecluster_webhook.go`
+
+- In `validateTiers`, replace the blanket `hasConnect && !hasGateway` rejection.
+  Allow `connectTo` standalone (management handle). Keep the edge-gateway rule
+  (`hasGateway && !hasStorage && !hasConnect` still errors).
+- In `validateConnectTo`, when the CR is a management handle, require an
+  admin-API path: `adminApiEndpoint` + `adminTokenSecretRef`, **or** `clusterRef`.
+  `rpcSecretRef`/`bootstrapPeers` alone give no Admin API and are rejected as the
+  only fields on a handle.
+
+### 3. Client resolution — `internal/controller/helpers.go`
+
+Extract the connectTo→client logic (currently duplicated in the reconciler's
+`getExternalStorageClient`/`getStorageClusterClient`) into a shared free
+function `resolveConnectToClient(ctx, c, cluster, clusterDomain)`:
+
+- `adminApiEndpoint` + `adminTokenSecretRef` → build directly.
+- `clusterRef` → resolve the referenced `GarageCluster`, use its managed
+  endpoint + admin token.
+
+`GetGarageClient` gains a leading branch: when `cluster.IsManagementHandle()`,
+return `resolveConnectToClient(...)` instead of the `svcFQDN` path. Every
+controller that already calls `GetGarageClient` (bucket, key, cluster) then
+transparently talks to the external cluster.
+
+### 4. Management-handle reconcile — `internal/controller/garagecluster_controller.go`
+
+Early branch in `Reconcile`, after finalizer + maintenance, before
+`ensureRPCSecret`:
+
+```go
+if cluster.IsManagementHandle() {
+    return r.reconcileManagementHandle(ctx, cluster)
+}
+```
+
+`reconcileManagementHandle`:
+- Resolves the admin client and probes reachability (`GetClusterStatus`).
+- Reachable → `Status.Phase = Running`, condition `ManagementHandleReady=True`,
+  requeue `RequeueAfterLong` (5m, matching healthy edge gateways).
+- Unreachable → `Status.Phase = Pending`, condition `False` with the error,
+  requeue `RequeueAfterUnhealthy`.
+- Creates/reconciles no workload: no RPC secret, ConfigMap, Services, PDB,
+  layout, migration, or pod-derived health.
+
+`finalize` short-circuits for a management handle (no owned Garage state or K8s
+workload to tear down; bucket/key finalizers own their own remote cleanup).
+
+### 5. Bucket/Key gating
+
+No logic change — both already gate on `Status.Phase == Running`, satisfied by
+the handle. Confirm `GarageKey` uses the same gate and nothing assumes a local
+Service.
+
+### 6. `GarageKey` RPC-secret consideration
+
+`deriveKeyMaterial` needs `GetRPCSecret`, which falls back to
+`<cluster>-rpc-secret` (absent on a handle). Adoption path is `importKey`
+(supplied material) or operator-created keys via the Admin API. A `GarageKey`
+on a handle without `importKey` and without a resolvable RPC secret must surface
+a clear condition rather than an obscure error. Verify actual key-controller
+behavior during implementation; handle explicitly if needed.
+
+## Testing
+
+- Webhook: handle accepted; `connectTo` with only rpcSecretRef/bootstrapPeers
+  rejected; edge-gateway rule preserved; full cluster unaffected.
+- `GetGarageClient`: handle → connectTo endpoint/token, not `svcFQDN`.
+- Controller: handle reconcile sets `Running` on reachable admin API (mock),
+  `Pending` when unreachable; asserts no STS/ConfigMap/Service created.
+
+## Docs
+
+- `CLAUDE.md`: document the management-handle shape under the cluster-shapes /
+  connectTo sections.
+- `config/samples/`: add a management-handle example CR.
+
+## Out of scope (Stage 2)
+
+In-place adoption of an existing StatefulSet + PVCs and retiring the Helm
+release. Deferred — the modern operator manages per-node GarageNodes with
+`metadata`/`data` PVC names that do not match the chart's `meta-*`/`data-*`,
+so adoption needs a dedicated design.

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -142,6 +142,15 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
 	}
 
+	// Management handle (#269): spec.connectTo only, no storage/gateway tier. The
+	// operator owns no workload here — it only manages the external Garage's
+	// Admin-API state (buckets/keys/layout). Handle it before the tier reconcile,
+	// which would otherwise try to build a managed Service, ConfigMap, RPC secret,
+	// and StatefulSets that must not exist for a handle.
+	if cluster.IsManagementHandle() {
+		return r.reconcileManagementHandle(ctx, cluster)
+	}
+
 	// Ensure RPC secret exists
 	if _, err := r.ensureRPCSecret(ctx, cluster); err != nil {
 		return r.updateStatus(ctx, cluster, PhaseFailed, err)
@@ -353,6 +362,14 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *GarageClusterReconciler) finalize(ctx context.Context, cluster *garagev1beta2.GarageCluster) error {
 	log := logf.FromContext(ctx)
 	log.Info("Finalizing GarageCluster", "name", cluster.Name)
+
+	// A management handle (#269) owns no K8s workload and no Garage layout roles —
+	// it only holds a connection. Its GarageBucket/GarageKey children run their own
+	// finalizers against the external Admin API. There is nothing for the cluster
+	// finalizer to tear down, and probing the remote layout here would be pointless.
+	if cluster.IsManagementHandle() {
+		return nil
+	}
 
 	// Collect node IDs from GarageNode CRs before they get deleted.
 	// These are used as a fallback when tag-based matching fails (e.g., nodes
@@ -2205,6 +2222,64 @@ func vctStorageClassChanged(existing, desired []corev1.PersistentVolumeClaim) bo
 		}
 	}
 	return false
+}
+
+// reconcileManagementHandle reconciles a connection-only GarageCluster (#269):
+// spec.connectTo with no storage/gateway tier. It provisions no workload — it
+// resolves the external Admin API from spec.connectTo, probes reachability, and
+// reflects the result on Status.Phase (Running/Pending) plus the
+// ManagementHandleReady condition. Dependent GarageBucket/GarageKey CRs gate on
+// Phase == Running, so this is what makes them start managing the external
+// cluster's state.
+func (r *GarageClusterReconciler) reconcileManagementHandle(ctx context.Context, cluster *garagev1beta2.GarageCluster) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	setPhase := func(phase string, cond metav1.Condition) (ctrl.Result, error) {
+		apply := func() {
+			cluster.Status.Phase = phase
+			cond.ObservedGeneration = cluster.Generation
+			meta.SetStatusCondition(&cluster.Status.Conditions, cond)
+			if phase == PhaseRunning {
+				cluster.Status.ObservedGeneration = cluster.Generation
+			}
+		}
+		apply()
+		if err := UpdateStatusWithRetry(ctx, r.Client, cluster, apply); err != nil {
+			return ctrl.Result{}, err
+		}
+		if phase == PhaseRunning {
+			return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
+		}
+		return ctrl.Result{RequeueAfter: RequeueAfterUnhealthy}, nil
+	}
+
+	client, err := GetGarageClient(ctx, r.Client, cluster, r.ClusterDomain)
+	if err != nil {
+		log.Info("Management handle: cannot build admin client", "error", err.Error())
+		return setPhase(PhasePending, metav1.Condition{
+			Type:    garagev1beta1.ConditionManagementHandleReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  garagev1beta1.ReasonAdminTokenMissing,
+			Message: fmt.Sprintf("failed to build admin client from spec.connectTo: %v", err),
+		})
+	}
+
+	if _, err := client.GetClusterStatus(ctx); err != nil {
+		log.Info("Management handle: external Garage Admin API not reachable", "error", err.Error())
+		return setPhase(PhasePending, metav1.Condition{
+			Type:    garagev1beta1.ConditionManagementHandleReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  garagev1beta1.ReasonAdminUnreachable,
+			Message: fmt.Sprintf("external Garage Admin API not reachable (will retry): %v", err),
+		})
+	}
+
+	return setPhase(PhaseRunning, metav1.Condition{
+		Type:    garagev1beta1.ConditionManagementHandleReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  garagev1beta1.ReasonReconcileSuccess,
+		Message: "external Garage Admin API reachable; managing buckets/keys/layout via spec.connectTo",
+	})
 }
 
 func (r *GarageClusterReconciler) updateStatus(ctx context.Context, cluster *garagev1beta2.GarageCluster, phase string, err error) (ctrl.Result, error) {

--- a/internal/controller/garagecluster_management_handle_test.go
+++ b/internal/controller/garagecluster_management_handle_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+func managementHandleScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme, appsv1.AddToScheme,
+		garagev1beta1.AddToScheme, garagev1beta2.AddToScheme,
+	} {
+		if err := add(s); err != nil {
+			t.Fatalf("AddToScheme: %v", err)
+		}
+	}
+	return s
+}
+
+func newHandle(endpoint string) (*garagev1beta2.GarageCluster, *corev1.Secret) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: mhSecret, Namespace: mhNS},
+		Data:       map[string][]byte{DefaultAdminTokenKey: []byte("prefix.secret")},
+	}
+	handle := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       mhName,
+			Namespace:  mhNS,
+			Finalizers: []string{garageClusterFinalizer},
+		},
+		Spec: garagev1beta2.GarageClusterSpec{
+			ConnectTo: &garagev1beta2.ConnectToConfig{
+				AdminAPIEndpoint:    endpoint,
+				AdminTokenSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mhSecret}, Key: DefaultAdminTokenKey},
+			},
+		},
+	}
+	return handle, secret
+}
+
+// Reachable external Admin API → Phase Running, ManagementHandleReady True, and
+// no managed workload created (no STS, ConfigMap, or Service).
+func TestReconcileManagementHandle_ReachableSetsRunning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"layoutVersion":1,"nodes":[]}`))
+	}))
+	defer srv.Close()
+
+	handle, secret := newHandle(srv.URL)
+	s := managementHandleScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(handle, secret).
+		WithStatusSubresource(&garagev1beta2.GarageCluster{}).
+		Build()
+	r := &GarageClusterReconciler{Client: fc, Scheme: s, ClusterDomain: "cluster.local"}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: mhName, Namespace: mhNS},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	got := &garagev1beta2.GarageCluster{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: mhName, Namespace: mhNS}, got); err != nil {
+		t.Fatalf("get cluster: %v", err)
+	}
+	if got.Status.Phase != PhaseRunning {
+		t.Errorf("Phase = %q, want %q", got.Status.Phase, PhaseRunning)
+	}
+	if c := meta.FindStatusCondition(got.Status.Conditions, garagev1beta1.ConditionManagementHandleReady); c == nil || c.Status != metav1.ConditionTrue {
+		t.Errorf("ManagementHandleReady condition = %+v, want True", c)
+	}
+
+	// No managed workload should exist for a handle.
+	sts := &appsv1.StatefulSet{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: mhName, Namespace: mhNS}, sts); err == nil {
+		t.Error("a StatefulSet was created for a management handle, want none")
+	}
+	cm := &corev1.ConfigMap{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: mhName, Namespace: mhNS}, cm); err == nil {
+		t.Error("a ConfigMap was created for a management handle, want none")
+	}
+	svc := &corev1.Service{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: mhName, Namespace: mhNS}, svc); err == nil {
+		t.Error("a Service was created for a management handle, want none")
+	}
+}
+
+// Unreachable external Admin API → Phase Pending, condition False.
+func TestReconcileManagementHandle_UnreachableSetsPending(t *testing.T) {
+	// Point at a closed server so the dial fails fast.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	handle, secret := newHandle(url)
+	s := managementHandleScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(handle, secret).
+		WithStatusSubresource(&garagev1beta2.GarageCluster{}).
+		Build()
+	r := &GarageClusterReconciler{Client: fc, Scheme: s, ClusterDomain: "cluster.local"}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: mhName, Namespace: mhNS},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	got := &garagev1beta2.GarageCluster{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: mhName, Namespace: mhNS}, got); err != nil {
+		t.Fatalf("get cluster: %v", err)
+	}
+	if got.Status.Phase != PhasePending {
+		t.Errorf("Phase = %q, want %q", got.Status.Phase, PhasePending)
+	}
+	if c := meta.FindStatusCondition(got.Status.Conditions, garagev1beta1.ConditionManagementHandleReady); c == nil || c.Status != metav1.ConditionFalse {
+		t.Errorf("ManagementHandleReady condition = %+v, want False", c)
+	}
+}
+
+// A key's generated Secret on a management handle must expose the EXTERNAL S3
+// endpoint (derived from connectTo.adminApiEndpoint host), not the nonexistent
+// managed Service FQDN (#269).
+func TestBuildSecretData_ManagementHandleEndpoint(t *testing.T) {
+	handle := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: mhName, Namespace: mhNS},
+		Spec: garagev1beta2.GarageClusterSpec{
+			ConnectTo: &garagev1beta2.ConnectToConfig{AdminAPIEndpoint: mhEndpoint},
+		},
+	}
+	key := &garagev1beta1.GarageKey{ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: mhNS}}
+	key.Status.AccessKeyID = "GKtest"
+
+	cfg := secretConfig{
+		accessKeyIDKey:  "access_key_id",
+		endpointKey:     "endpoint",
+		hostKey:         "host",
+		schemeKey:       "scheme",
+		includeEndpoint: true,
+	}
+	data := buildSecretData(cfg, key, handle, "sk", "cluster.local")
+	if got, want := string(data["endpoint"]), "http://garage.garage.svc:3900"; got != want {
+		t.Errorf("endpoint = %q, want %q (external host, S3 port)", got, want)
+	}
+	if got, want := string(data["host"]), "garage.garage.svc:3900"; got != want {
+		t.Errorf("host = %q, want %q", got, want)
+	}
+}

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"net/url"
 	"sort"
 	"time"
 
@@ -374,6 +375,15 @@ func (r *GarageKeyReconciler) createOrAdoptDeterministic(ctx context.Context, ke
 
 	rpcSecret, err := GetRPCSecret(ctx, r.Client, cluster)
 	if err != nil {
+		// A management handle (#269) has no operator-generated <cluster>-rpc-secret,
+		// so deterministic derivation cannot work unless the user points at the
+		// external cluster's RPC secret. Adoption of a pre-existing key works
+		// regardless (findKeyByName runs before this); creating a brand-new key
+		// needs either importKey or a resolvable RPC secret. Make that actionable
+		// rather than surfacing a bare "secret not found".
+		if cluster.IsManagementHandle() {
+			return nil, "", fmt.Errorf("cannot derive key material on a management handle: set spec.importKey with existing credentials, or set spec.network.rpcSecretRef on the GarageCluster to the external cluster's RPC secret (%w)", err)
+		}
 		return nil, "", fmt.Errorf("failed to read RPC secret for key derivation: %w", err)
 	}
 
@@ -767,8 +777,19 @@ func buildSecretData(cfg secretConfig, key *garagev1beta1.GarageKey, cluster *ga
 		if cluster.Spec.S3API != nil && cluster.Spec.S3API.BindPort != 0 {
 			s3Port = cluster.Spec.S3API.BindPort
 		}
-		host := svcFQDN(cluster.Name, cluster.Namespace, s3Port, clusterDomain)
 		scheme := "http"
+		// Management handle (#269): there is no managed S3 Service to point at. The
+		// external cluster's S3 API is typically the same host as its Admin API
+		// (different port), so derive the endpoint host from connectTo.adminApiEndpoint.
+		var host string
+		if cluster.IsManagementHandle() && cluster.Spec.ConnectTo != nil && cluster.Spec.ConnectTo.AdminAPIEndpoint != "" {
+			if u, err := url.Parse(cluster.Spec.ConnectTo.AdminAPIEndpoint); err == nil && u.Hostname() != "" {
+				host = fmt.Sprintf("%s:%d", u.Hostname(), s3Port)
+			}
+		}
+		if host == "" {
+			host = svcFQDN(cluster.Name, cluster.Namespace, s3Port, clusterDomain)
+		}
 		endpoint := fmt.Sprintf("%s://%s", scheme, host)
 		data[cfg.endpointKey] = []byte(endpoint)
 		data[cfg.hostKey] = []byte(host)

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -440,6 +440,15 @@ func GetRPCSecret(ctx context.Context, c client.Client, cluster *garagev1beta2.G
 // (svc.<clusterDomain>) and authenticated via a bearer token. For TLS, deploy a
 // service mesh (Istio/Linkerd) with mTLS or an in-cluster reverse proxy.
 func GetGarageClient(ctx context.Context, c client.Client, cluster *garagev1beta2.GarageCluster, clusterDomain string) (*garage.Client, error) {
+	// Management handle (#269): the operator owns no workload for this CR, so
+	// there is no managed Service to dial. Resolve the Admin API from
+	// spec.connectTo instead. Every controller (bucket, key, cluster) routes
+	// through this function, so they all transparently manage the external
+	// cluster's Admin-API state.
+	if cluster.IsManagementHandle() {
+		return resolveConnectToClient(ctx, c, cluster, clusterDomain)
+	}
+
 	adminPort := DefaultAdminPort
 	if cluster.Spec.Admin != nil && cluster.Spec.Admin.BindPort != 0 {
 		adminPort = cluster.Spec.Admin.BindPort
@@ -452,6 +461,54 @@ func GetGarageClient(ctx context.Context, c client.Client, cluster *garagev1beta
 	}
 
 	return garage.NewClient(adminEndpoint, adminToken), nil
+}
+
+// resolveConnectToClient builds an Admin API client from spec.connectTo for a
+// management handle. It does NOT probe reachability — callers that need a
+// health signal (the management-handle reconcile) call GetClusterStatus
+// separately, so buckets/keys don't pay a probe on every client build.
+//
+// Two Admin-API paths are supported (enforced by the webhook):
+//   - adminApiEndpoint + adminTokenSecretRef: dial the external endpoint directly.
+//   - clusterRef: resolve a sibling GarageCluster and use its managed endpoint + token.
+func resolveConnectToClient(ctx context.Context, c client.Client, cluster *garagev1beta2.GarageCluster, clusterDomain string) (*garage.Client, error) {
+	ct := cluster.Spec.ConnectTo
+	if ct == nil {
+		return nil, fmt.Errorf("management handle has no spec.connectTo")
+	}
+
+	if ct.AdminAPIEndpoint != "" {
+		if ct.AdminTokenSecretRef == nil {
+			return nil, fmt.Errorf("connectTo.adminApiEndpoint requires connectTo.adminTokenSecretRef")
+		}
+		secret := &corev1.Secret{}
+		if err := c.Get(ctx, types.NamespacedName{Name: ct.AdminTokenSecretRef.Name, Namespace: cluster.Namespace}, secret); err != nil {
+			return nil, fmt.Errorf("failed to get connectTo admin token secret: %w", err)
+		}
+		key := ct.AdminTokenSecretRef.Key
+		if key == "" {
+			key = DefaultAdminTokenKey
+		}
+		token := string(secret.Data[key])
+		if token == "" {
+			return nil, fmt.Errorf("connectTo admin token secret %s has empty key %q", ct.AdminTokenSecretRef.Name, key)
+		}
+		return garage.NewClient(ct.AdminAPIEndpoint, token), nil
+	}
+
+	if ct.ClusterRef != nil {
+		ref := &garagev1beta2.GarageCluster{}
+		nn := types.NamespacedName{Name: ct.ClusterRef.Name, Namespace: ct.ClusterRef.Namespace}
+		if nn.Namespace == "" {
+			nn.Namespace = cluster.Namespace
+		}
+		if err := c.Get(ctx, nn, ref); err != nil {
+			return nil, fmt.Errorf("failed to get connectTo clusterRef %s: %w", nn, err)
+		}
+		return GetGarageClient(ctx, c, ref, clusterDomain)
+	}
+
+	return nil, fmt.Errorf("management handle connectTo missing adminApiEndpoint or clusterRef")
 }
 
 // UpdateStatusWithRetry updates the status subresource with retry on conflict.

--- a/internal/controller/helpers_connectto_test.go
+++ b/internal/controller/helpers_connectto_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+const (
+	mhName     = "existing"
+	mhNS       = "garage"
+	mhEndpoint = "http://garage.garage.svc:3903"
+	mhSecret   = "ext-admin"
+)
+
+func connectToTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme corev1: %v", err)
+	}
+	if err := garagev1beta2.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme v1beta2: %v", err)
+	}
+	return s
+}
+
+// A management handle must dial the external adminApiEndpoint, not the managed
+// Service FQDN, using the token from connectTo.adminTokenSecretRef (#269).
+func TestGetGarageClient_ManagementHandle_AdminEndpoint(t *testing.T) {
+	s := connectToTestScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: mhSecret, Namespace: mhNS},
+		Data:       map[string][]byte{DefaultAdminTokenKey: []byte("prefix.secret")},
+	}
+	handle := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: mhName, Namespace: mhNS},
+		Spec: garagev1beta2.GarageClusterSpec{
+			ConnectTo: &garagev1beta2.ConnectToConfig{
+				AdminAPIEndpoint:    mhEndpoint,
+				AdminTokenSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mhSecret}, Key: DefaultAdminTokenKey},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(secret).Build()
+
+	c, err := GetGarageClient(context.Background(), fc, handle, "cluster.local")
+	if err != nil {
+		t.Fatalf("GetGarageClient: %v", err)
+	}
+	if got := c.BaseURL(); got != mhEndpoint {
+		t.Errorf("endpoint = %q, want external adminApiEndpoint (not svcFQDN)", got)
+	}
+}
+
+// A handle whose token secret is missing must fail with a clear error rather
+// than silently building a tokenless client.
+func TestGetGarageClient_ManagementHandle_MissingSecret(t *testing.T) {
+	s := connectToTestScheme(t)
+	handle := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: mhName, Namespace: mhNS},
+		Spec: garagev1beta2.GarageClusterSpec{
+			ConnectTo: &garagev1beta2.ConnectToConfig{
+				AdminAPIEndpoint:    mhEndpoint,
+				AdminTokenSecretRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "absent"}, Key: DefaultAdminTokenKey},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(s).Build()
+
+	if _, err := GetGarageClient(context.Background(), fc, handle, "cluster.local"); err == nil {
+		t.Fatal("GetGarageClient accepted a handle with a missing token secret, want error")
+	}
+}

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -187,6 +187,12 @@ func NewClient(baseURL, adminToken string) *Client {
 	}
 }
 
+// BaseURL returns the Admin API endpoint the client dials. Useful for asserting
+// which endpoint a client was built for (e.g. connectTo vs managed Service).
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
 // SetHTTPTimeout overrides the underlying http.Client.Timeout. Intended for
 // tests that need a much shorter transport-level deadline than the 90s
 // production default.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4241,6 +4241,255 @@ spec:
 	})
 })
 
+// Management Handle Cluster (#269): a GarageCluster with only spec.connectTo
+// (no storage/gateway tier) manages an EXISTING cluster's Admin-API state. Here
+// a real storage cluster stands in for the externally-managed (e.g. Helm)
+// Garage: the handle connects to it via connectTo.clusterRef and drives a
+// GarageBucket against it, provisioning no workload of its own.
+var _ = Describe("Management Handle Cluster", Ordered, Label("management-handle"), func() {
+	const testNamespace = "garage-mgmt-handle"
+	const externalClusterName = "external-cluster"
+	const handleClusterName = "handle-cluster"
+
+	BeforeAll(func() {
+		By("creating manager namespace")
+		_, _ = utils.Run(exec.Command("kubectl", "create", "ns", namespace))
+		_, _ = utils.Run(exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+			"pod-security.kubernetes.io/enforce=restricted"))
+
+		By("installing CRDs")
+		_, err := utils.Run(exec.Command("make", "install"))
+		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+		Expect(utils.WaitCRDsEstablished()).To(Succeed())
+
+		By("deploying the controller-manager")
+		_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage)))
+		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+		By("waiting for controller-manager pod to be Ready (webhook server started)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+				"-n", namespace,
+				"-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"), "Controller not Ready: %s", output)
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("creating test namespace")
+		_, _ = utils.Run(exec.Command("kubectl", "create", "ns", testNamespace))
+		_, err = utils.Run(exec.Command("kubectl", "label", "--overwrite", "ns", testNamespace,
+			"pod-security.kubernetes.io/enforce=restricted"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		cleanupManagementHandle(testNamespace, []string{handleClusterName, externalClusterName})
+	})
+
+	Context("When managing an existing cluster via connectTo only", func() {
+		It("should stand up the external (stand-in) storage cluster", func() {
+			By("creating admin token secret")
+			adminTokenSecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-admin-token
+  namespace: %s
+type: Opaque
+stringData:
+  admin-token: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+`, testNamespace)
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(adminTokenSecret)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create admin token secret")
+
+			storageYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replication:
+    factor: 1
+  storage:
+    replicas: 1
+    metadata:
+      size: 1Gi
+    data:
+      size: 1Gi
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        memory: 128Mi
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  admin:
+    adminTokenSecretRef:
+      name: garage-admin-token
+      key: admin-token
+  security:
+    allowInsecureSecretPermissions: true
+`, externalClusterName, testNamespace)
+
+			By("applying external cluster (retry until webhook is up)")
+			Eventually(func(g Gomega) {
+				c := exec.Command("kubectl", "apply", "-f", "-")
+				c.Stdin = strings.NewReader(storageYAML)
+				out, err := utils.Run(c)
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to create external cluster: %s", out)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("waiting for external cluster to be Running")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "garagecluster", externalClusterName,
+					"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"), "External cluster not ready: phase=%s", output)
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		It("should reach Running as a connectTo-only management handle", func() {
+			handleYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  connectTo:
+    clusterRef:
+      name: %s
+`, handleClusterName, testNamespace, externalClusterName)
+
+			By("applying the management handle")
+			Eventually(func(g Gomega) {
+				c := exec.Command("kubectl", "apply", "-f", "-")
+				c.Stdin = strings.NewReader(handleYAML)
+				out, err := utils.Run(c)
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to create management handle: %s", out)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("waiting for the handle to report Running (external Admin API reachable)")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "garagecluster", handleClusterName,
+					"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"), "Handle not Running: phase=%s", output)
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying ManagementHandleReady condition is True")
+			cmd := exec.Command("kubectl", "get", "garagecluster", handleClusterName,
+				"-n", testNamespace,
+				"-o", "jsonpath={.status.conditions[?(@.type=='ManagementHandleReady')].status}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(Equal("True"), "ManagementHandleReady not True: %s", output)
+		})
+
+		It("should provision no workload for the handle", func() {
+			By("verifying no StatefulSet exists for the handle")
+			cmd := exec.Command("kubectl", "get", "statefulset", handleClusterName, "-n", testNamespace)
+			_, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "handle must not create a StatefulSet")
+
+			By("verifying no operator-owned GarageNodes exist for the handle")
+			cmd = exec.Command("kubectl", "get", "garagenode", "-n", testNamespace,
+				"-l", "app.kubernetes.io/instance="+handleClusterName,
+				"-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "handle must not create GarageNodes, got: %s", output)
+		})
+
+		It("should manage a bucket on the external cluster via the handle", func() {
+			bucketYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: handle-bucket
+  namespace: %s
+spec:
+  clusterRef:
+    name: %s
+`, testNamespace, handleClusterName)
+
+			By("creating a GarageBucket that references the handle")
+			Eventually(func(g Gomega) {
+				c := exec.Command("kubectl", "apply", "-f", "-")
+				c.Stdin = strings.NewReader(bucketYAML)
+				out, err := utils.Run(c)
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to create bucket: %s", out)
+			}, 1*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("waiting for the bucket to reach Ready with a bucketId (created on the external cluster)")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "garagebucket", "handle-bucket",
+					"-n", testNamespace, "-o", "jsonpath={.status.phase}/{.status.bucketId}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(HavePrefix("Ready/"), "bucket not Ready: %s", output)
+				g.Expect(output).NotTo(Equal("Ready/"), "bucket has no bucketId: %s", output)
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+		})
+	})
+})
+
+// cleanupManagementHandle tears down the management-handle e2e block. The handle
+// owns no workload/finalizer-heavy state, but the stand-in external cluster does,
+// so it follows the same webhook-first / scale-to-0 / clear-finalizers order as
+// cleanupAuto190 to avoid hanging on admission or finalizer calls during teardown.
+func cleanupManagementHandle(testNamespace string, clusterNames []string) {
+	By("deleting admission webhook configurations first")
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "validatingwebhookconfiguration",
+		"garage-operator-validating-webhook-configuration", "--ignore-not-found"))
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "mutatingwebhookconfiguration",
+		"garage-operator-mutating-webhook-configuration", "--ignore-not-found"))
+
+	By("scaling operator to 0 so it can't re-add finalizers")
+	_, _ = utils.Run(exec.Command("kubectl", "scale", "deployment",
+		"garage-operator-controller-manager", "-n", namespace, "--replicas=0", "--timeout=30s"))
+	time.Sleep(3 * time.Second)
+
+	By("clearing finalizers and deleting test resources")
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "garagebucket", "--all", "-n", testNamespace,
+		"--wait=false", "--ignore-not-found"))
+	for _, n := range clusterNames {
+		_, _ = utils.Run(exec.Command("kubectl", "patch", "garagecluster", n, "-n", testNamespace,
+			"--type=merge", "-p", `{"metadata":{"finalizers":null}}`))
+	}
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "garagenode", "--all", "-n", testNamespace,
+		"--wait=false", "--ignore-not-found"))
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "garagecluster", "--all", "-n", testNamespace,
+		"--wait=false", "--ignore-not-found"))
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "ns", testNamespace,
+		"--ignore-not-found", "--timeout=60s"))
+
+	By("undeploying the controller-manager")
+	_, _ = utils.Run(exec.Command("make", "undeploy"))
+
+	By("uninstalling CRDs")
+	_, _ = utils.Run(exec.Command("make", "uninstall"))
+}
+
 // cleanupAuto190 tears down a #190 e2e block's resources reliably. The naive
 // "kubectl delete cluster + ns + make undeploy" pattern hangs in this codebase
 // because:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4453,41 +4453,26 @@ spec:
 	})
 })
 
-// cleanupManagementHandle tears down the management-handle e2e block. The handle
-// owns no workload/finalizer-heavy state, but the stand-in external cluster does,
-// so it follows the same webhook-first / scale-to-0 / clear-finalizers order as
-// cleanupAuto190 to avoid hanging on admission or finalizer calls during teardown.
+// cleanupManagementHandle tears down the management-handle e2e block with a
+// LIGHT teardown: it deletes only this block's namespace and CRs and leaves the
+// operator, CRDs, and admission webhooks running. This shard (api) runs several
+// independent Ordered blocks; each does its own `make install`/`make deploy` in
+// BeforeAll, so tearing the operator down here (as the #190 blocks do when they
+// own the cluster) only forces a slow reinstall+re-reconcile on the next block
+// and destabilizes it. Keeping the operator up also lets the CR finalizers
+// resolve normally — no webhook-delete / scale-to-0 / finalizer-strip dance is
+// needed. The kind cluster itself is torn down by `make cleanup-test-e2e` after
+// the whole suite.
 func cleanupManagementHandle(testNamespace string, clusterNames []string) {
-	By("deleting admission webhook configurations first")
-	_, _ = utils.Run(exec.Command("kubectl", "delete", "validatingwebhookconfiguration",
-		"garage-operator-validating-webhook-configuration", "--ignore-not-found"))
-	_, _ = utils.Run(exec.Command("kubectl", "delete", "mutatingwebhookconfiguration",
-		"garage-operator-mutating-webhook-configuration", "--ignore-not-found"))
-
-	By("scaling operator to 0 so it can't re-add finalizers")
-	_, _ = utils.Run(exec.Command("kubectl", "scale", "deployment",
-		"garage-operator-controller-manager", "-n", namespace, "--replicas=0", "--timeout=30s"))
-	time.Sleep(3 * time.Second)
-
-	By("clearing finalizers and deleting test resources")
+	By("deleting this block's CRs (operator finalizes them) then the namespace")
 	_, _ = utils.Run(exec.Command("kubectl", "delete", "garagebucket", "--all", "-n", testNamespace,
-		"--wait=false", "--ignore-not-found"))
-	for _, n := range clusterNames {
-		_, _ = utils.Run(exec.Command("kubectl", "patch", "garagecluster", n, "-n", testNamespace,
-			"--type=merge", "-p", `{"metadata":{"finalizers":null}}`))
-	}
-	_, _ = utils.Run(exec.Command("kubectl", "delete", "garagenode", "--all", "-n", testNamespace,
-		"--wait=false", "--ignore-not-found"))
-	_, _ = utils.Run(exec.Command("kubectl", "delete", "garagecluster", "--all", "-n", testNamespace,
-		"--wait=false", "--ignore-not-found"))
-	_, _ = utils.Run(exec.Command("kubectl", "delete", "ns", testNamespace,
 		"--ignore-not-found", "--timeout=60s"))
-
-	By("undeploying the controller-manager")
-	_, _ = utils.Run(exec.Command("make", "undeploy"))
-
-	By("uninstalling CRDs")
-	_, _ = utils.Run(exec.Command("make", "uninstall"))
+	for _, n := range clusterNames {
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "garagecluster", n, "-n", testNamespace,
+			"--ignore-not-found", "--timeout=90s"))
+	}
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "ns", testNamespace,
+		"--ignore-not-found", "--timeout=90s"))
 }
 
 // cleanupAuto190 tears down a #190 e2e block's resources reliably. The naive


### PR DESCRIPTION
## Summary

Stage 1 of #269. Adds a **management-handle** `GarageCluster` shape: `spec.connectTo` only, no `storage` or `gateway` tier. The operator provisions **no** workload for such a CR — it dials the external cluster's Admin API and manages Admin-API state only (buckets, keys, layout).

This lets an existing Helm-deployed Garage be brought under declarative control incrementally, with zero risk to the running workload.

```yaml
apiVersion: garage.rajsingh.info/v1beta2
kind: GarageCluster
metadata:
  name: existing-garage
spec:
  connectTo:
    adminApiEndpoint: http://garage.garage.svc:3903
    adminTokenSecretRef: { name: garage-admin, key: admin-token }
```

## What changed

- **`IsManagementHandle()`** helper — `connectTo` set, both tiers absent.
- **Webhook** — allow `connectTo` standalone; require an Admin-API path on a handle (`adminApiEndpoint` + `adminTokenSecretRef`, or `clusterRef`); `rpcSecretRef`/`bootstrapPeers` alone rejected. Edge-gateway rule preserved.
- **`GetGarageClient`** routes through a new shared `resolveConnectToClient` on a handle, so bucket/key/cluster controllers all talk to the external cluster transparently.
- **`reconcileManagementHandle`** — probes the Admin API (`GetClusterStatus`), sets `Status.Phase` Running/Pending + the `ManagementHandleReady` condition. Healthy handles requeue at 5m. `finalize` is a no-op (nothing owned).
- **`GarageKey`** — actionable error when deterministic derivation has no resolvable RPC secret on a handle (use `importKey`, or set `spec.network.rpcSecretRef`); generated Secret derives its S3 endpoint from `connectTo.adminApiEndpoint` rather than a nonexistent managed Service.
- Sample CR, CLAUDE.md docs.

## Testing

- Unit: `IsManagementHandle`, webhook accept/reject matrix, `GetGarageClient` routing, `reconcileManagementHandle` Running/Pending + no-workload assertions, handle S3-endpoint derivation.
- E2e (`management-handle` label): stands up a real cluster as the stand-in "external" Garage, connects a `connectTo`-only handle, asserts Running + `ManagementHandleReady`, verifies no workload/GarageNodes, and drives a `GarageBucket` to Ready against it.
- `make lint test` green.

## Out of scope (Stage 2)

In-place adoption of the external StatefulSet + PVCs and retiring Helm — blocked on the `metadata`/`data` vs chart `meta-*`/`data-*` PVC-name mismatch and the per-node GarageNode architecture; needs a dedicated design.

Closes #269 (Stage 1).