### PR TITLE
fix(automode): propagate type: EmptyDir into per-node GarageNodes (#283)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,33 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Guards against committed generated files (CRDs, Helm chart CRDs, JSON
+  # schemas, deepcopy) drifting from the Go source. `make test` regenerates
+  # these as a prerequisite but never diffs the result, helm.yml only compares
+  # the two committed CRD copies to each other, and schemas.yml regenerates
+  # schemas from the (possibly stale) committed CRDs — so a stale CRD slipped
+  # through all three. This job regenerates from source and fails on any diff.
+  verify-generated:
+    name: Verify Generated Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Verify generated files are in sync with the Go types
+        run: make verify-generate

--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,16 @@ helm-verify-crd-bases: ## Verify Helm chart CRDs match kustomize CRDs
 	fi; \
 	echo "All CRDs are in sync."
 
+.PHONY: verify-generate
+verify-generate: manifests generate ## Verify committed generated files (CRDs, Helm CRDs, JSON schemas, deepcopy) match the Go types.
+	@if ! git diff --quiet; then \
+		echo "ERROR: generated files are out of date with the Go types."; \
+		echo "Run 'make manifests generate' and commit the result:"; \
+		git --no-pager diff --stat; \
+		exit 1; \
+	fi; \
+	echo "Generated files are in sync with the Go types."
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/api/v1beta1/garagenode_webhook.go
+++ b/api/v1beta1/garagenode_webhook.go
@@ -201,6 +201,24 @@ func validateVolumeSource(vs *NodeVolumeConfig, fieldPath string) error {
 	hasExistingClaim := vs.ExistingClaim != ""
 	hasSize := vs.Size != nil
 
+	// EmptyDir is a self-contained ephemeral volume source: it binds no PVC and
+	// needs no provisioning size. Operator-generated ephemeral Auto-mode nodes
+	// (#283) produce exactly this shape (`{type: EmptyDir}` with no size), so the
+	// requirement below must accept it — otherwise the operator's own GarageNode
+	// create is rejected by admission and the ephemeral cluster never starts.
+	// A size, when present, is honored as the EmptyDir sizeLimit. existingClaim
+	// and storageClassName are meaningless for EmptyDir (PVC-only), so reject
+	// them — symmetric with the cluster webhook's EmptyDir guards.
+	if vs.Type == VolumeTypeEmptyDir {
+		if hasExistingClaim {
+			return fmt.Errorf("%s: existingClaim cannot be used with type=EmptyDir", fieldPath)
+		}
+		if vs.StorageClassName != nil {
+			return fmt.Errorf("%s: storageClassName cannot be used with type=EmptyDir", fieldPath)
+		}
+		return nil
+	}
+
 	// existingClaim + size is permitted: in multi-HDD `storage.dataPaths[]`
 	// entries Size is the capacity advertised to Garage in `data_dir`, which
 	// has independent semantics from PVC binding. The legacy-STS migration
@@ -212,7 +230,7 @@ func validateVolumeSource(vs *NodeVolumeConfig, fieldPath string) error {
 	// `data_dir` entries with `read_only = true` and no capacity (see
 	// ../garage src/block/layout.rs `make_data_dirs`).
 	if !hasExistingClaim && !hasSize && !vs.ReadOnly {
-		return fmt.Errorf("%s: must specify existingClaim, size, or readOnly", fieldPath)
+		return fmt.Errorf("%s: must specify existingClaim, size, readOnly, or type=EmptyDir", fieldPath)
 	}
 
 	if vs.StorageClassName != nil && hasExistingClaim {

--- a/api/v1beta1/webhook_test.go
+++ b/api/v1beta1/webhook_test.go
@@ -367,7 +367,7 @@ func TestGarageNodeValidator_CrossNamespaceBlocked(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: testSourceNS},
 		Spec: GarageNodeSpec{
 			ClusterRef: ClusterReference{Name: testCluster, Namespace: testTargetNS},
-			Zone:       "us-east-1",
+			Zone:       testZone,
 			Capacity:   func() *resource.Quantity { q := resource.MustParse("100Gi"); return &q }(),
 			Storage: &NodeStorageConfig{
 				Data: &NodeVolumeConfig{Size: func() *resource.Quantity { q := resource.MustParse("100Gi"); return &q }()},
@@ -388,7 +388,7 @@ func TestGarageNodeValidator_SameNamespaceExplicit(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: testSourceNS},
 		Spec: GarageNodeSpec{
 			ClusterRef: ClusterReference{Name: testCluster, Namespace: testSourceNS}, // explicit but same NS
-			Zone:       "us-east-1",
+			Zone:       testZone,
 			Capacity:   func() *resource.Quantity { q := resource.MustParse("100Gi"); return &q }(),
 			Storage: &NodeStorageConfig{
 				Data: &NodeVolumeConfig{Size: func() *resource.Quantity { q := resource.MustParse("100Gi"); return &q }()},
@@ -398,6 +398,100 @@ func TestGarageNodeValidator_SameNamespaceExplicit(t *testing.T) {
 	_, err := node.validateGarageNode()
 	if err != nil {
 		t.Errorf("same-namespace explicit clusterRef on GarageNode should be allowed: %v", err)
+	}
+}
+
+// ── GarageNodeValidator: EmptyDir volumes (#283) ──────────────────────────────
+
+func mustQty(s string) *resource.Quantity { q := resource.MustParse(s); return &q }
+
+// TestGarageNodeValidator_EmptyDirNoSize verifies the operator's own ephemeral
+// Auto-mode shape — metadata+data of type EmptyDir with no size — passes
+// admission. Before #283 validateVolumeSource rejected it ("must specify
+// existingClaim, size, or readOnly"), so the operator could not create the
+// GarageNode it generated for an EmptyDir cluster.
+func TestGarageNodeValidator_EmptyDirNoSize(t *testing.T) {
+	node := &GarageNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: testSourceNS},
+		Spec: GarageNodeSpec{
+			ClusterRef: ClusterReference{Name: testCluster, Namespace: testSourceNS},
+			Zone:       testZone,
+			Capacity:   mustQty("100Gi"),
+			Storage: &NodeStorageConfig{
+				Metadata: &NodeVolumeConfig{Type: VolumeTypeEmptyDir},
+				Data:     &NodeVolumeConfig{Type: VolumeTypeEmptyDir},
+			},
+		},
+	}
+	if _, err := node.validateGarageNode(); err != nil {
+		t.Errorf("EmptyDir metadata+data with no size should be valid: %v", err)
+	}
+}
+
+// TestGarageNodeValidator_EmptyDirWithSize verifies a sized EmptyDir (the
+// garage-ephemeral-limited shape) is accepted — the size becomes the tmpfs
+// sizeLimit at render time.
+func TestGarageNodeValidator_EmptyDirWithSize(t *testing.T) {
+	node := &GarageNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: testSourceNS},
+		Spec: GarageNodeSpec{
+			ClusterRef: ClusterReference{Name: testCluster, Namespace: testSourceNS},
+			Zone:       testZone,
+			Capacity:   mustQty("100Gi"),
+			Storage: &NodeStorageConfig{
+				Metadata: &NodeVolumeConfig{Type: VolumeTypeEmptyDir, Size: mustQty("1Gi")},
+				Data:     &NodeVolumeConfig{Type: VolumeTypeEmptyDir, Size: mustQty("10Gi")},
+			},
+		},
+	}
+	if _, err := node.validateGarageNode(); err != nil {
+		t.Errorf("EmptyDir metadata+data with size should be valid: %v", err)
+	}
+}
+
+// TestGarageNodeValidator_BareVolumeStillRejected guards the relaxation: a
+// volume with no type, no size, no claim, no readOnly is still an error (this
+// is the invalid shape #283 accidentally produced before the Type fix).
+func TestGarageNodeValidator_BareVolumeStillRejected(t *testing.T) {
+	node := &GarageNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: testSourceNS},
+		Spec: GarageNodeSpec{
+			ClusterRef: ClusterReference{Name: testCluster, Namespace: testSourceNS},
+			Zone:       testZone,
+			Capacity:   mustQty("100Gi"),
+			Storage: &NodeStorageConfig{
+				Data: &NodeVolumeConfig{}, // bare {}
+			},
+		},
+	}
+	if _, err := node.validateGarageNode(); err == nil {
+		t.Error("bare storage.data (no type/size/claim/readOnly) should be rejected")
+	}
+}
+
+// TestGarageNodeValidator_EmptyDirContradictions verifies EmptyDir combined
+// with PVC-only fields (existingClaim / storageClassName) is rejected.
+func TestGarageNodeValidator_EmptyDirContradictions(t *testing.T) {
+	sc := "fast"
+	cases := map[string]*NodeVolumeConfig{
+		"existingClaim":    {Type: VolumeTypeEmptyDir, ExistingClaim: "some-pvc"},
+		"storageClassName": {Type: VolumeTypeEmptyDir, StorageClassName: &sc},
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			node := &GarageNode{
+				ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: testSourceNS},
+				Spec: GarageNodeSpec{
+					ClusterRef: ClusterReference{Name: testCluster, Namespace: testSourceNS},
+					Zone:       testZone,
+					Capacity:   mustQty("100Gi"),
+					Storage:    &NodeStorageConfig{Data: data},
+				},
+			}
+			if _, err := node.validateGarageNode(); err == nil {
+				t.Errorf("EmptyDir + %s should be rejected", name)
+			}
+		})
 	}
 }
 

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -3304,6 +3304,215 @@ spec:
                   dataFsync:
                     description: DataFsync enables fsync for data block writes
                     type: boolean
