### PR TITLE
docs: correct the SBOM predicate type in the verification snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cosign verify "$IMAGE" \
 
 # Provenance and SBOM
 gh attestation verify "oci://$IMAGE" --repo rajsinghtech/garage-operator
-cosign download attestation "$IMAGE" --predicate-type https://spdx.dev/Document
+cosign download attestation "$IMAGE" --predicate-type https://spdx.dev/Document/v2.3
 ```
 
 The Helm chart is signed the same way (`--certificate-identity-regexp` ending in `helm\.yml@refs/`), and `dist/install.yaml` attached to each GitHub release has a provenance attestation verifiable with `gh attestation verify install.yaml --repo rajsinghtech/garage-operator`.


### PR DESCRIPTION
Follow-up to #299. `actions/attest-sbom` stores the SPDX attestation as `https://spdx.dev/Document/v2.3`, so the documented `--predicate-type https://spdx.dev/Document` matched nothing and printed an empty result.

Verified against the image the first signed `main` build just pushed:

```
$ cosign verify ghcr.io/rajsinghtech/garage-operator:latest \
    --certificate-identity-regexp '^https://github.com/rajsinghtech/garage-operator/\.github/workflows/docker\.yml@refs/' \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com
Verification for ghcr.io/rajsinghtech/garage-operator:latest --
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
```

All three payloads are present on digest `sha256:5d08ce0d…`: the cosign signature, `https://slsa.dev/provenance/v1`, and `https://spdx.dev/Document/v2.3`. `gh attestation verify oci://…` also passes.