### PR TITLE
fix(nodes): retain ID when running pod is unreachable

### DIFF
--- a/charts/garage-operator/Chart.yaml
+++ b/charts/garage-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: garage-operator
 description: A Kubernetes operator for managing Garage distributed S3-compatible object storage
 type: application
-version: 0.6.25
-appVersion: "0.6.25"
+version: 0.6.26
+appVersion: "0.6.26"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/rajsinghtech/garage-operator
 sources:

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)
-  tag: "v0.6.25"
+  tag: "v0.6.26"
 
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -1138,16 +1138,25 @@ func (r *GarageNodeReconciler) reconcileNode(ctx context.Context, node *garagev1
 			log.Info("Node not found in cluster status, trying direct discovery", "podIPs", podIPs)
 			discovered, err = r.discoverNodeIDDirect(ctx, cluster, podIPs)
 			if err != nil {
-				return fmt.Errorf("failed to discover node ID: %w", err)
-			}
-
-			// Connect this node to the cluster so other nodes can see it
-			log.Info("Connecting node to cluster", "nodeID", discovered, "podIPs", podIPs)
-			if err := r.connectNodeToCluster(ctx, garageClient, discovered, podIPs[0], cluster); err != nil {
-				return fmt.Errorf("failed to connect node to cluster: %w", err)
+				var usedObserved bool
+				nodeID, usedObserved, err = nodeIDFromDiscovery(discovered, err, node.Status.NodeID)
+				if err != nil {
+					return fmt.Errorf("failed to discover node ID: %w", err)
+				}
+				if usedObserved {
+					log.Info("Running node is unreachable; using previously observed node ID for layout reconciliation", "nodeID", nodeID)
+				}
+			} else {
+				// Connect this node to the cluster so other nodes can see it.
+				log.Info("Connecting node to cluster", "nodeID", discovered, "podIPs", podIPs)
+				if err := r.connectNodeToCluster(ctx, garageClient, discovered, podIPs[0], cluster); err != nil {
+					return fmt.Errorf("failed to connect node to cluster: %w", err)
+				}
 			}
 		}
-		nodeID = discovered
+		if nodeID == "" {
+			nodeID = discovered
+		}
 	}
 
 	if nodeID == "" {


### PR DESCRIPTION
## Summary
- use the previously observed node ID when a pod still reports Running but its direct admin API is unreachable
- continue layout-only RPC metadata reconciliation without masking live identity discovery
- prepare v0.6.26

## Production finding
A NotReady Kubernetes node leaves its pod phase recorded as Running. v0.6.25 handled non-running/unavailable pods, but the stale Running phase took the direct-discovery path before timing out. This closes that final recovery path.

## Validation
- `go test ./...`
- `make lint`
- `git diff --check`