+                  env:
+                    description: |-
+                      Env is a list of environment variables to set on the Garage container
+                      in the storage tier. These are appended AFTER the operator's built-in vars.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      EnvFrom is a list of sources to populate environment variables in the
+                      Garage container for the storage tier.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
                   layoutPolicy:
                     description: |-
                       LayoutPolicy overrides the cluster layoutPolicy for the storage tier only
@@ -3914,7 +4123,8 @@ spec:
                     pattern: ^(\d+(\.\d+)?\s*(ns|us|ms|s|m|h|d|w|M|y)\s*)+$
                     type: string
                   metadataFsync:
-                    description: MetadataFsync enables fsync for metadata transactions
+                    description: MetadataFsync enables fsync on metadata writes for
+                      this node.
                     type: boolean
                   metadataSnapshotsDir:
                     description: MetadataSnapshotsDir specifies directory for metadata

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -3304,6 +3304,215 @@ spec:
                   dataFsync:
                     description: DataFsync enables fsync for data block writes
                     type: boolean
+                  env:
+                    description: |-
+                      Env is a list of environment variables to set on the Garage container
+                      in the storage tier. These are appended AFTER the operator's built-in vars.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      EnvFrom is a list of sources to populate environment variables in the
+                      Garage container for the storage tier.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
                   layoutPolicy:
                     description: |-
                       LayoutPolicy overrides the cluster layoutPolicy for the storage tier only
