### PR TITLE
fix(chart): register GarageCluster webhooks at v1beta2 like the generated manifests

### DIFF
--- a/charts/garage-operator/templates/webhooks.yaml
+++ b/charts/garage-operator/templates/webhooks.yaml
@@ -97,6 +97,26 @@ webhooks:
     service:
       name: {{ include "garage-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
+      path: /mutate-garage-rajsingh-info-v1beta2-garagecluster
+  failurePolicy: {{ .Values.webhooks.failurePolicy }}
+  rules:
+  - apiGroups:
+    - garage.rajsingh.info
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - garageclusters
+  sideEffects: None
+- name: mgarageclusterv1beta1.kb.io
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "garage-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
       path: /mutate-garage-rajsingh-info-v1beta1-garagecluster
   failurePolicy: {{ .Values.webhooks.failurePolicy }}
   rules:
@@ -204,6 +224,26 @@ webhooks:
     - garagebuckets
   sideEffects: None
 - name: vgaragecluster.kb.io
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "garage-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-garage-rajsingh-info-v1beta2-garagecluster
+  failurePolicy: {{ .Values.webhooks.failurePolicy }}
+  rules:
+  - apiGroups:
+    - garage.rajsingh.info
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - garageclusters
+  sideEffects: None
+- name: vgarageclusterv1beta1.kb.io
   admissionReviewVersions:
   - v1
   clientConfig:


### PR DESCRIPTION
## Problem

The Helm chart's `webhooks.yaml` still registers `mgaragecluster.kb.io` / `vgaragecluster.kb.io` at `apiVersions: [v1beta1]` with the `/…-v1beta1-garagecluster` handler paths, while `config/webhook/manifests.yaml` has served GarageCluster webhooks at **v1beta2** since the dual-API-version work (#167).

Because the webhook rules use `matchPolicy: Equivalent` (default), the apiserver converts every **v1beta2** GarageCluster write down to v1beta1 for the mutating webhook and converts the mutated result back — **silently dropping every v1beta2-only field**: `storage.env`, `envFrom`, `affinity`, `resources`, `replicas`, `podDisruptionBudget`, …

## Live reproduction

Chart-installed operator (v0.6.21), server-side apply of a v1beta2 GarageCluster with:

```yaml
storage:
  env:
    - name: GARAGE_ALLOW_WORLD_READABLE_SECRETS
      value: "true"
```

The stored object comes back without `storage.env` (managedFields still credit the applier with the field), the StatefulSet renders without the env var, and the garage pod CrashLoops on its group-readable rpc-secret (`fsGroup`-mounted secrets are 0640). Deleting the chart-installed `MutatingWebhookConfiguration` and re-applying restores the field and the cluster starts cleanly — which is how we isolated it.

## Fix

Sync the chart with the generated manifests: the `mgaragecluster.kb.io` / `vgaragecluster.kb.io` entries serve **v1beta2** (paths + rules), and the v1beta1-named compat entries (`mgarageclusterv1beta1.kb.io` / `vgarageclusterv1beta1.kb.io`) are added exactly as `config/webhook/manifests.yaml` defines them, so legacy v1beta1 writers stay covered.

`helm template` output verified against `config/webhook/manifests.yaml` — the GarageCluster webhook set now matches 1:1.