### PR TITLE
docs: document supported Garage versions + fail loudly on silently-dropped lifecycle rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,41 @@ admin-write availability).
 
 Uses Admin API **v2** at `internal/garage/client.go`.
 
+### Supported Garage versions (#293)
+
+**Floor is Garage v2.0.0** — every endpoint in `internal/garage/client.go` is
+`/v2/...`, and that surface first shipped in upstream v2.0.0 (`doc/api/garage-admin-v2.json`
+does not exist at v1.3.0). Verified: all 30 endpoints the client calls are
+present in v2.0.0's spec, so v2.0.0 really is the floor and not just a guess.
+
+Fields that need newer than the floor, and what happens below it — Garage's
+`Config` has no `deny_unknown_fields`, so a too-new **config** key is silently
+ignored rather than fatal (`read_config` → `toml::from_str`, ../garage
+`src/util/config.rs`):
+
+| Field | Requires | Introduced in ../garage |
+|---|---|---|
+| `GarageBucket.spec.lifecycleRules` | v2.3.0 | `lifecycleRules` on `UpdateBucketRequestBody` |
+| `database.engine: fjall`, `database.fjallBlockCacheSize` | v2.1.0 | `src/db/fjall_adapter.rs` |
+| `blocks.maxConcurrentReads` | v2.1.0 | `default_block_max_concurrent_reads` |
+| `blocks.maxConcurrentWritesPerRequest` | v2.2.0 | `src/api/s3/put.rs` |
+
+The **admin API** has the same laxity and it bites harder: `UpdateBucketRequestBody`
+is a plain serde struct, so a pre-v2.3.0 node accepts `{"lifecycleRules": …}`,
+drops the unknown field, and returns 200 having changed nothing
+(`UpdateBucketRequest::handle` only acts on `websiteAccess`/`quotas`). The bucket
+controller therefore **verifies the readback** after every lifecycle write
+(`verifyLifecycleApplied` in `garagebucket_lifecycle.go`) and fails with an
+error naming v2.3.0 — otherwise `LifecycleConfigured=True` would be a permanent
+lie and the operator would re-issue the same no-op write forever. Only the write
+path pays the extra read; a converged bucket short-circuits on
+`adminLifecycleEqual`.
+
+CI runs two Garage versions on purpose (this is what backs the "v2.x" range
+claim): the Ginkgo suite on v2.3.0 — also `defaultGarageImage` — and the
+topology suites (`hack/e2e-*.sh`) on v2.2.0. Keep it that way; collapsing to one
+version silently narrows what "supported" means.
+
 ### Key Patterns
 
 - Auth: `Authorization: Bearer <prefix>.<secret>` (prefix is 24 hex chars)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,35 @@ helm install garage-operator oci://ghcr.io/rajsinghtech/charts/garage-operator \
   --set webhooks.enabled=false
 ```
 
+## Garage Version Compatibility
+
+The Garage version is yours to choose — `GarageCluster.spec.image`, `GarageNode.spec.image`, or the chart-wide `defaultGarageImage`. The chart's `appVersion` tracks the *operator*, not Garage.
+
+| Operator | Garage minimum | Garage tested in CI | Notes |
+|---|---|---|---|
+| 0.6.x | **v2.0.0** | v2.3.0, v2.2.0 | Admin API v2 only |
+
+`dxflrs/garage:v2.3.0` is the built-in default when `spec.image` is unset, so an unpinned cluster runs the newest tested version. CI exercises two versions on purpose: the Ginkgo suite runs v2.3.0 and the topology suites (multi-cluster, external gateway, IPv6, single-cluster) run v2.2.0, which is what backs the "v2.x range" claim rather than a single number.
+
+**Garage 0.x and 1.x are not supported.** The operator drives buckets, keys, layout, and repair exclusively through the `/v2/...` admin API, which first shipped in Garage v2.0.0. Against an older node every admin call 404s and no cluster will reconcile.
+
+Some fields need a newer Garage than the v2.0.0 floor:
+
+| Field | Requires | Behavior on older Garage |
+|---|---|---|
+| `GarageBucket.spec.lifecycle` | v2.3.0 | Older nodes accept the write and drop the field. The operator reads the rules back and sets `LifecycleConfigured=False` naming this requirement, rather than reporting a success that never took effect. The bucket itself still reconciles. |
+| `GarageCluster.spec.database.engine: fjall`, `spec.database.fjallBlockCacheSize` | v2.1.0 | Unknown config key, silently ignored; Garage falls back to the default engine |
+| `GarageCluster.spec.blocks.maxConcurrentReads` | v2.1.0 | Silently ignored |
+| `GarageCluster.spec.blocks.maxConcurrentWritesPerRequest` | v2.2.0 | Silently ignored |
+
+Garage's TOML parser ignores unknown keys, so setting a too-new config field degrades to a no-op rather than a crashloop. The operator only emits these keys when you set the corresponding field.
+
+The Garage version each cluster is actually running is reported back on the CR:
+
+```bash
+kubectl get garagecluster garage -o jsonpath='{.status.buildInfo.version}'
+```
+
 ## API Versions
 
 `GarageCluster` is served under two API versions; all other CRDs are `v1beta1`.

--- a/charts/garage-operator/README.md
+++ b/charts/garage-operator/README.md
@@ -6,8 +6,13 @@ A Kubernetes operator for managing [Garage](https://garagehq.deuxfleurs.fr/) - a
 
 - Kubernetes 1.25+
 - Helm 3.8+
+- Garage **v2.0.0 or newer** (the operator drives the `/v2` admin API exclusively; v2.3.0 is the tested default). See [Garage version compatibility](../../README.md#garage-version-compatibility).
 - cert-manager for admission and conversion webhook certificates, unless `webhooks.enabled=false`
 - (Optional) Prometheus Operator for ServiceMonitor and PrometheusRule resources
+
+> `appVersion` tracks the **operator** version, not Garage. The Garage version
+> comes from `GarageCluster.spec.image` / `GarageNode.spec.image`, or the
+> chart-wide `defaultGarageImage` value.
 
 ## Installation
 

--- a/internal/controller/garagebucket_lifecycle.go
+++ b/internal/controller/garagebucket_lifecycle.go
@@ -100,13 +100,53 @@ func (r *GarageBucketReconciler) applyLifecycle(
 	case len(desired) == 0 && len(current) == 0:
 		return nil
 	case len(desired) == 0:
-		return adminClient.SetBucketLifecycle(ctx, bucketID, []garage.AdminLifecycleRule{})
+		if err := adminClient.SetBucketLifecycle(ctx, bucketID, []garage.AdminLifecycleRule{}); err != nil {
+			return err
+		}
 	default:
 		if adminLifecycleEqual(current, desired) {
 			return nil
 		}
-		return adminClient.SetBucketLifecycle(ctx, bucketID, desired)
+		if err := adminClient.SetBucketLifecycle(ctx, bucketID, desired); err != nil {
+			return err
+		}
 	}
+
+	return r.verifyLifecycleApplied(ctx, bucketID, desired, adminClient)
+}
+
+// verifyLifecycleApplied re-reads the bucket after a write and fails loudly if
+// the rules did not stick.
+//
+// Garage only learned `lifecycleRules` on UpdateBucket in v2.3.0, and its admin
+// API does not set serde's deny_unknown_fields — so an older node accepts the
+// request, ignores the field, and returns 200 (../garage
+// src/api/admin/bucket.rs, UpdateBucketRequest::handle, which only acts on
+// websiteAccess/quotas). Without this check the operator reports
+// LifecycleConfigured=True forever while no rule is ever evaluated, and
+// re-issues the same no-op write on every reconcile.
+//
+// Only the write path pays for the extra read; a converged bucket short-circuits
+// on adminLifecycleEqual above and never reaches here.
+func (r *GarageBucketReconciler) verifyLifecycleApplied(
+	ctx context.Context,
+	bucketID string,
+	desired []garage.AdminLifecycleRule,
+	adminClient *garage.Client,
+) error {
+	applied, err := adminClient.GetBucketLifecycle(ctx, bucketID)
+	if err != nil {
+		return fmt.Errorf("verify lifecycle after write: %w", err)
+	}
+	if adminLifecycleEqual(applied, desired) {
+		return nil
+	}
+	if len(applied) == 0 && len(desired) > 0 {
+		return fmt.Errorf("garage accepted the lifecycle write but stored no rules; "+
+			"lifecycleRules on UpdateBucket requires Garage v2.3.0 or newer (bucket %s)", bucketID)
+	}
+	return fmt.Errorf("lifecycle rules readback does not match desired state after write "+
+		"(bucket %s: wrote %d rule(s), read back %d)", bucketID, len(desired), len(applied))
 }
 
 // buildAdminLifecycleRules translates the CRD lifecycle spec into Admin API rules.

--- a/internal/controller/garagebucket_lifecycle_test.go
+++ b/internal/controller/garagebucket_lifecycle_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package controller
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -293,5 +297,96 @@ func TestShouldSkipLifecycle(t *testing.T) {
 	b.Status.Conditions = []metav1.Condition{{Type: garagev1beta1.ConditionLifecycleConfigured, Status: metav1.ConditionTrue}}
 	if r.shouldSkipLifecycle(b) {
 		t.Fatal("should not skip when condition lingers")
+	}
+}
+
+// lifecycleStubServer emulates a Garage admin API that returns whatever
+// lifecycle rules `stored` points at, and applies UpdateBucket writes only when
+// acceptsLifecycle is true. Garage < v2.3.0 is the acceptsLifecycle=false case:
+// it returns 200 and silently drops the unknown lifecycleRules field.
+func lifecycleStubServer(t *testing.T, stored *[]garage.AdminLifecycleRule, acceptsLifecycle bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/GetBucketInfo":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":             testLifecycleBucketID,
+				"lifecycleRules": *stored,
+			})
+		case "/v2/UpdateBucket":
+			var body struct {
+				LifecycleRules []garage.AdminLifecycleRule `json:"lifecycleRules"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if acceptsLifecycle {
+				*stored = body.LifecycleRules
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": testLifecycleBucketID})
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+const testLifecycleBucketID = "b0000000000000000000000000000001"
+
+func lifecycleTestBucket() *garagev1beta1.GarageBucket {
+	return &garagev1beta1.GarageBucket{
+		Spec: garagev1beta1.GarageBucketSpec{
+			Lifecycle: &garagev1beta1.BucketLifecycle{
+				Rules: []garagev1beta1.LifecycleRule{{ID: "r1", ExpirationDays: days(7)}},
+			},
+		},
+	}
+}
+
+func TestApplyLifecycle_SucceedsWhenGarageStoresRules(t *testing.T) {
+	stored := []garage.AdminLifecycleRule{}
+	srv := lifecycleStubServer(t, &stored, true)
+	defer srv.Close()
+
+	r := &GarageBucketReconciler{}
+	err := r.applyLifecycle(t.Context(), lifecycleTestBucket(), testLifecycleBucketID, garage.NewClient(srv.URL, "token"))
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("expected 1 stored rule, got %d", len(stored))
+	}
+}
+
+// A pre-v2.3.0 Garage 200s the write and keeps no rules. That must surface as a
+// failure instead of a permanently-lying LifecycleConfigured=True.
+func TestApplyLifecycle_FailsWhenGarageSilentlyDropsRules(t *testing.T) {
+	stored := []garage.AdminLifecycleRule{}
+	srv := lifecycleStubServer(t, &stored, false)
+	defer srv.Close()
+
+	r := &GarageBucketReconciler{}
+	err := r.applyLifecycle(t.Context(), lifecycleTestBucket(), testLifecycleBucketID, garage.NewClient(srv.URL, "token"))
+	if err == nil {
+		t.Fatal("expected an error when garage drops the lifecycle rules")
+	}
+	if !strings.Contains(err.Error(), "v2.3.0") {
+		t.Fatalf("error should name the required Garage version, got: %v", err)
+	}
+}
+
+// Clearing rules is verified the same way, and must not trip the v2.3.0
+// diagnostic when the readback legitimately comes back empty.
+func TestApplyLifecycle_ClearIsVerified(t *testing.T) {
+	stored := []garage.AdminLifecycleRule{{ID: strPtr("r1"), Status: testLifecycleEnabled}}
+	srv := lifecycleStubServer(t, &stored, true)
+	defer srv.Close()
+
+	r := &GarageBucketReconciler{}
+	bucket := &garagev1beta1.GarageBucket{}
+	if err := r.applyLifecycle(t.Context(), bucket, testLifecycleBucketID, garage.NewClient(srv.URL, "token")); err != nil {
+		t.Fatalf("expected clear to succeed, got %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("expected rules cleared, got %d", len(stored))
 	}
 }


### PR DESCRIPTION
Closes #293.

## The compatibility statement

Added to the README (linked from the chart README), with the floor verified against `../garage` rather than guessed:

| Operator | Garage minimum | Garage tested in CI | Notes |
|---|---|---|---|
| 0.6.x | **v2.0.0** | v2.3.0, v2.2.0 | Admin API v2 only |

- **v2.0.0 floor** — all 30 `/v2/...` endpoints `internal/garage/client.go` calls are present in v2.0.0's `doc/api/garage-admin-v2.json`; that file does not exist at v1.3.0. So 0.x/1.x cannot work at all, and v2.0.0 isn't a conservative guess.
- **Two tested versions, deliberately** — the Ginkgo suite runs v2.3.0 (also the built-in default image), the topology suites run v2.2.0. That's what substantiates a "v2.x range" claim; collapsing to one number would narrow it. Documented as-is rather than normalized.
- **Per-field floors** — `lifecycle` needs v2.3.0; `fjall` + `blocks.maxConcurrentReads` need v2.1.0; `blocks.maxConcurrentWritesPerRequest` needs v2.2.0. Garage's `Config` has no `deny_unknown_fields`, so a too-new *config* key is silently ignored rather than a crashloop — documented, since silent is worse than loud.

## The bug this turned up

The same laxity on the *admin* API is not benign. `UpdateBucketRequestBody` is a plain serde struct, so a pre-v2.3.0 node accepts `{"lifecycleRules": [...]}`, drops the unknown field, and returns 200 — `UpdateBucketRequest::handle` only acts on `websiteAccess`/`quotas`.

Result today: `LifecycleConfigured=True` forever while no rule is ever evaluated, plus the same no-op write re-issued on every reconcile (the readback never matches, so `adminLifecycleEqual` never short-circuits).

`applyLifecycle` now verifies the readback after a write and returns an error naming the v2.3.0 requirement, which surfaces as `LifecycleConfigured=False`. This is the "early, explicit error beats a confusing downstream failure" follow-on the issue raised — done behaviorally rather than by parsing Garage's version string, so dev/prerelease builds aren't false-positived. Only the write path pays the extra read.

Three unit tests cover it: rules stored, rules silently dropped (asserts the message names v2.3.0), and clearing rules (must not trip the diagnostic on a legitimately empty readback).

## Verification

`go test ./internal/... ./api/...` — all green. `golangci-lint` clean.