@@ -3914,7 +4123,8 @@ spec:
                     pattern: ^(\d+(\.\d+)?\s*(ns|us|ms|s|m|h|d|w|M|y)\s*)+$
                     type: string
                   metadataFsync:
-                    description: MetadataFsync enables fsync for metadata transactions
+                    description: MetadataFsync enables fsync on metadata writes for
+                      this node.
                     type: boolean
                   metadataSnapshotsDir:
                     description: MetadataSnapshotsDir specifies directory for metadata

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -410,6 +410,14 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 		}
 		storage.Metadata.StorageClassName = cluster.Spec.Storage.Metadata.StorageClassName
 		storage.Metadata.AccessModes = cluster.Spec.Storage.Metadata.AccessModes
+		// Propagate the volume type so `storage.metadata.type: EmptyDir` reaches
+		// the per-node GarageNode (#283). Without this the node controller sees a
+		// bare `{}` metadata volume and either produces an invalid StatefulSet
+		// (no size → no PVC template, no EmptyDir, but the pod still mounts `meta`)
+		// or silently provisions a PVC (size set). Mirrors the multi-path branch.
+		if cluster.Spec.Storage.Metadata.Type != "" {
+			storage.Metadata.Type = garagev1beta1.VolumeType(cluster.Spec.Storage.Metadata.Type)
+		}
 	}
 
 	// Data volume(s):
@@ -496,6 +504,13 @@ func (r *GarageClusterReconciler) buildAutoModeStorageNode(
 			}
 			storage.Data.StorageClassName = cluster.Spec.Storage.Data.StorageClassName
 			storage.Data.AccessModes = cluster.Spec.Storage.Data.AccessModes
+			// Propagate the volume type so `storage.data.type: EmptyDir` reaches
+			// the per-node GarageNode (#283) — same rationale as the metadata
+			// block above and the multi-path branch. On EmptyDir any `size` is
+			// carried through as the EmptyDir sizeLimit by the node controller.
+			if cluster.Spec.Storage.Data.Type != "" {
+				storage.Data.Type = garagev1beta1.VolumeType(cluster.Spec.Storage.Data.Type)
+			}
 		}
 	}
 

