### PR TITLE
fix(cosi): make GrantAccess idempotent — look up by recorded account ID, never mint on lookup failure

### DIFF
--- a/internal/cosi/bucketaccess_controller.go
+++ b/internal/cosi/bucketaccess_controller.go
@@ -128,7 +128,7 @@ func (r *BucketAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.fail(ctx, access, err)
 	}
 
-	result, err := r.Provisioner.GrantAccess(ctx, access.Name, slots, params, access.Spec.ServiceAccountName)
+	result, err := r.Provisioner.GrantAccess(ctx, access.Name, access.Status.AccountID, slots, params, access.Spec.ServiceAccountName)
 	if err != nil {
 		return r.fail(ctx, access, err)
 	}

--- a/internal/cosi/provisioner.go
+++ b/internal/cosi/provisioner.go
@@ -236,9 +236,13 @@ func (p *Provisioner) DeleteBucket(ctx context.Context, bucketID string, params 
 // GrantAccess creates or idempotently returns a Garage key with access to the given bucket slots.
 // Each slot specifies its own AccessMode so a single BucketAccess can grant
 // mixed RW/RO permissions across buckets, as v1alpha2 requires.
+// knownAccountID, when non-empty (the BucketAccess already has Status.AccountID),
+// pins the lookup to that exact key — Garage key NAMES are not unique, so a
+// name search can turn ambiguous and must never be the source of truth for an
+// already-provisioned access.
 // The returned AccessResult.PerBucket is in the same order as the input slots —
 // callers may index it positionally against their slot slice.
-func (p *Provisioner) GrantAccess(ctx context.Context, accountName string, slots []BucketAccessSlot, params *BucketAccessClassParameters, serviceAccountName string) (*AccessResult, error) {
+func (p *Provisioner) GrantAccess(ctx context.Context, accountName, knownAccountID string, slots []BucketAccessSlot, params *BucketAccessClassParameters, serviceAccountName string) (*AccessResult, error) {
 	if accountName == "" {
 		return nil, fmt.Errorf("accountName is required")
 	}
@@ -258,10 +262,24 @@ func (p *Provisioner) GrantAccess(ctx context.Context, accountName string, slots
 
 	keyName := sanitizeKeyName(accountName)
 
-	// Idempotency: reuse existing key, re-applying permissions as needed.
-	existing, err := gc.GetKey(ctx, garage.GetKeyRequest{Search: keyName, ShowSecretKey: true})
+	// Idempotency: reuse the existing key, re-applying permissions as needed.
+	// Look up by the recorded account ID when we have one (exact, unique);
+	// fall back to a name search only for first-time adoption. Only a genuine
+	// NotFound may fall through to CreateKey — treating ANY lookup failure as
+	// "absent" mints a duplicate key per reconcile (key leak) and, once two
+	// keys share a name, the search stays ambiguous forever.
+	var existing *garage.Key
+	var err2 error
+	if knownAccountID != "" {
+		existing, err2 = gc.GetKey(ctx, garage.GetKeyRequest{ID: knownAccountID, ShowSecretKey: true})
+	} else {
+		existing, err2 = gc.GetKey(ctx, garage.GetKeyRequest{Search: keyName, ShowSecretKey: true})
+	}
+	if err2 != nil && !garage.IsNotFound(err2) {
+		return nil, fmt.Errorf("lookup key: %w", err2)
+	}
 	var key *garage.Key
-	if err == nil && existing != nil {
+	if err2 == nil && existing != nil {
 		log.Info("key already exists, verifying bucket permissions", "keyId", existing.AccessKeyID)
 		for _, slot := range slots {
 			perms := mapAccessModeForGarage(slot.AccessMode)

--- a/internal/cosi/provisioner_test.go
+++ b/internal/cosi/provisioner_test.go
@@ -71,6 +71,7 @@ type mockGarageClient struct {
 	updateBucketErr error
 	deleteBucketErr error
 	createKeyErr    error
+	getKeyErr       error
 	deleteKeyErr    error
 	allowKeyErr     error
 	denyKeyErr      error
@@ -150,6 +151,9 @@ func (m *mockGarageClient) CreateKey(ctx context.Context, name string) (*garage.
 }
 
 func (m *mockGarageClient) GetKey(ctx context.Context, req garage.GetKeyRequest) (*garage.Key, error) {
+	if m.getKeyErr != nil {
+		return nil, m.getKeyErr
+	}
 	if req.ID != "" {
 		if key, ok := m.keys[req.ID]; ok {
 			return key, nil
@@ -318,7 +322,7 @@ func TestProvisioner_GrantAccess_EmptyAccountName(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
 	p := NewProvisioner(fakeClient, testGarageSystem, "cluster.local")
 
-	_, err := p.GrantAccess(context.Background(), "", []BucketAccessSlot{{BucketID: testBucketID}}, defaultAccessParams(), "")
+	_, err := p.GrantAccess(context.Background(), "", "", []BucketAccessSlot{{BucketID: testBucketID}}, defaultAccessParams(), "")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accountName is required")
@@ -328,7 +332,7 @@ func TestProvisioner_GrantAccess_NoBuckets(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
 	p := NewProvisioner(fakeClient, testGarageSystem, "cluster.local")
 
-	_, err := p.GrantAccess(context.Background(), testAccountName, []BucketAccessSlot{}, defaultAccessParams(), "")
+	_, err := p.GrantAccess(context.Background(), testAccountName, "", []BucketAccessSlot{}, defaultAccessParams(), "")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one bucket")
@@ -407,7 +411,7 @@ func TestProvisioner_GrantAccess_Success(t *testing.T) {
 	})
 
 	slots := []BucketAccessSlot{{BucketID: testBucketID, AccessMode: AccessModeReadWrite}}
-	result, err := p.GrantAccess(context.Background(), testAccountName, slots, defaultAccessParams(), "")
+	result, err := p.GrantAccess(context.Background(), testAccountName, "", slots, defaultAccessParams(), "")
 
 	require.NoError(t, err)
 	assert.Contains(t, result.AccountID, "GK")
@@ -467,7 +471,7 @@ func TestProvisioner_GrantAccess_Idempotent(t *testing.T) {
 	})
 
 	slots := []BucketAccessSlot{{BucketID: testBucketID, AccessMode: AccessModeReadWrite}}
-	result, err := p.GrantAccess(context.Background(), testAccountName, slots, defaultAccessParams(), "")
+	result, err := p.GrantAccess(context.Background(), testAccountName, "", slots, defaultAccessParams(), "")
 
 	require.NoError(t, err)
 	assert.Equal(t, testGarageAccessKeyID, result.AccountID)
@@ -550,7 +554,7 @@ func TestProvisioner_GrantAccess_MultiBucket(t *testing.T) {
 		{BucketID: "bucket-2"},
 		{BucketID: "bucket-3"},
 	}
-	result, err := p.GrantAccess(context.Background(), "multi-bucket-access", slots, defaultAccessParams(), "")
+	result, err := p.GrantAccess(context.Background(), "multi-bucket-access", "", slots, defaultAccessParams(), "")
 
 	require.NoError(t, err)
 	require.Len(t, result.PerBucket, 3)
@@ -588,7 +592,7 @@ func TestProvisioner_GrantAccess_AccessModes(t *testing.T) {
 		{BucketID: "bucket-ro", AccessMode: AccessModeReadOnly},
 		{BucketID: "bucket-wo", AccessMode: AccessModeWriteOnly},
 	}
-	result, err := p.GrantAccess(context.Background(), "access-modes-test", slots, defaultAccessParams(), "")
+	result, err := p.GrantAccess(context.Background(), "access-modes-test", "", slots, defaultAccessParams(), "")
 	require.NoError(t, err)
 	require.Len(t, result.PerBucket, 3)
 
@@ -780,7 +784,7 @@ func TestProvisioner_GrantAccess_IdempotentUpdatesPermissions(t *testing.T) {
 
 	// Request READ_ONLY -- should update even though key already has access
 	slots := []BucketAccessSlot{{BucketID: testBucketID, AccessMode: AccessModeReadOnly}}
-	result, err := p.GrantAccess(context.Background(), testAccountName, slots, defaultAccessParams(), "")
+	result, err := p.GrantAccess(context.Background(), testAccountName, "", slots, defaultAccessParams(), "")
 
 	require.NoError(t, err)
 	assert.Equal(t, testGarageAccessKeyID, result.AccountID)
@@ -817,7 +821,7 @@ func TestProvisioner_GrantAccess_IdempotentSkipsMatchingPermissions(t *testing.T
 	})
 
 	slots := []BucketAccessSlot{{BucketID: testBucketID, AccessMode: AccessModeReadOnly}}
-	result, err := p.GrantAccess(context.Background(), testAccountName, slots, defaultAccessParams(), "")
+	result, err := p.GrantAccess(context.Background(), testAccountName, "", slots, defaultAccessParams(), "")
 
 	require.NoError(t, err)
 	assert.Equal(t, testGarageAccessKeyID, result.AccountID)
@@ -858,7 +862,7 @@ func TestProvisioner_GrantAccess_StoresServiceAccountName(t *testing.T) {
 	})
 
 	slots := []BucketAccessSlot{{BucketID: testBucketID}}
-	_, err := p.GrantAccess(context.Background(), testAccountName, slots, defaultAccessParams(), "my-sa")
+	_, err := p.GrantAccess(context.Background(), testAccountName, "", slots, defaultAccessParams(), "my-sa")
 	require.NoError(t, err)
 
 	keyList := &garagev1beta1.GarageKeyList{}
@@ -914,7 +918,7 @@ func TestGrantAccess_ShadowKeyFailure_RollsBackGarageKey(t *testing.T) {
 	}
 
 	slots := []BucketAccessSlot{{BucketID: testBucketID, AccessMode: AccessModeReadWrite}}
-	_, err := p.GrantAccess(context.Background(), testAccountName, slots, defaultAccessParams(), "")
+	_, err := p.GrantAccess(context.Background(), testAccountName, "", slots, defaultAccessParams(), "")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create shadow key")
@@ -965,4 +969,57 @@ func TestProvisioner_RevokeAccess_NoParameters_UsesClusterRefFromShadow(t *testi
 	require.NoError(t, err)
 	require.Len(t, mockClient.deleteKeyCalls, 1)
 	assert.Equal(t, testGKTestKey, mockClient.deleteKeyCalls[0])
+}
+
+// Regression: a transient (non-404) key-lookup failure must surface as an
+// error, NOT fall through to CreateKey — otherwise every failed reconcile
+// mints a duplicate Garage key (key leak), and once two keys share a name the
+// name search stays ambiguous forever.
+func TestGrantAccess_TransientLookupErrorDoesNotCreateKey(t *testing.T) {
+	cluster := createReadyCluster()
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
+	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
+
+	mockClient := newMockGarageClient()
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
+	mockClient.getKeyErr = &garage.APIError{StatusCode: 500, Message: "temporarily unavailable"}
+
+	p := NewProvisionerWithFactory(fakeClient, testGarageSystem, func(_ context.Context, _ client.Client, _ *garagev1beta2.GarageCluster) (GarageClient, error) {
+		return mockClient, nil
+	})
+
+	slots := []BucketAccessSlot{{BucketID: testBucketID, AccessMode: AccessModeReadWrite}}
+	_, err := p.GrantAccess(context.Background(), testAccountName, "", slots, defaultAccessParams(), "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookup key")
+	assert.Empty(t, mockClient.createKeyCalls, "a lookup failure must never mint a new key")
+}
+
+// Regression: when the BucketAccess already records an AccountID, the lookup
+// must be by that exact ID — key names are not unique in Garage, so a name
+// search can match the wrong key (or turn ambiguous) once duplicates exist.
+func TestGrantAccess_KnownAccountIDReusesExactKey(t *testing.T) {
+	cluster := createReadyCluster()
+	shadowBucket := createShadowBucket(testBucketID, testBucketName)
+	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(cluster, shadowBucket).Build()
+
+	mockClient := newMockGarageClient()
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
+	// Two keys with the SAME name (the duplicate scenario); only GKoriginal is
+	// the recorded account.
+	mockClient.keys["GKoriginal"] = &garage.Key{AccessKeyID: "GKoriginal", SecretAccessKey: "secret-original", Name: testAccountName}
+	mockClient.keys["GKduplicate"] = &garage.Key{AccessKeyID: "GKduplicate", SecretAccessKey: "secret-duplicate", Name: testAccountName}
+
+	p := NewProvisionerWithFactory(fakeClient, testGarageSystem, func(_ context.Context, _ client.Client, _ *garagev1beta2.GarageCluster) (GarageClient, error) {
+		return mockClient, nil
+	})
+
+	slots := []BucketAccessSlot{{BucketID: testBucketID, AccessMode: AccessModeReadWrite}}
+	result, err := p.GrantAccess(context.Background(), testAccountName, "GKoriginal", slots, defaultAccessParams(), "")
+
+	require.NoError(t, err)
+	assert.Equal(t, "GKoriginal", result.AccountID)
+	assert.Equal(t, "secret-original", result.SecretAccessKey)
+	assert.Empty(t, mockClient.createKeyCalls, "an already-provisioned access must reuse its recorded key")
 }


### PR DESCRIPTION
## The bug

`GrantAccess` (`internal/cosi/provisioner.go`) has two compounding defects that make every `BucketAccess` leak one Garage key per reconcile once anything goes transiently wrong:

1. **Any `GetKey` error is treated as "key absent".** The reuse path only checks `err == nil`; a non-404 failure (network blip, admin API briefly unreachable) falls straight through to `CreateKey`, minting a duplicate.
2. **The reuse lookup searches by key *name*, which is not unique in Garage.** Once a duplicate exists, `GetKeyInfo?search=` answers 400 (ambiguous match) forever — so *every* periodic resync falls through and mints another key. The subsequent status write then fails on the CRD-immutable `status.accountId`, so the reconciler errors, backs off, and repeats. It never converges.

## Observed live

On a single-node cluster with one canary `BucketAccess`: one transient `GetKey` failure during a restart window kicked off the loop — **~50 leaked keys in 22 hours** (one per ~17-min backoff cycle, all named after the BucketAccess), the credentials Secret rotating to each newly minted key, `status.readyToUse` stuck `false`, and `Reconciler error … accountId is immutable once set` every cycle. Only the first shadow `GarageKey` ever exists (deterministic name, `AlreadyExists` tolerated), so the leaked keys are invisible on the K8s side — they only show up in `garage key list`.

Reproduce: create a working `BucketAccess`, make one `GetKey` call fail (or just create a second Garage key with the same name), then watch `garage key list` grow on every resync.

## The fix

`GrantAccess` now takes the BucketAccess's recorded `Status.AccountID` and, when set, resolves the key by exact ID; the name search remains only for first-time adoption, and **only a genuine 404 may fall through to `CreateKey`** — any other lookup error surfaces as a reconcile error instead of minting.

Two regression tests cover the failure modes: a transient lookup error must not create a key, and a recorded account ID must be reused even when duplicate key names exist.

We've been running this patch in production on our fork (`v0.6.18-fix.1`) — the stuck BucketAccess self-healed on upgrade (recovered its original key into the Secret, `readyToUse=true`) and the key count has been stable across resyncs since.
