### PR TITLE
fix(nodes): reconcile RPC metadata while offline

### DIFF
--- a/charts/garage-operator/Chart.yaml
+++ b/charts/garage-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: garage-operator
 description: A Kubernetes operator for managing Garage distributed S3-compatible object storage
 type: application
-version: 0.6.24
-appVersion: "0.6.24"
+version: 0.6.25
+appVersion: "0.6.25"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/rajsinghtech/garage-operator
 sources:

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)
-  tag: "v0.6.24"
+  tag: "v0.6.25"
 
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -1100,14 +1100,26 @@ func (r *GarageNodeReconciler) selectorLabelsForNode(node *garagev1beta1.GarageN
 func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster, garageClient *garage.Client) error {
 	log := logf.FromContext(ctx)
 
-	// Discover or use provided node ID
+	// Discover or use the provided node ID. If a previously reconciled node is
+	// currently offline, discovery from its pod is impossible; retain the
+	// observed status ID so layout-only metadata (notably rpc-address) can still
+	// be repaired through another healthy cluster admin endpoint. A live
+	// discovery always wins, so replacing a pod's persisted identity is still
+	// detected rather than masked by stale status.
 	nodeID := node.Spec.NodeID
 	if nodeID == "" {
-		discovered, err := r.discoverNodeID(ctx, node, cluster)
+		discovered, discoverErr := r.discoverNodeID(ctx, node, cluster)
+		var (
+			usedObserved bool
+			err          error
+		)
+		nodeID, usedObserved, err = nodeIDFromDiscovery(discovered, discoverErr, node.Status.NodeID)
 		if err != nil {
 			return fmt.Errorf("failed to discover node ID: %w", err)
 		}
-		nodeID = discovered
+		if usedObserved {
+			log.Info("Node unavailable; using previously observed node ID for layout reconciliation", "nodeID", nodeID)
+		}
 	}
 
 	// If node ID is still empty, try to discover from Admin API using pod IPs.
@@ -1289,6 +1301,19 @@ func desiredNodeRoleTags(specTags []string, rpcPublicAddr string) []string {
 		desired = append(desired, nodeRPCAddressTagPrefix+addr)
 	}
 	return desired
+}
+
+// nodeIDFromDiscovery falls back only when live discovery failed. This keeps
+// offline nodes reconcilable without masking a changed identity once the pod is
+// available again.
+func nodeIDFromDiscovery(discovered string, discoverErr error, observed string) (string, bool, error) {
+	if discoverErr == nil {
+		return discovered, false, nil
+	}
+	if observed == "" {
+		return "", false, discoverErr
+	}
+	return observed, true, nil
 }
 
 func (r *GarageNodeReconciler) discoverNodeID(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) (string, error) {

--- a/internal/controller/storage_rpcaddr_test.go
+++ b/internal/controller/storage_rpcaddr_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -97,6 +98,20 @@ var _ = Describe("buildAutoModeStorageNode rpc_public_addr per-ordinal (#cross-r
 
 // TestParseRemotePodOrdinal verifies ordinal extraction for both tiers from
 // layout tags, including the gateway delegation wrapper.
+func TestNodeIDFromDiscovery(t *testing.T) {
+	discoveryErr := errors.New("pod unavailable")
+
+	if got, fallback, err := nodeIDFromDiscovery("live-id", nil, "stale-id"); got != "live-id" || fallback || err != nil {
+		t.Fatalf("live discovery = (%q,%v,%v), want live-id without fallback", got, fallback, err)
+	}
+	if got, fallback, err := nodeIDFromDiscovery("", discoveryErr, "observed-id"); got != "observed-id" || !fallback || err != nil {
+		t.Fatalf("offline fallback = (%q,%v,%v), want observed-id fallback", got, fallback, err)
+	}
+	if _, _, err := nodeIDFromDiscovery("", discoveryErr, ""); !errors.Is(err, discoveryErr) {
+		t.Fatalf("missing fallback error = %v, want discovery error", err)
+	}
+}
+
 func TestNodeSpecificRPCAddressTags(t *testing.T) {
 	original := []string{testGatewayOwnershipTag, testTierStorageTag, nodeRPCAddressTagPrefix + "old.example:3901"}
 	tags := desiredNodeRoleTags(original, "new.example:3901")


### PR DESCRIPTION
## Summary
- fall back to the previously observed Garage node ID only when live pod discovery fails
- allow layout-only `rpc-address` repair while a known node is offline
- keep live discovery authoritative so changed persisted identities are still detected
- prepare patch release v0.6.25

## Why
The v0.6.24 production rollout correctly tagged healthy nodes, but exposed that a node already offline before upgrade could not publish its endpoint even though `status.nodeId` and `spec.network.rpcPublicAddr` were known.

## Validation
- regression tests cover live discovery, offline fallback, and no-ID failure
- `go test ./...`
- `make lint`
- `git diff --check`