--- a/internal/controller/garagecluster_automode_gateway.go
+++ b/internal/controller/garagecluster_automode_gateway.go
@@ -173,6 +173,18 @@ func (r *GarageClusterReconciler) buildAutoModeGatewayNode(cluster *garagev1beta
 		storage = &garagev1beta1.NodeStorageConfig{
 			Metadata: &garagev1beta1.NodeVolumeConfig{ExistingClaim: adoptedMetadataPVC},
 		}
+	} else if gw := cluster.Spec.Gateway; gw != nil && gw.Metadata != nil && gw.Metadata.Type == garagev1beta2.VolumeTypeEmptyDir {
+		// Fully-ephemeral gateway metadata (#283): EmptyDir, no PVC. Node identity
+		// is not persisted across restarts — acceptable for throwaway gateways and
+		// already flagged by the cluster webhook's identity warning. Only carry an
+		// explicit size (as the EmptyDir sizeLimit); do NOT inject the 1Gi PVC
+		// default, which would silently bound the tmpfs the user never sized.
+		meta := &garagev1beta1.NodeVolumeConfig{Type: garagev1beta1.VolumeTypeEmptyDir}
+		if gw.Metadata.Size != nil && !gw.Metadata.Size.IsZero() {
+			s := gw.Metadata.Size.DeepCopy()
+			meta.Size = &s
+		}
+		storage = &garagev1beta1.NodeStorageConfig{Metadata: meta}
 	} else {
 		// Metadata PVC sizing: gateway.metadata.size when set, else the 1Gi default.
 		metaSize := gatewayDefaultMetadataSize

--- a/internal/controller/garagecluster_automode_test.go
+++ b/internal/controller/garagecluster_automode_test.go
@@ -63,6 +63,8 @@ func (c *conflictInjectingClient) Update(ctx context.Context, obj client.Object,
 
 // uniqueClusterName returns a per-test cluster name based on the spec subject
 // so each test gets its own resources in the shared testNamespace.
+const testCRUID = "test-uid"
+
 func uniqueClusterName(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 }
@@ -684,7 +686,7 @@ var _ = Describe("buildAutoModeStorageNode PublicEndpoint propagation (bug #7)",
 	}
 	makeCluster := func(name string, ep *garagev1beta2.PublicEndpointConfig) *garagev1beta2.GarageCluster {
 		return &garagev1beta2.GarageCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: "test-uid"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: testCRUID},
 			Spec: garagev1beta2.GarageClusterSpec{
 				LayoutPolicy: LayoutPolicyAuto,
 				Storage: &garagev1beta2.StorageSpec{
@@ -816,6 +818,114 @@ var _ = Describe("buildAutoModeStorageNode PublicEndpoint propagation (bug #7)",
 			Expect(n.Spec.PublicEndpoint.LoadBalancer).NotTo(BeNil())
 			Expect(n.Spec.PublicEndpoint.LoadBalancer.PerNode).To(BeTrue())
 		}
+	})
+})
+
+var _ = Describe("buildAutoModeStorageNode EmptyDir propagation (#283)", func() {
+	makeReconciler := func() *GarageClusterReconciler {
+		return &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+	}
+	makeCluster := func(name string, meta, data *garagev1beta2.VolumeConfig) *garagev1beta2.GarageCluster {
+		return &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: testCRUID},
+			Spec: garagev1beta2.GarageClusterSpec{
+				LayoutPolicy: LayoutPolicyAuto,
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas: 1,
+					Metadata: meta,
+					Data:     data,
+				},
+				Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+			},
+		}
+	}
+
+	It("propagates type=EmptyDir with no size onto the GarageNode (the common ephemeral shape)", func() {
+		// Regression for #283: the generated node used to have bare `{}` volumes,
+		// which the node controller rendered as neither EmptyDir nor PVC — the
+		// StatefulSet mounted meta/data with no matching volume and was rejected.
+		r := makeReconciler()
+		cluster := makeCluster("ephem-nosize",
+			&garagev1beta2.VolumeConfig{Type: garagev1beta2.VolumeTypeEmptyDir},
+			&garagev1beta2.VolumeConfig{Type: garagev1beta2.VolumeTypeEmptyDir},
+		)
+		node, err := r.buildAutoModeStorageNode(cluster, 0, "", "", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Spec.Storage).NotTo(BeNil())
+		Expect(node.Spec.Storage.Metadata).NotTo(BeNil())
+		Expect(node.Spec.Storage.Metadata.Type).To(Equal(garagev1beta1.VolumeTypeEmptyDir))
+		Expect(node.Spec.Storage.Metadata.Size).To(BeNil())
+		Expect(node.Spec.Storage.Data).NotTo(BeNil())
+		Expect(node.Spec.Storage.Data.Type).To(Equal(garagev1beta1.VolumeTypeEmptyDir))
+		Expect(node.Spec.Storage.Data.Size).To(BeNil())
+	})
+
+	It("propagates type=EmptyDir and preserves size (the ephemeral-limited shape)", func() {
+		r := makeReconciler()
+		cluster := makeCluster("ephem-sized",
+			&garagev1beta2.VolumeConfig{Type: garagev1beta2.VolumeTypeEmptyDir, Size: ptrQuantity(resource.MustParse("1Gi"))},
+			&garagev1beta2.VolumeConfig{Type: garagev1beta2.VolumeTypeEmptyDir, Size: ptrQuantity(resource.MustParse("10Gi"))},
+		)
+		node, err := r.buildAutoModeStorageNode(cluster, 0, "", "", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Spec.Storage.Metadata.Type).To(Equal(garagev1beta1.VolumeTypeEmptyDir))
+		Expect(node.Spec.Storage.Metadata.Size).NotTo(BeNil())
+		Expect(node.Spec.Storage.Metadata.Size.Cmp(resource.MustParse("1Gi"))).To(Equal(0))
+		Expect(node.Spec.Storage.Data.Type).To(Equal(garagev1beta1.VolumeTypeEmptyDir))
+		Expect(node.Spec.Storage.Data.Size).NotTo(BeNil())
+		Expect(node.Spec.Storage.Data.Size.Cmp(resource.MustParse("10Gi"))).To(Equal(0))
+	})
+
+	It("leaves type empty (PVC) for a normal persistent cluster", func() {
+		r := makeReconciler()
+		cluster := makeCluster("persistent",
+			&garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+			&garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("100Gi"))},
+		)
+		node, err := r.buildAutoModeStorageNode(cluster, 0, "", "", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Spec.Storage.Metadata.Type).To(BeEmpty())
+		Expect(node.Spec.Storage.Data.Type).To(BeEmpty())
+		Expect(node.Spec.Storage.Data.Size.Cmp(resource.MustParse("100Gi"))).To(Equal(0))
+	})
+})
+
+var _ = Describe("buildAutoModeGatewayNode EmptyDir metadata propagation (#283)", func() {
+	makeReconciler := func() *GarageClusterReconciler {
+		return &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+	}
+	makeCluster := func(name string, gwMeta *garagev1beta2.VolumeConfig) *garagev1beta2.GarageCluster {
+		return &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: testCRUID},
+			Spec: garagev1beta2.GarageClusterSpec{
+				LayoutPolicy: LayoutPolicyAuto,
+				Storage: &garagev1beta2.StorageSpec{
+					Replicas: 1,
+					Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+					Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+				},
+				Gateway:     &garagev1beta2.GatewaySpec{Replicas: 1, Metadata: gwMeta},
+				Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+			},
+		}
+	}
+
+	It("renders EmptyDir metadata without injecting the 1Gi PVC default", func() {
+		r := makeReconciler()
+		cluster := makeCluster("gw-ephem", &garagev1beta2.VolumeConfig{Type: garagev1beta2.VolumeTypeEmptyDir})
+		node, err := r.buildAutoModeGatewayNode(cluster, 0, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Spec.Storage.Metadata.Type).To(Equal(garagev1beta1.VolumeTypeEmptyDir))
+		Expect(node.Spec.Storage.Metadata.Size).To(BeNil(), "EmptyDir gateway metadata must not inherit the 1Gi PVC default")
+	})
+
+	It("keeps a PVC (default 1Gi) when gateway metadata type is unset", func() {
+		r := makeReconciler()
+		cluster := makeCluster("gw-persistent", nil)
+		node, err := r.buildAutoModeGatewayNode(cluster, 0, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Spec.Storage.Metadata.Type).To(BeEmpty())
+		Expect(node.Spec.Storage.Metadata.Size).NotTo(BeNil())
 	})
 })
 

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -768,6 +768,21 @@ func (r *GarageNodeReconciler) lookupPVCCapacity(ctx context.Context, ns, name s
 	return ""
 }
 
