### PR TITLE
fix(controller): populate secret bucketName from ref globalAlias

### DIFF
--- a/hack/test-resources.yaml
+++ b/hack/test-resources.yaml
@@ -83,3 +83,4 @@ spec:
     name: test-s3-credentials
     includeEndpoint: true
     includeRegion: true
+    includeBucketName: true

--- a/internal/controller/garagecluster_management_handle_test.go
+++ b/internal/controller/garagecluster_management_handle_test.go
@@ -174,7 +174,13 @@ func TestBuildSecretData_ManagementHandleEndpoint(t *testing.T) {
 		schemeKey:       "scheme",
 		includeEndpoint: true,
 	}
-	data := buildSecretData(cfg, key, handle, "sk", "cluster.local")
+
+	s := managementHandleScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &GarageKeyReconciler{Client: fc, Scheme: s, ClusterDomain: "cluster.local"}
+
+	data := r.buildSecretData(context.Background(), cfg, key, handle, "sk")
+
 	if got, want := string(data["endpoint"]), "http://garage.garage.svc:3900"; got != want {
 		t.Errorf("endpoint = %q, want %q (external host, S3 port)", got, want)
 	}

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -763,7 +763,7 @@ func resolveSecretConfig(key *garagev1beta1.GarageKey) secretConfig {
 }
 
 // buildSecretData constructs the secret data map based on configuration
-func buildSecretData(cfg secretConfig, key *garagev1beta1.GarageKey, cluster *garagev1beta2.GarageCluster, secretAccessKey, clusterDomain string) map[string][]byte {
+func (r *GarageKeyReconciler) buildSecretData(ctx context.Context, cfg secretConfig, key *garagev1beta1.GarageKey, cluster *garagev1beta2.GarageCluster, secretAccessKey string) map[string][]byte {
 	data := map[string][]byte{
 		cfg.accessKeyIDKey: []byte(key.Status.AccessKeyID),
 	}
@@ -788,7 +788,7 @@ func buildSecretData(cfg secretConfig, key *garagev1beta1.GarageKey, cluster *ga
 			}
 		}
 		if host == "" {
-			host = svcFQDN(cluster.Name, cluster.Namespace, s3Port, clusterDomain)
+			host = svcFQDN(cluster.Name, cluster.Namespace, s3Port, r.ClusterDomain)
 		}
 		endpoint := fmt.Sprintf("%s://%s", scheme, host)
 		data[cfg.endpointKey] = []byte(endpoint)
@@ -805,7 +805,7 @@ func buildSecretData(cfg secretConfig, key *garagev1beta1.GarageKey, cluster *ga
 	}
 
 	if cfg.includeBucketName {
-		if name, ok := singleBucketName(key); ok {
+		if name, ok := r.singleBucketName(ctx, key); ok {
 			data[cfg.bucketNameKey] = []byte(name)
 		}
 	}
@@ -821,7 +821,7 @@ func buildSecretData(cfg secretConfig, key *garagev1beta1.GarageKey, cluster *ga
 // bucket via bucketRef (with a name) or globalAlias. It returns ("", false) for
 // the ambiguous cases: zero permissions, more than one permission, allBuckets,
 // or a single permission that carries neither a bucketRef name nor a globalAlias.
-func singleBucketName(key *garagev1beta1.GarageKey) (string, bool) {
+func (r *GarageKeyReconciler) singleBucketName(ctx context.Context, key *garagev1beta1.GarageKey) (string, bool) {
 	if key.Spec.AllBuckets != nil {
 		return "", false
 	}
@@ -834,6 +834,16 @@ func singleBucketName(key *garagev1beta1.GarageKey) (string, bool) {
 		return p.GlobalAlias, true
 	}
 	if p.BucketRef != nil && p.BucketRef.Name != "" {
+		ns := p.BucketRef.Namespace
+		if ns == "" {
+			ns = key.Namespace
+		}
+		bucket := &garagev1beta1.GarageBucket{}
+		if err := r.Get(ctx, types.NamespacedName{Name: p.BucketRef.Name, Namespace: ns}, bucket); err == nil {
+			if bucket.Spec.GlobalAlias != "" {
+				return bucket.Spec.GlobalAlias, true
+			}
+		}
 		return p.BucketRef.Name, true
 	}
 	return "", false
@@ -869,7 +879,7 @@ func (r *GarageKeyReconciler) reconcileSecret(ctx context.Context, key *garagev1
 	log := logf.FromContext(ctx)
 
 	cfg := resolveSecretConfig(key)
-	secretData := buildSecretData(cfg, key, cluster, secretAccessKey, r.ClusterDomain)
+	secretData := r.buildSecretData(ctx, cfg, key, cluster, secretAccessKey)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
@@ -487,7 +490,15 @@ func TestBuildSecretData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildSecretData(tt.cfg, tt.key, tt.cluster, tt.secretAccessKey, "cluster.local")
+			s := runtime.NewScheme()
+			_ = corev1.AddToScheme(s)
+			_ = garagev1beta1.AddToScheme(s)
+			_ = garagev1beta2.AddToScheme(s)
+			fc := fake.NewClientBuilder().WithScheme(s).Build()
+
+			r := &GarageKeyReconciler{Client: fc, Scheme: s, ClusterDomain: "cluster.local"}
+
+			result := r.buildSecretData(context.Background(), tt.cfg, tt.key, tt.cluster, tt.secretAccessKey)
 
 			for _, key := range tt.wantKeys {
 				if _, ok := result[key]; !ok {


### PR DESCRIPTION
Refactored `singleBucketName` and `buildSecretData` into reconciler methods, so controller now can look up the target `GarageBucket` and extract its `globalAlias` dynamically.