### PR TITLE
ci: sign release artifacts and publish provenance + SBOM attestations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign image (keyless)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Keyless signing (cosign) and the attest-* actions both mint a short-lived
+      # Sigstore certificate from the workflow's OIDC identity — no secrets.
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -78,6 +82,7 @@ jobs:
           echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -91,4 +96,66 @@ jobs:
             BUILD_DATE=${{ steps.version.outputs.BUILD_DATE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # buildx SLSA attestations stay off on purpose: they add
+          # unknown/unknown platform entries to the image index, which trips
+          # up tooling that enumerates platforms. Provenance is published
+          # below as an OCI referrer instead, which leaves the index clean.
           provenance: false
+
+      # --- Supply-chain attestations (release path only) -------------------
+      # Everything below signs the immutable digest, so a single invocation
+      # covers every tag that resolves to it.
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v4
+
+      - name: Sign image (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE_DIGEST}"
+
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Summary
+        if: github.event_name != 'pull_request'
+        run: |
+          {
+            echo "### Image published"
+            echo
+            echo "**Digest:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}\`"
+            echo
+            echo "Signed with keyless cosign; provenance and SPDX SBOM attached as OCI referrers."
+            echo
+            echo '```bash'
+            echo "cosign verify ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }} \\"
+            echo "  --certificate-identity-regexp '^https://github.com/${{ github.repository }}/\\.github/workflows/docker\\.yml@refs/' \\"
+            echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -131,7 +131,7 @@ jobs:
           version: v4.2.3
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -115,6 +115,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Keyless signing + provenance attestation for the OCI chart.
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -126,6 +129,9 @@ jobs:
         uses: azure/setup-helm@v5
         with:
           version: v4.2.3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
@@ -148,8 +154,32 @@ jobs:
           helm package charts/${{ env.CHART_NAME }} -d dist/
 
       - name: Push chart to GHCR
+        id: push
         run: |
-          helm push dist/${{ env.CHART_NAME }}-${{ steps.chart_version.outputs.VERSION }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+          # helm writes "Pushed:"/"Digest:" to stderr; fold it into stdout so the
+          # digest can be captured for signing.
+          OUT=$(helm push \
+            "dist/${{ env.CHART_NAME }}-${{ steps.chart_version.outputs.VERSION }}.tgz" \
+            "oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts" 2>&1)
+          echo "$OUT"
+          DIGEST=$(echo "$OUT" | awk '/^Digest: /{print $2}')
+          case "$DIGEST" in
+            sha256:*) ;;
+            *) echo "::error::could not parse chart digest from helm push output"; exit 1 ;;
+          esac
+          echo "DIGEST=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart (keyless)
+        env:
+          CHART_DIGEST: ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/${{ env.CHART_NAME }}@${{ steps.push.outputs.DIGEST }}
+        run: cosign sign --yes "${CHART_DIGEST}"
+
+      - name: Attest chart provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/${{ env.CHART_NAME }}
+          subject-digest: ${{ steps.push.outputs.DIGEST }}
+          push-to-registry: true
 
       - name: Summary
         run: |
@@ -158,6 +188,7 @@ jobs:
           echo "**Chart:** ${{ env.CHART_NAME }}" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.chart_version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "**Registry:** oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/${{ env.CHART_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Digest:** ${{ steps.push.outputs.DIGEST }} (signed, provenance attested)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Install command:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
     permissions:
       contents: write
       packages: read
+      # Provenance attestation for the install.yaml release asset.
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -42,6 +45,11 @@ jobs:
       - name: Generate install manifests
         run: |
           make build-installer IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
+
+      - name: Attest install manifest provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/install.yaml
 
       - name: Generate changelog
         id: changelog

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -682,6 +682,23 @@ Import test: `go get git.deuxfleurs.fr/garage-sdk/garage-admin-sdk-golang` succe
 | `helm.yml` | Helm chart lint, verify CRDs, verify version, push to OCI registry |
 | `release.yml` | GitHub release with install.yaml |
 
+### Supply-chain attestations (#292)
+
+Every non-PR build signs and attests the **digest**, so one invocation covers
+all tags pointing at it:
+
+- `docker.yml` — keyless `cosign sign`, `actions/attest-build-provenance`, and
+  an SPDX SBOM (`anchore/sbom-action` → `actions/attest-sbom`), all pushed to
+  GHCR as OCI referrers (`push-to-registry: true`).
+- `helm.yml` — the OCI chart is signed and provenance-attested at the digest
+  parsed out of `helm push` output.
+- `release.yml` — provenance attestation for the `dist/install.yaml` asset.
+
+`provenance: false` stays on `docker/build-push-action` deliberately: buildx's
+inline SLSA attestation adds `unknown/unknown` platform entries to the image
+index. The referrer-based attestations above keep the index clean. Jobs need
+`id-token: write` + `attestations: write`; there are no secrets to rotate.
+
 ```bash
 # Install
 kubectl apply -f https://github.com/rajsinghtech/garage-operator/releases/latest/download/install.yaml

--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ helm install garage-operator oci://ghcr.io/rajsinghtech/charts/garage-operator \
   --set webhooks.enabled=false
 ```
 
+### Verifying release artifacts
+
+Released container images and Helm charts are signed with [cosign](https://docs.sigstore.dev/) keyless signing (the GitHub Actions OIDC identity — no long-lived keys), and carry SLSA build provenance. The image additionally carries an SPDX SBOM. All three are stored in GHCR as OCI referrers of the artifact digest.
+
+```bash
+IMAGE=ghcr.io/rajsinghtech/garage-operator:v0.6.29
+
+# Signature
+cosign verify "$IMAGE" \
+  --certificate-identity-regexp '^https://github.com/rajsinghtech/garage-operator/\.github/workflows/docker\.yml@refs/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# Provenance and SBOM
+gh attestation verify "oci://$IMAGE" --repo rajsinghtech/garage-operator
+cosign download attestation "$IMAGE" --predicate-type https://spdx.dev/Document
+```
+
+The Helm chart is signed the same way (`--certificate-identity-regexp` ending in `helm\.yml@refs/`), and `dist/install.yaml` attached to each GitHub release has a provenance attestation verifiable with `gh attestation verify install.yaml --repo rajsinghtech/garage-operator`.
+
+Under a policy controller, pin by digest and require the signature — e.g. Kyverno `verifyImages` with `keyless.issuer: https://token.actions.githubusercontent.com` and the subject regexp above.
+
 ## Garage Version Compatibility
 
 The Garage version is yours to choose — `GarageCluster.spec.image`, `GarageNode.spec.image`, or the chart-wide `defaultGarageImage`. The chart's `appVersion` tracks the *operator*, not Garage.


### PR DESCRIPTION
Closes #292.

Makes every published artifact verifiable without mirroring and re-signing it. All signing is keyless against the Actions OIDC identity — no secrets to add or rotate.

## What ships

| Workflow | Added |
|---|---|
| `docker.yml` | `cosign sign` on the image digest, `actions/attest-build-provenance`, SPDX SBOM via `anchore/sbom-action` → `actions/attest-sbom` |
| `helm.yml` | digest parsed from `helm push`, `cosign sign`, provenance attestation for the OCI chart |
| `release.yml` | provenance attestation for the `dist/install.yaml` release asset |

Signing targets the **digest**, so a single invocation covers every tag that resolves to it. Attestations are pushed to GHCR as OCI referrers (`push-to-registry: true`), which is what `gh attestation verify` and policy controllers read.

## Why `provenance: false` stays

The issue offered flipping buildx's `provenance: true` as an alternative. Left off deliberately: inline buildx attestations add `unknown/unknown` platform entries to the image index, which breaks tooling that enumerates platforms. The referrer-based attestation gives the same SLSA predicate with a clean index.

## Consumer-facing

README gains a "Verifying release artifacts" section with the exact `cosign verify --certificate-identity-regexp` / `gh attestation verify` invocations and a note on pinning under a policy controller.

## Notes

- New job permissions: `id-token: write` + `attestations: write`. PR builds skip every new step (nothing is pushed on a PR, so there is no digest to sign).
- The chart-signing step fails loudly if the digest can't be parsed out of `helm push`, rather than silently skipping the signature.