+// emptyDirSource builds an EmptyDir volume source, honoring an optional size as
+// the medium's sizeLimit. A sized EmptyDir bounds ephemeral scratch so a runaway
+// pod can't exhaust the node's ephemeral storage (#283) — this is what
+// `type: EmptyDir` + `size: 10Gi` (the garage-ephemeral-limited sample) means.
+// Without a size the volume is unbounded (limited only by node capacity),
+// preserving prior behavior for sizeless ephemeral clusters.
+func emptyDirSource(size *resource.Quantity) *corev1.EmptyDirVolumeSource {
+	src := &corev1.EmptyDirVolumeSource{}
+	if size != nil && !size.IsZero() {
+		s := size.DeepCopy()
+		src.SizeLimit = &s
+	}
+	return src
+}
+
 // buildNodeVolumesAndMounts returns volumes and volume mounts for a GarageNode's StatefulSet.
 func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumeMounts := []corev1.VolumeMount{
@@ -840,7 +855,7 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1beta1.Gar
 			vol := corev1.Volume{Name: nodeMultiHDDDataVolName(i)}
 			switch {
 			case dp.Type == garagev1beta1.VolumeTypeEmptyDir:
-				vol.VolumeSource = corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}
+				vol.VolumeSource = corev1.VolumeSource{EmptyDir: emptyDirSource(dp.Size)}
 				volumes = append(volumes, vol)
 			case dp.ExistingClaim != "":
 				vol.VolumeSource = corev1.VolumeSource{
@@ -851,9 +866,15 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1beta1.Gar
 			// else: dynamically provisioned via VolumeClaimTemplate (no Volume entry needed)
 		}
 	case node.Spec.Gateway || (node.Spec.Storage != nil && node.Spec.Storage.Data != nil && node.Spec.Storage.Data.Type == garagev1beta1.VolumeTypeEmptyDir):
+		// Gateway data is always EmptyDir (no size field); an EmptyDir storage
+		// data volume carries its size through as the sizeLimit (#283).
+		var dataSize *resource.Quantity
+		if node.Spec.Storage != nil && node.Spec.Storage.Data != nil {
+			dataSize = node.Spec.Storage.Data.Size
+		}
 		volumes = append(volumes, corev1.Volume{
 			Name:         dataVolName,
-			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			VolumeSource: corev1.VolumeSource{EmptyDir: emptyDirSource(dataSize)},
 		})
 	case node.Spec.Storage != nil && node.Spec.Storage.Data != nil && node.Spec.Storage.Data.ExistingClaim != "":
 		volumes = append(volumes, corev1.Volume{
@@ -871,7 +892,7 @@ func (r *GarageNodeReconciler) buildNodeVolumesAndMounts(node *garagev1beta1.Gar
 		case node.Spec.Storage.Metadata.Type == garagev1beta1.VolumeTypeEmptyDir:
 			volumes = append(volumes, corev1.Volume{
 				Name:         metadataVolName,
-				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				VolumeSource: corev1.VolumeSource{EmptyDir: emptyDirSource(node.Spec.Storage.Metadata.Size)},
 			})
 		case node.Spec.Storage.Metadata.ExistingClaim != "":
 			volumes = append(volumes, corev1.Volume{

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -1999,3 +1999,79 @@ var _ = Describe("nodesForClusterConfigMap mapper", func() {
 		Expect(r.nodesForClusterConfigMap(bctx, cm)).To(BeEmpty())
 	})
 })
+
+var _ = Describe("buildNodeVolumesAndMounts EmptyDir rendering (#283)", func() {
+	r := &GarageNodeReconciler{}
+	cluster := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "ephem", Namespace: testNamespace},
+		Spec:       garagev1beta2.GarageClusterSpec{Storage: &garagev1beta2.StorageSpec{Replicas: 1}},
+	}
+
+	volByName := func(vols []corev1.Volume, name string) *corev1.Volume {
+		for i := range vols {
+			if vols[i].Name == name {
+				return &vols[i]
+			}
+		}
+		return nil
+	}
+
+	It("renders EmptyDir volumes for a sizeless ephemeral node, and every mount resolves to a volume", func() {
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "ephem-storage-0", Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: cluster.Name},
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Type: garagev1beta1.VolumeTypeEmptyDir},
+					Data:     &garagev1beta1.NodeVolumeConfig{Type: garagev1beta1.VolumeTypeEmptyDir},
+				},
+			},
+		}
+		vols, mounts := r.buildNodeVolumesAndMounts(node, cluster)
+
+		meta := volByName(vols, metadataVolName)
+		Expect(meta).NotTo(BeNil())
+		Expect(meta.EmptyDir).NotTo(BeNil(), "metadata must be an EmptyDir, not a PVC")
+		Expect(meta.EmptyDir.SizeLimit).To(BeNil())
+
+		data := volByName(vols, dataVolName)
+		Expect(data).NotTo(BeNil())
+		Expect(data.EmptyDir).NotTo(BeNil(), "data must be an EmptyDir, not a PVC")
+
+		// The bug: a mount with no backing volume makes the STS invalid. Assert
+		// every mount name resolves to a defined volume.
+		for _, m := range mounts {
+			Expect(volByName(vols, m.Name)).NotTo(BeNil(), "mount %q has no backing volume", m.Name)
+		}
+
+		// And no PVC templates are generated for an all-EmptyDir node.
+		Expect(r.buildNodeVolumeClaimTemplates(node, cluster)).To(BeEmpty())
+	})
+
+	It("sets EmptyDir sizeLimit from the volume size (ephemeral-limited shape)", func() {
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "ephem-storage-0", Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: cluster.Name},
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Type: garagev1beta1.VolumeTypeEmptyDir, Size: ptrQuantity(resource.MustParse("1Gi"))},
+					Data:     &garagev1beta1.NodeVolumeConfig{Type: garagev1beta1.VolumeTypeEmptyDir, Size: ptrQuantity(resource.MustParse("10Gi"))},
+				},
+			},
+		}
+		vols, _ := r.buildNodeVolumesAndMounts(node, cluster)
+
+		meta := volByName(vols, metadataVolName)
+		Expect(meta.EmptyDir).NotTo(BeNil())
+		Expect(meta.EmptyDir.SizeLimit).NotTo(BeNil())
+		Expect(meta.EmptyDir.SizeLimit.Cmp(resource.MustParse("1Gi"))).To(Equal(0))
+
+		data := volByName(vols, dataVolName)
+		Expect(data.EmptyDir).NotTo(BeNil())
+		Expect(data.EmptyDir.SizeLimit).NotTo(BeNil())
+		Expect(data.EmptyDir.SizeLimit.Cmp(resource.MustParse("10Gi"))).To(Equal(0))
+
+		// Still no PVC templates — a sized EmptyDir is a tmpfs sizeLimit, not a PVC.
+		Expect(r.buildNodeVolumeClaimTemplates(node, cluster)).To(BeEmpty())
+	})
+})

