### PR TITLE
fix(federation): reconnect nodes through identity-specific RPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ Tenants can only access what the platform team grants them. Revoking access is a
 
 Garage supports federating clusters across Kubernetes clusters for geo-distributed storage. All clusters share the same RPC secret and Garage distributes replicas across zones automatically.
 
-> **Every federated cluster must advertise an externally-routable RPC address** (`spec.network.rpcPublicAddr` or `spec.publicEndpoint`). Without one, Garage's HelloMessage carries no `server_addr`, peers infer the unroutable pod IP, and cross-cluster RPC degrades after any pod restart. The webhook warns when `spec.remoteClusters` is set with neither, and the `FederationConfigured` status condition goes False.
+> **Every Garage node in a federated cluster needs its own externally-routable RPC address.** Garage authenticates the expected node ID during its RPC handshake, so a shared L4 LoadBalancer cannot safely represent multiple nodes: if it selects a different pod, the identity check fails. Use per-node `spec.network.rpcPublicAddr`, `spec.publicEndpoint`, or ordinal address templates. Since v0.6.24 the operator publishes each effective node address in Garage's replicated layout and uses it for direct cross-cluster reconnection. Shared addresses remain bootstrap-only compatibility fallbacks.
 
 1. Create the same RPC secret in every Kubernetes cluster:
    ```bash
@@ -861,7 +861,7 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
    kubectl create secret generic garage-rpc-secret --from-literal=rpc-secret=$SECRET
    ```
 
-2. For **uniform clusters** (all nodes identical), use `GarageCluster` with a shared/global `publicEndpoint`:
+2. For **uniform clusters** (all nodes identical), use Auto layout with a per-node RPC address template:
    ```yaml
    apiVersion: garage.rajsingh.info/v1beta2
    kind: GarageCluster
@@ -873,6 +873,7 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
        factor: 3
      storage:
        replicas: 3
+       rpcPublicAddr: "garage-us-storage-{ordinal}.example.com:3901"
        metadata:
          size: 10Gi
        data:
@@ -881,8 +882,13 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
        rpcSecretRef:
          name: garage-rpc-secret
          key: rpc-secret
+     # Provision one external endpoint for each ordinal hostname above. As an
+     # alternative, publicEndpoint.loadBalancer.perNode lets the operator create
+     # one LoadBalancer and derive one effective RPC address per storage node.
      publicEndpoint:
-       type: LoadBalancer   # single shared/global LB; all pods share one external RPC endpoint
+       type: LoadBalancer
+       loadBalancer:
+         perNode: true
      remoteClusters:
        - name: eu-west
          zone: eu-west-1
@@ -897,14 +903,7 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
          key: admin-token
    ```
 
-   Shared LoadBalancer mode is intentionally still supported. It is the smallest configuration when your load balancer provides one stable, externally-routable RPC endpoint for the cluster. If you need one externally-routable RPC endpoint per pod, add:
-   ```yaml
-   publicEndpoint:
-     type: LoadBalancer
-     loadBalancer:
-       perNode: true
-   ```
-   In auto-layout `GarageCluster` mode, this creates one LoadBalancer service per StatefulSet pod and the operator uses those addresses for reverse `ConnectClusterNodes` calls. The Garage pods still share a single ConfigMap, so this mode does not write distinct per-pod `rpc_public_addr` values into Garage's own config.
+   A shared LoadBalancer is retained only for backwards-compatible bootstrap. Do not rely on it for steady-state federation with multiple identity-bearing RPC nodes. `loadBalancer.perNode` creates one Service per operator-managed node; alternatively, `storage.rpcPublicAddr` with `{ordinal}` writes a stable distinct address into every generated `GarageNode`.
 
 3. For **per-node advertised RPC addresses** (recommended when every storage node needs its own stable public address in Garage config), use `layoutPolicy: Manual` with individual `GarageNode` resources — each node gets its own LoadBalancer service and `rpc_public_addr`:
    ```yaml
@@ -946,7 +945,7 @@ Garage supports federating clusters across Kubernetes clusters for geo-distribut
        type: LoadBalancer   # operator creates garage-node-0-rpc service
        # rpc_public_addr is auto-derived from the LB ingress IP
    ```
