### PR TITLE
docs: pin node-local pools to v0.7.0 and document reserved Garage env vars

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,9 +1,6 @@
 # Migration Guide
 
-## Node-local pools (next minor release)
-
-No release version is assigned by this change. Do not tag or publish a release
-as part of this migration work.
+## Node-local pools (v0.7.0)
 
 Node-local pools are an experimental, explicitly selected v1beta2 API under
 `spec.storage.nodeLocalPools`. Released v0.6.29 does not contain the feature, so existing
@@ -108,7 +105,7 @@ After the final topology transaction and rollout have cleared at every site,
 configuration-only rollout if the deployment relies on that read-availability
 tradeoff.
 
-## Reserved Garage environment variables (next minor release)
+## Reserved Garage environment variables (v0.7.0)
 
 Released operators let `spec.storage.env`, `spec.gateway.env`, and
 `GarageNode.spec.env` override `GARAGE_CONFIG_FILE` and the RPC, Admin, and

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A Kubernetes operator for [Garage](https://garagehq.deuxfleurs.fr/) - distribute
 
 ## Install
 
+Requires Kubernetes 1.25+, or **1.27+ if you use
+[node-local pools](#experimental-node-local-pools-daemonset-backed)**, which
+depend on Pod scheduling gates for their activation fence.
+
 The Helm chart enables admission and conversion webhooks by default, so install
 cert-manager first. Disabling webhooks is limited to local development or
 simple v1beta2-only installs that neither use `nodeLocalPools` nor rely on
@@ -830,7 +834,7 @@ ordinary `GarageNode` with a pre-provisioned `existingClaim`.
 
 ## Custom Container Environment Variables
 
-Both tiers expose `env` and `envFrom` for injecting arbitrary env vars into the Garage container. Built-in vars (`GARAGE_NODE_HOST`, log sinks) are set first; user entries are appended after, so a user-supplied `GARAGE_NODE_HOST` would shadow the built-in.
+Both tiers expose `env` and `envFrom` for injecting arbitrary env vars into the Garage container, as does `GarageNode.spec.env`. Built-in vars (`GARAGE_NODE_HOST`, log sinks) are set first; user entries are appended after, so a user-supplied `GARAGE_NODE_HOST` would shadow the built-in.
 
 ```yaml
 spec:
@@ -846,6 +850,28 @@ spec:
       - name: RUST_BACKTRACE
         value: "full"
 ```
+
+### Reserved variables
+
+These names are operator-reserved and rejected by admission:
+
+| Variable | Also reserved |
+|---|---|
+| `GARAGE_CONFIG_FILE` | — |
+| `GARAGE_RPC_SECRET` | `GARAGE_RPC_SECRET_FILE` |
+| `GARAGE_ADMIN_TOKEN` | `GARAGE_ADMIN_TOKEN_FILE` |
+| `GARAGE_METRICS_TOKEN` | `GARAGE_METRICS_TOKEN_FILE` |
+
+Overriding them would change the live mesh identity, or the consistency and
+timeout settings a storage-drain proof depends on, without the operator being
+able to see it. `envFrom` prefixes that could expand into one of these names are
+rejected for the same reason.
+
+Earlier releases accepted these overrides. If you are upgrading with one set,
+the object keeps reconciling only while the entry stays byte-for-byte unchanged,
+and the operator asks you to remove it — see
+[MIGRATION.md](MIGRATION.md#reserved-garage-environment-variables-v070) for the
+two-step annotation flow.
 
 ## Operational Annotations
 

--- a/docs/node-local-pools.md
+++ b/docs/node-local-pools.md
@@ -652,7 +652,7 @@ failure domains within one workload-owning cluster.
 
 ## Upgrading development snapshots of this feature
 
-Node-local pools are new in the next minor release; released v0.6.29 and the
+Node-local pools are new in v0.7.0; released v0.6.29 and the
 upstream base do not contain a pool API. Ordinary v1beta1/v1beta2 clusters need
 no compatibility migration.
 


### PR DESCRIPTION
Release prep for v0.7.0, split out from #297.

## Reserved Garage environment variables

The README described `env`/`envFrom` as always-applied ("user entries are appended after, so a user-supplied `GARAGE_NODE_HOST` would shadow the built-in"). Since #297, admission **rejects** `GARAGE_CONFIG_FILE`, `GARAGE_RPC_SECRET(_FILE)`, `GARAGE_ADMIN_TOKEN(_FILE)`, and `GARAGE_METRICS_TOKEN(_FILE)` — so the docs promised behaviour the operator refuses. Adds the reserved table, the reason (mesh identity and the consistency/timeout settings a drain proof depends on), and a pointer to the migration flow for anyone upgrading with one set.

## Version placeholders

`MIGRATION.md` still said *"No release version is assigned by this change. Do not tag or publish a release as part of this migration work."* Resolves that and the two other `next minor release` placeholders to v0.7.0.

## Discoverability

Node-local pools need Kubernetes 1.27+ for the scheduling-gate fence; that was stated only ~400 lines into the README. Moved into Install, where someone choosing a cluster will see it.

Verified all relative links and in-page anchors resolve.