--- a/internal/controller/storage_rpcaddr_test.go
+++ b/internal/controller/storage_rpcaddr_test.go
@@ -37,7 +37,7 @@ var _ = Describe("buildAutoModeStorageNode rpc_public_addr per-ordinal (#cross-r
 	}
 	makeCluster := func(name, rpcAddr string, ep *garagev1beta2.PublicEndpointConfig) *garagev1beta2.GarageCluster {
 		return &garagev1beta2.GarageCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: "test-uid"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: testCRUID},
 			Spec: garagev1beta2.GarageClusterSpec{
 				LayoutPolicy: LayoutPolicyAuto,
 				Storage: &garagev1beta2.StorageSpec{

--- a/schemas/garagecluster_v1beta1.json
+++ b/schemas/garagecluster_v1beta1.json
@@ -2964,6 +2964,213 @@
               "description": "DataFsync enables fsync for data block writes",
               "type": "boolean"
             },
+            "env": {
+              "description": "Env is a list of environment variables to set on the Garage container\nin the storage tier. These are appended AFTER the operator's built-in vars.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fileKeyRef": {
+                        "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                        "properties": {
+                          "key": {
+                            "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "default": false,
+                            "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                            "type": "boolean"
+                          },
+                          "path": {
+                            "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "The name of the volume mount containing the env file.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "path",
+                          "volumeName"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "envFrom": {
+              "description": "EnvFrom is a list of sources to populate environment variables in the\nGarage container for the storage tier.",
+              "items": {
+                "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                "properties": {
+                  "configMapRef": {
+                    "description": "The ConfigMap to select from",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "prefix": {
+                    "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "The Secret to select from",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "layoutPolicy": {
               "description": "LayoutPolicy overrides the cluster layoutPolicy for the storage tier only\n(Auto/Manual). Round-trips losslessly with v1beta2 spec.storage.layoutPolicy.",
               "type": "string"
@@ -3547,7 +3754,7 @@
               "type": "string"
             },
             "metadataFsync": {
-              "description": "MetadataFsync enables fsync for metadata transactions",
+              "description": "MetadataFsync enables fsync on metadata writes for this node.",
               "type": "boolean"
             },
             "metadataSnapshotsDir": {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4108,6 +4108,184 @@ spec:
 	})
 })
 
+// Auto Mode EmptyDir (ephemeral) — regression for #283. Before the fix, an
+// Auto-mode cluster with storage.{metadata,data}.type=EmptyDir dropped the type
+// when projecting to per-node GarageNodes, so the sizeless ephemeral shape
+// produced an invalid StatefulSet (pod never started) and the sized shape
+// silently provisioned PVCs. This exercises the sizeless shape end-to-end: the
+// pod must reach Running with EmptyDir volumes and NO PVCs.
+var _ = Describe("Auto Mode EmptyDir (ephemeral)", Ordered, Label("auto-mode-ephemeral"), func() {
+	const testNamespace = "garage-auto-ephemeral-test"
+	const clusterName = "ephem-cluster"
+	const nodeName = "ephem-cluster-storage-0"
+
+	BeforeAll(func() {
+		By("creating manager namespace")
+		_, _ = utils.Run(exec.Command("kubectl", "create", "ns", namespace))
+
+		By("labeling the manager namespace to enforce the restricted security policy")
+		_, _ = utils.Run(exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+			"pod-security.kubernetes.io/enforce=restricted"))
+
+		By("installing CRDs")
+		_, err := utils.Run(exec.Command("make", "install"))
+		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+		By("waiting for Garage CRDs to be Established")
+		Expect(utils.WaitCRDsEstablished()).To(Succeed())
+
+		By("deploying the controller-manager")
+		_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage)))
+		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+		By("waiting for controller-manager pod to be Ready (webhook server started)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+				"-n", namespace,
+				"-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"), "Controller not Ready: %s", output)
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("creating test namespace")
+		_, _ = utils.Run(exec.Command("kubectl", "create", "ns", testNamespace))
+		_, err = utils.Run(exec.Command("kubectl", "label", "--overwrite", "ns", testNamespace,
+			"pod-security.kubernetes.io/enforce=restricted"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		cleanupAuto190(testNamespace, clusterName, []string{nodeName})
+	})
+
+	It("should boot a sizeless EmptyDir Auto cluster with an EmptyDir-backed pod and no PVCs", func() {
+		By("creating admin token secret")
+		adminTokenSecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-admin-token
+  namespace: %s
+type: Opaque
+stringData:
+  admin-token: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+`, testNamespace)
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(adminTokenSecret)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create admin token secret")
+
+		By("creating an ephemeral GarageCluster (metadata+data type=EmptyDir, no size)")
+		clusterYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  layoutPolicy: Auto
+  zone: us-test
+  replication:
+    factor: 1
+  storage:
+    replicas: 1
+    metadata:
+      type: EmptyDir
+    data:
+      type: EmptyDir
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        memory: 128Mi
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  admin:
+    adminTokenSecretRef:
+      name: garage-admin-token
+      key: admin-token
+  security:
+    allowInsecureSecretPermissions: true
+`, clusterName, testNamespace)
+
+		By("applying GarageCluster (retry until admission webhook is up)")
+		Eventually(func(g Gomega) {
+			c := exec.Command("kubectl", "apply", "-f", "-")
+			c.Stdin = strings.NewReader(clusterYAML)
+			out, err := utils.Run(c)
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to create GarageCluster: %s", out)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the per-node GarageNode is created")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagenode", nodeName,
+				"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal(nodeName))
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the StatefulSet's metadata and data volumes are EmptyDir")
+		Eventually(func(g Gomega) {
+			for _, vol := range []string{"metadata", "data"} {
+				cmd := exec.Command("kubectl", "get", "statefulset", nodeName, "-n", testNamespace,
+					"-o", fmt.Sprintf("jsonpath={.spec.template.spec.volumes[?(@.name==%q)].emptyDir}", vol))
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("{}"), "volume %q must be EmptyDir, got %q", vol, output)
+			}
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the storage pod reaches Running")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pod", nodeName+"-0",
+				"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Running"), "Pod %s-0 not running: %s", nodeName, output)
+		}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying NO PersistentVolumeClaims were created for the ephemeral cluster")
+		cmd = exec.Command("kubectl", "get", "pvc", "-n", testNamespace,
+			"-o", "jsonpath={.items[*].metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Fields(output)).To(BeEmpty(),
+			"ephemeral EmptyDir cluster must not provision PVCs, found: %q", output)
+
+		By("verifying the node connects and joins the layout (cluster is functional, not just started)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagenode", nodeName,
+				"-n", testNamespace, "-o", "jsonpath={.status.connected}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("true"), "GarageNode %s not connected: %q", nodeName, output)
+
+			cmd = exec.Command("kubectl", "get", "garagenode", nodeName,
+				"-n", testNamespace, "-o", "jsonpath={.status.inLayout}")
+			output, err = utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("true"), "GarageNode %s not in layout: %q", nodeName, output)
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+	})
+})
+
 // LayoutPolicy webhook — covers issue #190: the webhook rejects Manual→Auto
 // transitions because Auto mode would attempt to take over user-managed
 // GarageNodes (one-way migration only).