-   Each `GarageNode` creates a separate StatefulSet and its own `<node>-rpc` LoadBalancer service. The operator writes the node-specific `rpc_public_addr` into the per-node ConfigMap automatically.
+   Each `GarageNode` creates a separate StatefulSet and its own `<node>-rpc` LoadBalancer service. The operator writes the node-specific `rpc_public_addr` into the per-node ConfigMap and publishes the same effective address as an operator-owned `rpc-address:` layout tag. Remote operators preserve that tag while importing roles and prefer it over shared regional endpoints. This works for storage nodes, gateways, external nodes, IPv4/IPv6 endpoints, and both Auto and Manual layout modes; it is independent of the operator container architecture.
 
    To set `rpc_public_addr` manually (e.g. for a static hostname), use `spec.network.rpcPublicAddr` instead:
    ```yaml

--- a/charts/garage-operator/Chart.yaml
+++ b/charts/garage-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: garage-operator
 description: A Kubernetes operator for managing Garage distributed S3-compatible object storage
 type: application
-version: 0.6.23
-appVersion: "0.6.23"
+version: 0.6.24
+appVersion: "0.6.24"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/rajsinghtech/garage-operator
 sources:

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)
-  tag: "v0.6.23"
+  tag: "v0.6.24"
 
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.

--- a/internal/controller/federation_test.go
+++ b/internal/controller/federation_test.go
@@ -55,6 +55,7 @@ const (
 	testGatewayOwnershipTag = "cluster:garage/garage"
 	testTierGatewayTag      = "tier:gateway"
 	testTierStorageTag      = "tier:storage"
+	testRemoteRoleTag       = "remote"
 )
 
 // newMockGarageServer creates a mock Garage Admin API server with configurable
@@ -296,7 +297,7 @@ var _ = Describe("Federation - connectToRemoteCluster", func() {
 					{
 						ID:   "fedcba9876543210fedcba98remote001",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{"remote"}},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{testRemoteRoleTag}},
 					},
 				},
 			}
@@ -620,7 +621,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 					{
 						ID:   "fedcba9876543210fedcba98newnode01",
 						IsUp: true,
-						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{"remote"}, Capacity: &cap},
+						Role: &garage.NodeAssignedRole{Zone: testZoneRemote, Tags: []string{testRemoteRoleTag}, Capacity: &cap},
 					},
 				},
 			}
@@ -640,7 +641,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 			Expect(updatedRoles[0].Zone).To(Equal(testZoneRemote))
 			// Recovery path gets the same tag treatment as the remoteStatus path:
 			// remote.Name retained + tier derived from capacity (#224).
-			Expect(updatedRoles[0].Tags).To(ContainElements("tier:storage", testTagRemoteCluster))
+			Expect(updatedRoles[0].Tags).To(ContainElements(testTierStorageTag, testTagRemoteCluster))
 		})
 
 		It("should not stage nodes that are already in the layout", func() {
@@ -764,7 +765,7 @@ var _ = Describe("Federation - addRemoteNodesToLayout", func() {
 			// a cluster:<remote>/<ns> ownership tag added so tier-aware logic recognizes it (#224).
 			storage := byID["fedcba9876543210fedcba98fromapi1"]
 			gateway := byID["fedcba9876543210fedcba98fromapi2"]
-			Expect(storage.Tags).To(ContainElements("tier:storage", testTagRemoteCluster))
+			Expect(storage.Tags).To(ContainElements(testTierStorageTag, testTagRemoteCluster))
 			Expect(gateway.Tags).To(ContainElements("tier:gateway", testTagRemoteCluster))
 			Expect(gateway.Tags).To(ContainElement(HavePrefix("cluster:")))
 		})
@@ -1018,7 +1019,7 @@ var _ = Describe("Federation - connectRemoteGatewayPods", func() {
 					IsUp: false,
 					Role: &garage.NodeAssignedRole{
 						Zone: testZoneRemote,
-						Tags: []string{testGatewayOwnershipTag, "tier:storage", "garage-0"},
+						Tags: []string{testGatewayOwnershipTag, testTierStorageTag, "garage-0"},
 					},
 				},
 			},
@@ -1115,7 +1116,7 @@ func TestParseRemoteGatewayOrdinal(t *testing.T) {
 		},
 		{
 			name:   "storage node (no gateway pod-name tag)",
-			tags:   []string{"cluster:garage/garage", "tier:storage", "garage-storage-0-0"},
+			tags:   []string{testGatewayOwnershipTag, testTierStorageTag, "garage-storage-0-0"},
 			wantOK: false,
 		},
 	}

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -4272,20 +4272,18 @@ func (r *GarageClusterReconciler) connectToRemoteCluster(
 	connectedCount := 0
 	if needsConnect {
 		for _, node := range remoteNodes {
-			// IMPORTANT: We use the remote cluster's hostname (from adminApiEndpoint)
-			// instead of the node's advertised address. This is because:
-			// 1. Nodes may advertise their local proxy IP which isn't routable cross-cluster
-			// 2. The admin endpoint hostname is the Tailscale service that routes to all nodes
-			// 3. Tailscale handles the actual routing to the correct pod
-			var addr string
-			if remoteRPCHost != "" {
-				addr = rpcAddr(remoteRPCHost, rpcPort)
-			} else if node.Address != nil && *node.Address != "" {
-				addr = *node.Address
-			} else {
+			// Garage authenticates the expected node ID during the RPC handshake. A
+			// shared L4 Service cannot route by that identity and may select a
+			// different pod, which then correctly fails authentication. Prefer the
+			// node-specific address replicated in its layout tags. The shared admin
+			// hostname remains a compatibility/bootstrap fallback for old nodes.
+			addr, addressSource := remoteNodeRPCAddress(node, remoteRPCHost, rpcPort)
+			if addr == "" {
 				log.V(1).Info("Remote node has no address", "nodeID", node.ID[:16]+"...")
 				continue
 			}
+
+			log.V(1).Info("Connecting to remote node", "nodeID", node.ID[:16]+"...", "addr", addr, "addressSource", addressSource)
 
 			// Use a short per-call timeout so a stale/unreachable node ID (e.g. after
 			// metadata wipe) doesn't block the whole reconcile. Garage v2.2.0 had no TCP
@@ -4556,28 +4554,63 @@ func parseRemotePodOrdinal(tags []string, tier string) (string, bool) {
 	return "", false
 }
 
-// remoteImportTags builds the layout tags for a federated remote node imported into
-// the local layout. remote.Name is kept as a standalone tag because removeStaleRemoteNodes
-// exact-matches it to find imported roles whose node has vanished from the remote cluster.
-// The tier tag (derived from capacity: nil => gateway, non-nil => storage) makes the role
-// tier-identifiable instead of untyped — previously imported roles carried only remote.Name,
-// so when such a gateway role later orphaned in its own zone the owning region's gateway
-// reaper had no tier signal and it stuck forever (#224); the reaper's capacity-shape
-// backstop now also covers that case. (It does NOT let connectRemoteGatewayPods dial the
-// node: that needs a "<name>-gateway-<ordinal>" pod-name tag the import does not carry, so
-// connectRemoteGatewayPods still skips imported nodes — gracefully.) The ownership tag
-// encodes the REMOTE region's name, not the local cluster's, so the local finalizer cleanup
-// and zone-gated reaper never mistake an imported role for local-owned.
-func remoteImportTags(remote garagev1beta2.RemoteClusterConfig, namespace string, capacity *uint64) []string {
+// nodeRPCAddressTagPrefix marks operator-owned layout metadata carrying the
+// effective, externally routable address of one identity-bearing Garage node.
+const nodeRPCAddressTagPrefix = "rpc-address:"
+
+// remoteNodeRPCAddress chooses a routable address for an identity-authenticated
+// Garage RPC connection. Layout tags are the only node-specific address data
+// available before a disconnected mesh has been bootstrapped: NodeInfo.Address
+// is null for disconnected peers and is merely the observed socket address for
+// connected peers, not necessarily their configured rpc_public_addr.
+func remoteNodeRPCAddress(node garage.NodeInfo, sharedHost string, rpcPort int32) (string, string) {
+	if node.Role != nil {
+		for _, tag := range node.Role.Tags {
+			if addr, found := strings.CutPrefix(tag, nodeRPCAddressTagPrefix); found && strings.TrimSpace(addr) != "" {
+				return strings.TrimSpace(addr), "layout-tag"
+			}
+		}
+	}
+	if sharedHost != "" {
+		return rpcAddr(sharedHost, rpcPort), "shared-bootstrap"
+	}
+	if node.Address != nil && *node.Address != "" {
+		return *node.Address, "observed-peer"
+	}
+	return "", ""
+}
+
+// remoteImportTags preserves remote role metadata needed to reconnect directly
+// to a specific identity-bearing RPC node. Ownership and tier tags are replaced
+// with the importing cluster's canonical values so cleanup remains zone-safe;
+// all other tags, including rpc-address and legacy per-ordinal tags, survive.
+func remoteImportTags(remote garagev1beta2.RemoteClusterConfig, namespace string, capacity *uint64, sourceTags ...[]string) []string {
 	tier := tierGateway
 	if capacity != nil {
 		tier = tierStorage
 	}
-	return []string{
+	tags := []string{
 		fmt.Sprintf("cluster:%s/%s", remote.Name, namespace),
 		"tier:" + tier,
 		remote.Name,
 	}
+	seen := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		seen[tag] = struct{}{}
+	}
+	for _, source := range sourceTags {
+		for _, tag := range source {
+			if tag == "" || strings.HasPrefix(tag, "cluster:") || strings.HasPrefix(tag, "tier:") {
+				continue
+			}
+			if _, exists := seen[tag]; exists {
+				continue
+			}
+			tags = append(tags, tag)
+			seen[tag] = struct{}{}
+		}
+	}
+	return tags
 }
 
 // addRemoteNodesToLayout adds remote cluster nodes to the local cluster's layout.
@@ -4679,7 +4712,7 @@ func (r *GarageClusterReconciler) addRemoteNodesToLayout(
 			role = garage.NodeRoleChange{
 				ID:       node.ID,
 				Zone:     remote.Zone, // Use configured zone from CRD
-				Tags:     remoteImportTags(remote, cluster.Namespace, node.Role.Capacity),
+				Tags:     remoteImportTags(remote, cluster.Namespace, node.Role.Capacity, node.Role.Tags),
 				Capacity: node.Role.Capacity, // nil = gateway, non-nil = storage
 			}
 		} else if stagedRole, ok := remoteStagedRoles[node.ID]; ok {
@@ -4690,7 +4723,7 @@ func (r *GarageClusterReconciler) addRemoteNodesToLayout(
 			role = garage.NodeRoleChange{
 				ID:       node.ID,
 				Zone:     remote.Zone, // Use configured zone from CRD
-				Tags:     remoteImportTags(remote, cluster.Namespace, stagedRole.Capacity),
+				Tags:     remoteImportTags(remote, cluster.Namespace, stagedRole.Capacity, stagedRole.Tags),
 				Capacity: stagedRole.Capacity, // Use capacity from staged role
 			}
 		} else {

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -1189,11 +1190,17 @@ func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1
 		capacity = &nodeCapacity
 	}
 
-	// Ensure tags is never nil (Garage API requires tags field to be present)
-	desiredTags := node.Spec.Tags
-	if desiredTags == nil {
-		desiredTags = []string{}
+	// Publish the effective node-specific RPC address in the replicated layout.
+	// Remote operators need this before the RPC mesh is connected; Garage's
+	// status API reports a disconnected peer's address as null, so
+	// rpc_public_addr in garage.toml alone cannot break the federation bootstrap
+	// chicken-and-egg. This covers explicit addresses, external nodes, and
+	// operator-managed LoadBalancer/NodePort endpoints.
+	rpcPublicAddr, err := r.effectiveNodeRPCPublicAddr(ctx, node, cluster)
+	if err != nil {
+		return fmt.Errorf("resolving node RPC public address: %w", err)
 	}
+	desiredTags := desiredNodeRoleTags(node.Spec.Tags, rpcPublicAddr)
 
 	// Check if update is needed
 	needsUpdate := false
@@ -1266,6 +1273,22 @@ func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1
 	}
 
 	return nil
+}
+
+// desiredNodeRoleTags returns a fresh tag slice and, when configured, carries
+// rpc_public_addr through Garage's replicated layout. The tag is operator-owned:
+// stale values are removed so changing the address cannot leave two candidates.
+func desiredNodeRoleTags(specTags []string, rpcPublicAddr string) []string {
+	desired := make([]string, 0, len(specTags)+1)
+	for _, tag := range specTags {
+		if !strings.HasPrefix(tag, nodeRPCAddressTagPrefix) {
+			desired = append(desired, tag)
+		}
+	}
+	if addr := strings.TrimSpace(rpcPublicAddr); addr != "" {
+		desired = append(desired, nodeRPCAddressTagPrefix+addr)
+	}
+	return desired
 }
 
 func (r *GarageNodeReconciler) discoverNodeID(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) (string, error) {
@@ -1909,6 +1932,61 @@ func (r *GarageNodeReconciler) reconcileNodeService(ctx context.Context, node *g
 	return reconcileService(ctx, r.Client, svc, node, r.Scheme)
 }
 
+// effectiveNodeRPCPublicAddr resolves the same address written to garage.toml
+// and published in the node's replicated layout tags. An empty result means the
+// node has no node-specific endpoint and may inherit cluster-level bootstrap
+// configuration; shared cluster addresses are deliberately not advertised as
+// identity-specific endpoints.
+func (r *GarageNodeReconciler) effectiveNodeRPCPublicAddr(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) (string, error) {
+	if node.Spec.Network != nil && strings.TrimSpace(node.Spec.Network.RPCPublicAddr) != "" {
+		return strings.TrimSpace(node.Spec.Network.RPCPublicAddr), nil
+	}
+	if node.Spec.External != nil && strings.TrimSpace(node.Spec.External.Address) != "" {
+		port := node.Spec.External.Port
+		if port == 0 {
+			port = DefaultRPCPort
+		}
+		return rpcAddr(strings.TrimSpace(node.Spec.External.Address), port), nil
+	}
+	if node.Spec.PublicEndpoint == nil {
+		return "", nil
+	}
+
+	rpcPort := DefaultRPCPort
+	if cluster.Spec.Network.RPCBindPort != 0 {
+		rpcPort = cluster.Spec.Network.RPCBindPort
+	}
+	switch node.Spec.PublicEndpoint.Type {
+	case publicEndpointTypeLoadBalancer:
+		svc := &corev1.Service{}
+		svcName := effectiveNodeRPCServiceName(node, cluster)
+		if err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: cluster.Namespace}, svc); err != nil {
+			if errors.IsNotFound(err) {
+				return "", nil
+			}
+			return "", err
+		}
+		for _, ing := range svc.Status.LoadBalancer.Ingress {
+			addr := ing.IP
+			if addr == "" {
+				addr = ing.Hostname
+			}
+			if addr != "" {
+				return rpcAddr(addr, rpcPort), nil
+			}
+		}
+	case publicEndpointTypeNodePort:
+		if ep := node.Spec.PublicEndpoint.NodePort; ep != nil && len(ep.ExternalAddresses) > 0 {
+			port := ep.BasePort
+			if port == 0 {
+				port = 30901
+			}
+			return rpcAddr(ep.ExternalAddresses[0], port), nil
+		}
+	}
+	return "", nil
+}
+
 // reconcileNodeConfigMap generates a per-node garage.toml ConfigMap by building a configContext
 // with node-specific overrides and calling the shared config generator.
 func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) error {
@@ -1932,39 +2010,11 @@ func (r *GarageNodeReconciler) reconcileNodeConfigMap(ctx context.Context, node 
 
 	// Apply node-level rpc_public_addr via NodeRPCPublicAddr — this takes highest priority
 	// in writeRPCConfig, overriding even cluster.Spec.Network.RPCPublicAddr.
-	if node.Spec.Network != nil && node.Spec.Network.RPCPublicAddr != "" {
-		cfgCtx.NodeRPCPublicAddr = node.Spec.Network.RPCPublicAddr
-	} else if node.Spec.PublicEndpoint != nil {
-		rpcPort := DefaultRPCPort
-		if cluster.Spec.Network.RPCBindPort != 0 {
-			rpcPort = cluster.Spec.Network.RPCBindPort
-		}
-		switch node.Spec.PublicEndpoint.Type {
-		case publicEndpointTypeLoadBalancer:
-			svc := &corev1.Service{}
-			svcName := effectiveNodeRPCServiceName(node, cluster)
-			if err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: cluster.Namespace}, svc); err == nil {
-				for _, ing := range svc.Status.LoadBalancer.Ingress {
-					addr := ing.IP
-					if addr == "" {
-						addr = ing.Hostname
-					}
-					if addr != "" {
-						cfgCtx.NodeRPCPublicAddr = fmt.Sprintf("%s:%d", addr, rpcPort)
-						break
-					}
-				}
-			}
-		case publicEndpointTypeNodePort:
-			if ep := node.Spec.PublicEndpoint.NodePort; ep != nil && len(ep.ExternalAddresses) > 0 {
-				basePort := ep.BasePort
-				if basePort == 0 {
-					basePort = 30901
-				}
-				cfgCtx.NodeRPCPublicAddr = fmt.Sprintf("%s:%d", ep.ExternalAddresses[0], basePort)
-			}
-		}
+	rpcPublicAddr, err := r.effectiveNodeRPCPublicAddr(ctx, node, cluster)
+	if err != nil {
+		return fmt.Errorf("resolving node RPC public address: %w", err)
 	}
+	cfgCtx.NodeRPCPublicAddr = rpcPublicAddr
 
 	// Apply node-level fsync + snapshot overrides.
 	if node.Spec.Storage != nil {

--- a/internal/controller/storage_rpcaddr_test.go
+++ b/internal/controller/storage_rpcaddr_test.go
@@ -27,6 +27,7 @@ import (
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 var _ = Describe("buildAutoModeStorageNode rpc_public_addr per-ordinal (#cross-region storage reachability)", func() {
@@ -96,6 +97,51 @@ var _ = Describe("buildAutoModeStorageNode rpc_public_addr per-ordinal (#cross-r
 
 // TestParseRemotePodOrdinal verifies ordinal extraction for both tiers from
 // layout tags, including the gateway delegation wrapper.
+func TestNodeSpecificRPCAddressTags(t *testing.T) {
+	original := []string{testGatewayOwnershipTag, testTierStorageTag, nodeRPCAddressTagPrefix + "old.example:3901"}
+	tags := desiredNodeRoleTags(original, "new.example:3901")
+	if len(tags) != 3 || tags[2] != nodeRPCAddressTagPrefix+"new.example:3901" {
+		t.Fatalf("desired tags = %#v, want one current RPC address tag", tags)
+	}
+	if original[2] != nodeRPCAddressTagPrefix+"old.example:3901" {
+		t.Fatalf("desiredNodeRoleTags mutated its input: %#v", original)
+	}
+
+	capacity := uint64(1024)
+	remote := garagev1beta2.RemoteClusterConfig{Name: testRemoteRoleTag, Zone: "remote-zone"}
+	imported := remoteImportTags(remote, "garage", &capacity, tags)
+	wantRPC := nodeRPCAddressTagPrefix + "new.example:3901"
+	foundRPC := false
+	for _, tag := range imported {
+		if tag == wantRPC {
+			foundRPC = true
+		}
+		if tag == testGatewayOwnershipTag {
+			t.Fatalf("source ownership tag must not survive import: %#v", imported)
+		}
+	}
+	if !foundRPC {
+		t.Fatalf("imported tags lost node RPC address: %#v", imported)
+	}
+
+	node := garage.NodeInfo{Role: &garage.NodeAssignedRole{Tags: imported}}
+	addr, source := remoteNodeRPCAddress(node, "shared.example", 3901)
+	if addr != "new.example:3901" || source != "layout-tag" {
+		t.Fatalf("address = (%q,%q), want node-specific layout address", addr, source)
+	}
+}
+
+func TestRemoteNodeRPCAddressFallbacks(t *testing.T) {
+	observed := "10.0.0.2:3901"
+	node := garage.NodeInfo{Address: &observed}
+	if addr, source := remoteNodeRPCAddress(node, "shared.example", 3901); addr != "shared.example:3901" || source != "shared-bootstrap" {
+		t.Fatalf("shared fallback = (%q,%q)", addr, source)
+	}
+	if addr, source := remoteNodeRPCAddress(node, "", 3901); addr != observed || source != "observed-peer" {
+		t.Fatalf("observed fallback = (%q,%q)", addr, source)
+	}
+}
+
 func TestParseRemotePodOrdinal(t *testing.T) {
 	storageTags := []string{testGatewayOwnershipTag, testTierStorageTag, "garage-storage-2-0"}
 	if got, ok := parseRemotePodOrdinal(storageTags, tierStorage); !ok || got != "2" {


### PR DESCRIPTION
## Summary
- publish each GarageNode effective RPC public address through replicated layout metadata
- preserve node-specific metadata while importing remote roles
- prefer authenticated per-node endpoints over shared regional bootstrap addresses
- support explicit, external, LoadBalancer, NodePort, Auto/Manual, IPv4/IPv6 configurations
- correct federation documentation and prepare patch release v0.6.24

## Safety
- no node IDs, PVCs, capacities, or zones change
- layout changes are tag-only and do not rebalance partitions
- shared addresses remain a compatibility fallback
- release image remains multi-arch linux/amd64 + linux/arm64

## Validation
- `go test ./...`
- `make lint`
- `git diff --check`