### PR TITLE
fix(automode): migrate EmptyDir legacy StatefulSets without requiring PVCs (#286)

### DIFF
--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -947,20 +947,47 @@ func (r *GarageClusterReconciler) migrateLegacyStorageSTSIfNeeded(ctx context.Co
 	// belt-and-suspenders).
 	nodeIDByOrdinal := r.discoverLegacyNodeIDsByOrdinal(ctx, cluster, replicas)
 
-	for ord := int32(0); ord < replicas; ord++ {
-		metadataPVC := fmt.Sprintf("%s-%s-%d", metadataVolName, cluster.Name, ord)
+	// Whether the legacy STS provisioned each volume via a volumeClaimTemplate.
+	// A pre-v0.6 EmptyDir cluster (#286) has no volumeClaimTemplates, so there
+	// is nothing to adopt — migration for those volumes is "create fresh" and
+	// buildAutoModeStorageNode renders EmptyDir from spec.storage (post-#284).
+	// This is spec-independent: it reflects what the running workload actually
+	// has, so a cluster whose spec drifted still migrates against reality. A
+	// PVC-backed legacy volume is always adopted (preserving data + the
+	// node_key that fixes node identity) regardless of the current spec type.
+	legacyVCTNames := map[string]bool{}
+	for i := range legacySTS.Spec.VolumeClaimTemplates {
+		legacyVCTNames[legacySTS.Spec.VolumeClaimTemplates[i].Name] = true
+	}
+	metadataIsPVC := legacyVCTNames[metadataVolName]
+	dataIsPVC := legacyVCTNames[dataVolName]
 
-		// Verify the metadata PVC exists; abort if not.
-		mPVC := &corev1.PersistentVolumeClaim{}
-		if err := r.Get(ctx, types.NamespacedName{Name: metadataPVC, Namespace: cluster.Namespace}, mPVC); err != nil {
-			msg := fmt.Sprintf("ordinal %d: metadata PVC %q not found: %v", ord, metadataPVC, err)
-			return r.failMigration(ctx, cluster, msg)
+	for ord := int32(0); ord < replicas; ord++ {
+		nodeID := nodeIDByOrdinal[ord]
+
+		// Metadata: adopt the legacy PVC by name only when the legacy STS was
+		// PVC-backed. For EmptyDir metadata there is no PVC and no persisted
+		// node_key, so leave metadataPVC empty (fresh EmptyDir volume) and drop
+		// any discovered node ID — it is stale the moment the fresh pod boots
+		// with a new identity.
+		metadataPVC := ""
+		if metadataIsPVC {
+			metadataPVC = fmt.Sprintf("%s-%s-%d", metadataVolName, cluster.Name, ord)
+			mPVC := &corev1.PersistentVolumeClaim{}
+			if err := r.Get(ctx, types.NamespacedName{Name: metadataPVC, Namespace: cluster.Namespace}, mPVC); err != nil {
+				msg := fmt.Sprintf("ordinal %d: metadata PVC %q not found: %v", ord, metadataPVC, err)
+				return r.failMigration(ctx, cluster, msg)
+			}
+		} else {
+			nodeID = ""
 		}
 
 		// Resolve the data PVCs for this ordinal. Prefer the multi-HDD layout
-		// when present; otherwise fall back to the single-HDD name.
+		// when present; otherwise fall back to the single-HDD name — but only
+		// when the legacy data volume was PVC-backed. EmptyDir data has nothing
+		// to adopt, so leave dataPVCs empty (fresh EmptyDir volume via spec).
 		dataPVCs := dataPVCsByOrdinal[ord]
-		if len(dataPVCs) == 0 {
+		if len(dataPVCs) == 0 && dataIsPVC {
 			single := fmt.Sprintf("%s-%s-%d", dataVolName, cluster.Name, ord)
 			dPVC := &corev1.PersistentVolumeClaim{}
 			if err := r.Get(ctx, types.NamespacedName{Name: single, Namespace: cluster.Namespace}, dPVC); err != nil {
@@ -970,7 +997,7 @@ func (r *GarageClusterReconciler) migrateLegacyStorageSTSIfNeeded(ctx context.Co
 			dataPVCs = []legacyDataPVC{{name: single, size: pvcRequestedStorage(dPVC)}}
 		}
 
-		desired, err := r.buildAutoModeStorageNode(cluster, ord, nodeIDByOrdinal[ord], metadataPVC, dataPVCs)
+		desired, err := r.buildAutoModeStorageNode(cluster, ord, nodeID, metadataPVC, dataPVCs)
 		if err != nil {
 			return fmt.Errorf("building migrated GarageNode for ordinal %d: %w", ord, err)
 		}

--- a/internal/controller/garagecluster_automode_test.go
+++ b/internal/controller/garagecluster_automode_test.go
@@ -343,8 +343,9 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 
 			// Seed a legacy STS plus multi-HDD PVCs (two disks per ordinal,
-			// two ordinals → 4 data PVCs + 2 metadata PVCs).
-			legacySTS := makeFakeLegacySTS(clusterNN.Name, 2)
+			// two ordinals → 4 data PVCs + 2 metadata PVCs). The legacy STS
+			// declares one VCT per provisioned volume.
+			legacySTS := makeFakeLegacySTS(clusterNN.Name, 2, metadataVolName, "data-0", "data-1")
 			Expect(k8sClient.Create(ctx, legacySTS)).To(Succeed())
 			for ord := 0; ord < 2; ord++ {
 				Expect(k8sClient.Create(ctx, makeFakePVC(fmt.Sprintf("metadata-%s-%d", clusterNN.Name, ord)))).To(Succeed())
@@ -397,8 +398,8 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 
 			// Legacy STS scaled to zero, but PVCs from the original 2-replica
 			// run are still around — exactly the data-loss scenario the guard
-			// closes (audit #6).
-			legacySTS := makeFakeLegacySTS(clusterNN.Name, 0)
+			// closes (audit #6). PVC-backed, so it declares its VCTs.
+			legacySTS := makeFakeLegacySTS(clusterNN.Name, 0, metadataVolName, dataVolName)
 			Expect(k8sClient.Create(ctx, legacySTS)).To(Succeed())
 			Expect(k8sClient.Create(ctx, makeFakePVC(fmt.Sprintf("metadata-%s-0", clusterNN.Name)))).To(Succeed())
 			Expect(k8sClient.Create(ctx, makeFakePVC(fmt.Sprintf("data-%s-0", clusterNN.Name)))).To(Succeed())
@@ -439,8 +440,9 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 			}
 			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 
-			// Seed a legacy STS named after the cluster + its PVCs.
-			legacySTS := makeFakeLegacySTS(clusterNN.Name, 2)
+			// Seed a legacy STS named after the cluster + its PVCs. PVC-backed,
+			// so it declares metadata + data volumeClaimTemplates.
+			legacySTS := makeFakeLegacySTS(clusterNN.Name, 2, metadataVolName, dataVolName)
 			Expect(k8sClient.Create(ctx, legacySTS)).To(Succeed())
 			for ord := 0; ord < 2; ord++ {
 				Expect(k8sClient.Create(ctx, makeFakePVC(fmt.Sprintf("metadata-%s-%d", clusterNN.Name, ord)))).To(Succeed())
@@ -466,6 +468,59 @@ var _ = Describe("GarageCluster Auto-mode (#190)", func() {
 			}
 
 			// Legacy STS was orphan-deleted (envtest may take a moment).
+			Eventually(func() bool {
+				sts := &appsv1.StatefulSet{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterNN.Name, Namespace: testNamespace}, sts)
+				return errors.IsNotFound(err) || (err == nil && !sts.DeletionTimestamp.IsZero())
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("migrates an EmptyDir legacy STS (no PVCs to adopt) to fresh EmptyDir GarageNodes (#286)", func() {
+			clusterNN = types.NamespacedName{Name: uniqueClusterName("auto-mig-ephem"), Namespace: testNamespace}
+			cluster = &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterNN.Name, Namespace: testNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					LayoutPolicy: LayoutPolicyAuto,
+					Storage: &garagev1beta2.StorageSpec{
+						Replicas: 2,
+						Metadata: &garagev1beta2.VolumeConfig{Type: garagev1beta2.VolumeTypeEmptyDir},
+						Data:     &garagev1beta2.VolumeConfig{Type: garagev1beta2.VolumeTypeEmptyDir},
+					},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			// Legacy EmptyDir STS: no volumeClaimTemplates, and (crucially) NO
+			// metadata/data PVCs exist. Pre-#286 the per-ordinal loop called
+			// failMigration on the missing metadata PVC and the cluster stuck.
+			legacySTS := makeFakeLegacySTS(clusterNN.Name, 2)
+			Expect(k8sClient.Create(ctx, legacySTS)).To(Succeed())
+
+			Expect(reconciler.migrateLegacyStorageSTSIfNeeded(ctx, cluster)).To(Succeed())
+
+			updated := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, clusterNN, updated)).To(Succeed())
+			cond := meta.FindStatusCondition(updated.Status.Conditions, garagev1beta1.ConditionLegacySTSMigrated)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("Completed"))
+
+			// Fresh EmptyDir GarageNodes: type propagated from spec, no
+			// existingClaim, and no stale node ID adopted (EmptyDir has no
+			// persisted node_key).
+			gnList := listOperatorOwnedStorageNodes(clusterNN.Name)
+			Expect(gnList.Items).To(HaveLen(2))
+			for _, n := range gnList.Items {
+				Expect(n.Spec.Storage).NotTo(BeNil())
+				Expect(n.Spec.Storage.Metadata.Type).To(Equal(garagev1beta1.VolumeTypeEmptyDir))
+				Expect(n.Spec.Storage.Metadata.ExistingClaim).To(BeEmpty())
+				Expect(n.Spec.Storage.Data.Type).To(Equal(garagev1beta1.VolumeTypeEmptyDir))
+				Expect(n.Spec.Storage.Data.ExistingClaim).To(BeEmpty())
+				Expect(n.Spec.NodeID).To(BeEmpty())
+			}
+
+			// Legacy STS was orphan-deleted.
 			Eventually(func() bool {
 				sts := &appsv1.StatefulSet{}
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterNN.Name, Namespace: testNamespace}, sts)
@@ -1016,17 +1071,32 @@ func listOperatorOwnedStorageNodes(clusterName string) *garagev1beta1.GarageNode
 	return gnList
 }
 
-// makeFakeLegacySTS returns a minimal pre-#190 storage StatefulSet for testing
-// migration. The pod template is bare-bones because the test never actually
-// schedules pods.
-func makeFakeLegacySTS(clusterName string, replicas int32) *appsv1.StatefulSet {
+// makeFakeLegacySTS returns a minimal pre-#190 storage StatefulSet. vctNames are
+// the volumeClaimTemplate names it provisioned — a real PVC-backed legacy STS
+// declares "metadata"+"data" (single-HDD) or "metadata"+"data-0"+"data-1"…
+// (multi-HDD); a pre-v0.6 EmptyDir cluster declares none. Migration keys off
+// these to decide what to adopt vs. recreate fresh (#286).
+func makeFakeLegacySTS(clusterName string, replicas int32, vctNames ...string) *appsv1.StatefulSet {
 	labels := map[string]string{labelCluster: clusterName, labelTier: tierStorage}
+	vcts := make([]corev1.PersistentVolumeClaim, 0, len(vctNames))
+	for _, name := range vctNames {
+		vcts = append(vcts, corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		})
+	}
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace, Labels: labels},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName: clusterName + "-headless",
-			Replicas:    ptr.To(replicas),
-			Selector:    &metav1.LabelSelector{MatchLabels: labels},
+			ServiceName:          clusterName + "-headless",
+			Replicas:             ptr.To(replicas),
+			Selector:             &metav1.LabelSelector{MatchLabels: labels},
+			VolumeClaimTemplates: vcts,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4286,6 +4286,223 @@ spec:
 	})
 })
 
+// Auto Mode EmptyDir legacy-STS migration — regression for #286. A pre-v0.6
+// EmptyDir cluster has a legacy cluster-level StatefulSet but no PVCs; before
+// the fix, migrateLegacyStorageSTSIfNeeded required the metadata/data PVCs and
+// failed, permanently wedging the cluster. This seeds a legacy EmptyDir STS,
+// then creates the GarageCluster and asserts the operator migrates it to a
+// fresh EmptyDir-backed per-node GarageNode (no PVCs) and removes the legacy STS.
+var _ = Describe("Auto Mode EmptyDir migration", Ordered, Label("auto-mode-ephemeral"), func() {
+	const testNamespace = "garage-auto-migration-test"
+	const clusterName = "mig-ephem-cluster"
+	const nodeName = "mig-ephem-cluster-storage-0"
+
+	BeforeAll(func() {
+		By("creating manager namespace")
+		_, _ = utils.Run(exec.Command("kubectl", "create", "ns", namespace))
+		_, _ = utils.Run(exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+			"pod-security.kubernetes.io/enforce=restricted"))
+
+		By("installing CRDs")
+		_, err := utils.Run(exec.Command("make", "install"))
+		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+		Expect(utils.WaitCRDsEstablished()).To(Succeed())
+
+		By("deploying the controller-manager")
+		_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage)))
+		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+		By("waiting for controller-manager pod to be Ready (webhook server started)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+				"-n", namespace,
+				"-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"), "Controller not Ready: %s", output)
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("creating test namespace")
+		_, _ = utils.Run(exec.Command("kubectl", "create", "ns", testNamespace))
+		_, err = utils.Run(exec.Command("kubectl", "label", "--overwrite", "ns", testNamespace,
+			"pod-security.kubernetes.io/enforce=restricted"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		cleanupAuto190(testNamespace, clusterName, []string{nodeName})
+	})
+
+	It("migrates a legacy EmptyDir StatefulSet (no PVCs) to a fresh EmptyDir per-node GarageNode", func() {
+		By("seeding a legacy EmptyDir cluster-level StatefulSet (no volumeClaimTemplates)")
+		legacySTS := fmt.Sprintf(`
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+  labels:
+    garage.rajsingh.info/cluster: %[1]s
+    garage.rajsingh.info/tier: storage
+spec:
+  serviceName: %[1]s-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      garage.rajsingh.info/cluster: %[1]s
+      garage.rajsingh.info/tier: storage
+  template:
+    metadata:
+      labels:
+        garage.rajsingh.info/cluster: %[1]s
+        garage.rajsingh.info/tier: storage
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: garage
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep 100000"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: metadata
+              mountPath: /var/lib/garage/meta
+            - name: data
+              mountPath: /var/lib/garage/data
+      volumes:
+        - name: metadata
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+`, clusterName, testNamespace)
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(legacySTS)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create legacy STS")
+
+		By("creating admin token secret")
+		adminTokenSecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-admin-token
+  namespace: %s
+type: Opaque
+stringData:
+  admin-token: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+`, testNamespace)
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(adminTokenSecret)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create admin token secret")
+
+		By("creating the ephemeral GarageCluster over the legacy STS")
+		clusterYAML := fmt.Sprintf(`
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  layoutPolicy: Auto
+  zone: us-test
+  replication:
+    factor: 1
+  storage:
+    replicas: 1
+    metadata:
+      type: EmptyDir
+    data:
+      type: EmptyDir
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        memory: 128Mi
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  admin:
+    adminTokenSecretRef:
+      name: garage-admin-token
+      key: admin-token
+  security:
+    allowInsecureSecretPermissions: true
+`, clusterName, testNamespace)
+		Eventually(func(g Gomega) {
+			c := exec.Command("kubectl", "apply", "-f", "-")
+			c.Stdin = strings.NewReader(clusterYAML)
+			out, err := utils.Run(c)
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to create GarageCluster: %s", out)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying migration completes (LegacySTSMigrated=Completed)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagecluster", clusterName, "-n", testNamespace,
+				"-o", "jsonpath={.status.conditions[?(@.type=='LegacySTSMigrated')].reason}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Completed"), "migration not Completed: %q", output)
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the legacy cluster-level StatefulSet was removed")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "statefulset", clusterName, "-n", testNamespace)
+			_, err := utils.Run(cmd)
+			g.Expect(err).To(HaveOccurred(), "legacy STS %q should have been orphan-deleted", clusterName)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying a fresh per-node GarageNode was created")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "garagenode", nodeName, "-n", testNamespace,
+				"-o", "jsonpath={.metadata.name}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal(nodeName))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the migrated pod runs EmptyDir-backed with no PVCs")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pod", nodeName+"-0", "-n", testNamespace,
+				"-o", "jsonpath={.status.phase}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Running"), "migrated pod %s-0 not running: %s", nodeName, output)
+		}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+		cmd = exec.Command("kubectl", "get", "pvc", "-n", testNamespace,
+			"-o", "jsonpath={.items[*].metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Fields(output)).To(BeEmpty(),
+			"migrated EmptyDir cluster must not provision PVCs, found: %q", output)
+	})
+})
+
 // LayoutPolicy webhook — covers issue #190: the webhook rejects Manual→Auto
 // transitions because Auto mode would attempt to take over user-managed
 // GarageNodes (one-way migration only).


### PR DESCRIPTION
Fixes #286. Follow-up to #283/#284.

## Problem

`migrateLegacyStorageSTSIfNeeded` unconditionally required the legacy
`metadata-<cluster>-<N>` and `data-<cluster>-<N>` PVCs and called `failMigration`
when they were absent. A pre-v0.6 **EmptyDir** cluster never had PVCs, so every
EmptyDir cluster with a legacy StatefulSet failed migration on upgrade to v0.6.x:

```
Ready: ReconcileFailed — legacy STS migration: storage migration failed:
ordinal 0: metadata PVC "metadata-preview-garage-0" not found
```

The failure is non-destructive (it happens before the orphan-delete, so the
legacy STS keeps running), but the cluster is then **permanently stuck** —
reconciliation aborts at the migration step every pass, so no later spec change
is ever applied. The reporter hit this on 33 of 34 clusters upgrading v0.5.11 → v0.6.27.

#284 fixed the *builder* (fresh-create propagates `type: EmptyDir`); this fixes
the *migration precondition*, which still assumed PVC-backed storage.

## Fix

Detect what the legacy STS **actually provisioned** by inspecting its
`spec.volumeClaimTemplates` — spec-independent, reflects the running workload:

- **PVC-backed volume** (a matching `volumeClaimTemplate` exists) → adopt the PVC
  by name, exactly as before (preserves data + the `node_key` that fixes node
  identity), regardless of the current spec type.
- **EmptyDir volume** (no template) → nothing to adopt; pass empty to
  `buildAutoModeStorageNode`, which renders it EmptyDir from `spec.storage` (the
  #284 fresh-create path). For EmptyDir metadata there is no persisted
  `node_key`, so the discovered node ID is dropped too — it would be stale the
  moment the fresh pod boots with a new identity.

This also covers a cluster whose spec drifted (e.g. PVC→EmptyDir): migration
follows the *actual* legacy workload, and PVC-backed data is never silently
discarded.

The reporter's manual workaround (`kubectl delete sts <cluster>` → the
`IsNotFound` path marks Completed and fresh nodes come up) is no longer needed.

## Tests

- **Unit**: an EmptyDir legacy STS (no `volumeClaimTemplates`, no PVCs) migrates
  to fresh EmptyDir GarageNodes (type from spec, empty `existingClaim`, empty
  `nodeID`) and the legacy STS is orphan-deleted. Verified this fails on the
  pre-fix code with the exact "metadata PVC ... not found" error from the issue.
- `makeFakeLegacySTS` now declares `volumeClaimTemplates` (variadic names) so the
  PVC-backed single-/multi-HDD migration fixtures are realistic; EmptyDir tests
  pass none. Existing migration tests still pass.
- **e2e** (auto-mode-ephemeral shard): seeds a legacy EmptyDir StatefulSet, then
  creates the GarageCluster and asserts the operator migrates it to a fresh
  EmptyDir-backed per-node pod (Running, no PVCs) with the legacy STS removed —
  closing the migration gap the reporter noted (#284's e2e covers fresh create only).

No CRD/API changes.