### PR DESCRIPTION
Fixes #283.

## Problem

Since the per-node GarageNode reshape of Auto mode (#192, v0.6.0),
`buildAutoModeStorageNode` copied `size`/`storageClassName`/`accessModes` from
the cluster's `spec.storage.{metadata,data}` into the generated per-node
`GarageNode` but dropped `type`. Depending on whether `size` was set, an
EmptyDir Auto-mode cluster either produced an **invalid StatefulSet** (pod
never starts) or **silently became PVC-backed**:

- **No size** (the common ephemeral shape, `garage_v1beta1_garagecluster_ephemeral.yaml`):
  the generated node had bare `storage.metadata: {}` / `storage.data: {}`. The
  node controller made no EmptyDir (type empty), no inline PVC (no
  existingClaim), and no volumeClaimTemplate (size nil) — but the pod template
  still mounted `meta`/`data`, so the API server rejected the StatefulSet.
- **Size set** (`garage-ephemeral-limited`): the size survived, the type didn't,
  so the node controller provisioned real PVCs. An explicitly-ephemeral cluster
  silently got persistent volumes.

Migrating an existing ≤v0.5 EmptyDir cluster to v0.6.x hit the same broken
fresh-create path, since EmptyDir clusters have no PVCs to adopt.

## Why the reporter's two-line suggestion wasn't enough

Propagating `type` alone still fails: the operator's own generated
`{type: EmptyDir}` node with no size was **rejected by the GarageNode
validating webhook** (`validateVolumeSource`: "must specify existingClaim,
size, or readOnly"). So the no-size ephemeral shape stayed broken. This PR
closes the whole class end-to-end.

## Changes

- **`buildAutoModeStorageNode`** — propagate `Type` on the metadata and
  single-volume data blocks, mirroring the multi-path branch that already did.
- **`buildAutoModeGatewayNode`** — same bug on the gateway metadata block:
  `spec.gateway.metadata.type: EmptyDir` (a legitimate fully-ephemeral gateway)
  silently became a PVC. Now EmptyDir-backed, and the 1Gi PVC default is not
  injected as a phantom tmpfs `sizeLimit`.
- **`validateVolumeSource`** — `EmptyDir` is a self-contained volume source and
  satisfies the requirement on its own (like `readOnly` does); the contradictory
  `EmptyDir + existingClaim` / `EmptyDir + storageClassName` combinations are
  rejected, symmetric with the cluster webhook.
- **Rendering** — EmptyDir volumes now carry `size` through as the medium
  `sizeLimit` (metadata, single data, multi-HDD). This honors the
  `-limited` sample's `size: 10Gi` (bound ephemeral scratch so a runaway pod
  can't fill the node) — previously `size` on an EmptyDir was silently dropped.

No CRD/API changes.

## A note on `needsUpdate`

Deliberately **not** adding `Type` to the `needsUpdate` comparators. The node
controller renders from the `GarageNode` CR, so leaving `Type` out keeps a
pre-fix node's CR unchanged and avoids an immutable-`volumeClaimTemplates`
collision (a new EmptyDir pod-template volume vs. the existing PVC template
of the same name) that would hard-loop the STS update. The remedy for a rare
already-created wrong node is to delete it and let the operator recreate it
(ephemeral data, so this is safe).

## Tests

- Unit: `buildAutoModeStorageNode` (EmptyDir no-size / EmptyDir+size / PVC) and
  `buildAutoModeGatewayNode` (EmptyDir metadata) projection.
- Unit: `validateVolumeSource` accepts EmptyDir w/o size, still rejects bare
  `{}`, rejects the contradictions.
- Render: an EmptyDir node yields EmptyDir volumes (no PVC templates), every
  mount resolves to a defined volume, and `sizeLimit` is set when sized.
- e2e: boots the ephemeral sample under Auto mode and asserts the pod reaches
  Running with EmptyDir volumes, **no PVCs**, and the node joins the layout.
  (Previously the e2e only asserted the EmptyDir webhook *warning*, not that the
  cluster reconciled.)

Verified the new specs fail on the un-fixed code.
