### PR TITLE
ci: run the core Ginkgo e2e shard on arm64 runners

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   e2e-ginkgo:
     name: Ginkgo E2E Tests (${{ matrix.shard.name }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.shard.runner }}
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -29,13 +29,23 @@ jobs:
         # claimed by "core" or "api" (including future unlabeled Describes) still
         # runs exactly once — no coverage is silently dropped. The three filters
         # are disjoint and exhaustive over the suite's labels.
+        # core-arm64 re-runs the core shard on GitHub's free arm64 runners —
+        # the operator ships multi-arch images (docker.yml) but nothing
+        # exercised them; arch-specific breakage surfaced only on user
+        # clusters (arm64 SBCs are a common Garage substrate).
         shard:
           - name: core
+            runner: ubuntu-latest
             filter: "gateway || manager || webhooks || external-gateway"
           - name: api
+            runner: ubuntu-latest
             filter: "dual-version || manual-mode || management-handle"
           - name: layout
+            runner: ubuntu-latest
             filter: "!(gateway || manager || webhooks || external-gateway || dual-version || manual-mode || management-handle)"
+          - name: core-arm64
+            runner: ubuntu-24.04-arm
+            filter: "gateway || manager || webhooks || external-gateway"
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
The operator ships multi-arch images (`docker.yml` builds `linux/amd64,linux/arm64`), but no CI lane ever executes the operator on arm64 — arch-specific breakage only surfaces on user clusters, and arm64 SBCs are a common Garage substrate (that's where we run it).

This parameterizes the Ginkgo shard matrix with a `runner` field and adds one `core-arm64` shard on GitHub's free `ubuntu-24.04-arm` runners (available for public repos), re-running the core filter (`gateway || manager || webhooks || external-gateway`) on arm64. kind, Go, and kubectl all install cleanly there; `kindest/node` is multi-arch at the pinned version.

Scope kept to one shard to hold CI wall-clock — the existing aggregator gate (`needs: [e2e-ginkgo]`) covers the new shard automatically. Happy to extend to the other e2e jobs (cluster/COSI/multicluster/ipv6) if you want broader arm64 coverage.