### PR TITLE
fix(admin): pin the layout rebuild to one Pod; split the factor-migration shard

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -23,7 +23,7 @@ jobs:
     # and dual-version topology changes intentionally wait through Garage's
     # production proof windows, while each management-handle block starts a
     # real Garage. Isolation preserves cleanup/debug margin under this cap.
-    timeout-minutes: 45
+    timeout-minutes: 58
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +138,7 @@ jobs:
   e2e-cluster:
     name: Single-Cluster E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 58
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,9 +54,18 @@ jobs:
             runner: ubuntu-latest
             filter: "management-handle"
             kind_config: ""
+          # factor-migration is split out of the catch-all because it is a
+          # destructive whole-cluster purge with its own multi-minute barriers.
+          # Together with the drain in auto-mode-pernode (a single ~13m spec,
+          # bounded by Garage's BLOCK_GC_DELAY) it pushed the catch-all past the
+          # 40m Go timeout on a loaded runner.
+          - name: factor-migration
+            runner: ubuntu-latest
+            filter: "factor-migration"
+            kind_config: ""
           - name: layout
             runner: ubuntu-latest
-            filter: "!(gateway || manager || webhooks || external-gateway || dual-version || manual-mode || management-handle || node-local-pools)"
+            filter: "!(gateway || manager || webhooks || external-gateway || dual-version || manual-mode || management-handle || node-local-pools || factor-migration)"
             kind_config: ""
           - name: node-local-pools
             runner: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,15 @@ GINKGO_LABEL_FILTER ?=
 # its goroutine dump, so a hung spec is indistinguishable from a slow one. Going
 # through Go's own timeout instead yields a full stack trace naming the stuck
 # spec.
-E2E_GO_TIMEOUT ?= 40m
+#
+# Sized against a measured floor, not guessed: removing a node that holds
+# positive capacity is a drain, and the barrier must outlast Garage's
+# delayed-resync window (BLOCK_GC_DELAY + 10s, ../garage src/block/manager.rs)
+# before it can conclude no block is coming back. That makes one spec in the
+# catch-all shard ~13m on its own, and the shard ~27m. At the previous 40m the
+# margin was thin enough that a loaded runner tipped it over, which reports as an
+# unattributed "test timed out" rather than as the slow spec.
+E2E_GO_TIMEOUT ?= 50m
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist

--- a/internal/controller/garagecluster_factor_migration.go
+++ b/internal/controller/garagecluster_factor_migration.go
@@ -607,9 +607,26 @@ func (r *GarageClusterReconciler) fmRebuildLayout(ctx context.Context, cluster *
 		return ctrl.Result{RequeueAfter: 5 * time.Second}
 	}
 
-	gc, err := GetGarageClient(ctx, r.Client, cluster, r.ClusterDomain)
+	// Pin to one storage Pod rather than dialing the cluster Service.
+	//
+	// The purge deleted cluster_layout everywhere, so there is no committed layout
+	// yet — which is exactly the state the shared client cannot serve. Its dynamic
+	// token cannot be re-proved (that needs the admin-token table, which needs a
+	// layout, which needs this client), and the load-balanced Service must never
+	// carry a substituted credential: a Pod that predates the last static rotation
+	// rejects it with a 403, intermittently, depending on which Pod is picked.
+	//
+	// staticGarageClientForPod reads the bearer out of the target Pod's own spec,
+	// so it is by construction the credential that process accepted at startup.
+	// This is the same bootstrap client reconcileOperatorAdminToken uses before a
+	// dynamic token exists, which is the situation a purge recreates.
+	podSet, err := getOperatorAdminPodSet(ctx, r.safetyReader(), cluster)
 	if err != nil {
-		return waiting("Admin API client unavailable: %v", err), nil
+		return waiting("managed storage Pod set is not provable yet: %v", err), nil
+	}
+	gc, err := r.staticGarageClientForPod(ctx, &podSet.Pods[0], getAdminPort(cluster))
+	if err != nil {
+		return waiting("exact-Pod bootstrap Admin client unavailable: %v", err), nil
 	}
 	// The node-local-pool rollout exclusion cannot legitimately apply here, and
 	// waiting on it deadlocks. It is asserted whenever StorageRolloutReady's

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -21,7 +21,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	stderrors "errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -383,30 +382,24 @@ const (
 // every running process, and otherwise uses the immutable static bootstrap
 // credential revision.
 func GetAdminToken(ctx context.Context, c client.Client, cluster *garagev1beta2.GarageCluster) (string, error) {
+	// An unproven dynamic token is deliberately NOT downgraded to the static
+	// credential here. This client dials the load-balanced cluster Service, and
+	// GetStaticAdminToken returns the cluster's *current* credential revision —
+	// which a Pod that started before the last rotation does not have, because
+	// Garage reads its config once at startup. Substituting it sends a bearer the
+	// receiving process never accepted and earns a 403 from whichever Pod the
+	// Service happens to pick, intermittently.
+	//
+	// Callers that legitimately need to reach Garage while the dynamic token is
+	// unprovable must pin to one Pod instead: directVerifiedOperatorAdminClient
+	// once a layout is committed, or staticGarageClientForPod before one exists,
+	// which reads the credential from that Pod's own spec and so cannot mismatch.
 	token, ready, err := getReadyOperatorAdminToken(ctx, c, cluster)
-	switch {
-	case ready:
-		return token, nil
-	case err == nil:
-		// No dynamic token exists yet — ordinary bootstrap.
-	case stderrors.Is(err, errAdminTokenUnproven):
-		// The credential is intact but not proven against the Pod incarnations
-		// that are live now, so it cannot be used. That is a liveness state, not
-		// an integrity failure, and it is indistinguishable — credential-wise —
-		// from the bootstrap case above: the static token mounted into those very
-		// Pods is the operator's own, and is what every direct Pod probe and the
-		// dynamic token's own re-verification already authenticate with. Falling
-		// through keeps a deliberate whole-cluster restart (a factor-migration
-		// purge above all) from wedging: re-proving the dynamic token needs the
-		// admin-token table, the table needs a layout, and committing a layout
-		// needs this client.
-		static, staticErr := GetStaticAdminToken(ctx, c, cluster)
-		if staticErr != nil {
-			return "", fmt.Errorf("%w; static bootstrap fallback also unavailable: %w", err, staticErr)
-		}
-		return static, nil
-	default:
+	if err != nil {
 		return "", err
+	}
+	if ready {
+		return token, nil
 	}
 	return GetStaticAdminToken(ctx, c, cluster)
 }

--- a/internal/controller/operator_admin_token_layoutless_test.go
+++ b/internal/controller/operator_admin_token_layoutless_test.go
@@ -135,14 +135,18 @@ func unprovenTokenFixture() (*garagev1beta2.GarageCluster, []client.Object, stri
 // A replication-factor purge deletes cluster_layout on every storage node, so
 // Garage answers every admin-token read with "Layout not ready" until a layout is
 // committed. Re-proving the dynamic token needs that table; committing a layout
-// needs an Admin client. If an unproven-but-intact token is fatal to client
-// construction, those two facts close a loop and RebuildingLayout waits forever
-// — observed as a 40-minute e2e shard timeout with the cluster fully healthy.
+// needs an Admin client. That loop is real — it wedged RebuildingLayout for a
+// full 40m e2e shard — but it must NOT be broken here, by downgrading the shared
+// client to the static credential.
 //
-// The static bootstrap credential is mounted in the very Pods being dialed and is
-// what the token's own re-verification authenticates with, so it is the correct
-// fallback here, exactly as it is before any dynamic token exists.
-func TestAdminTokenFallsBackToStaticWhenDynamicTokenIsUnprovenOnLivePods(t *testing.T) {
+// GetStaticAdminToken returns the cluster's *current* credential revision, while
+// this client dials the load-balanced Service. A Pod that started before the last
+// rotation still holds the older bearer (Garage reads its config once at
+// startup), so the substituted token draws a 403 from whichever Pod the Service
+// happens to pick — intermittently, which is the worst way to fail. Callers that
+// must reach Garage while the dynamic token is unprovable pin to one Pod instead:
+// staticGarageClientForPod reads the bearer from that Pod's own spec.
+func TestAdminTokenDoesNotDowngradeToStaticOnTheSharedServiceClient(t *testing.T) {
 	cluster, objects, staticToken := unprovenTokenFixture()
 	kubeClient := fake.NewClientBuilder().WithScheme(operatorPodSetTestScheme(t)).WithObjects(objects...).Build()
 
@@ -151,11 +155,14 @@ func TestAdminTokenFallsBackToStaticWhenDynamicTokenIsUnprovenOnLivePods(t *test
 	}
 
 	token, err := GetAdminToken(context.Background(), kubeClient, cluster)
-	if err != nil {
-		t.Fatalf("GetAdminToken must fall back to the mounted static credential, got error: %v", err)
+	if err == nil {
+		t.Fatalf("an unproven dynamic token must not silently become the static credential; got token %q", token)
 	}
-	if token != staticToken {
-		t.Fatalf("GetAdminToken = %q, want the static bootstrap credential %q", token, staticToken)
+	if token == staticToken {
+		t.Fatal("GetAdminToken returned the static credential for the load-balanced Service client")
+	}
+	if !strings.Contains(err.Error(), "not been directly verified") {
+		t.Fatalf("want the unproven-incarnation error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Three things, all fallout from getting #297 green.

## 1. Never route a substituted credential through the cluster Service (the real fix)

`GetAdminToken` downgraded an unproven dynamic token to the static credential. That client dials the **load-balanced Service**, and `GetStaticAdminToken` returns the cluster's *current* credential revision — which a Pod that started before the last rotation does not hold, since Garage reads its config once at startup. The substituted bearer then draws an **intermittent 403** from whichever Pod the Service happens to pick.

That is what left `factor-cluster-storage-1` in `Failed` with `Forbidden: Invalid bearer token` while Garage itself was perfectly healthy — 256/256 partitions, both nodes up, `factorMigration: Completed`.

The GarageNode controller already had the answer in a comment beside its own bridge:

> Break that cycle through an exact existing Pod that proves it accepts the authoritative dynamic token; **never send a fallback credential through the load-balanced cluster Service.**

The downgrade made `GetGarageClient` succeed where it used to error, so that bridge stopped engaging. Restored to strict.

The deadlock that motivated the downgrade is real, so it's fixed where it happens instead: `fmRebuildLayout` pins to one storage Pod via `staticGarageClientForPod`, which reads the bearer from that Pod's own spec and therefore cannot mismatch. `directVerifiedOperatorAdminClient` can't serve this path — it requires a committed layout, which is exactly what the rebuild is about to create.

## 2. Give the factor migration its own shard

The catch-all carried both expensive specs: the purge, and the `auto-mode-pernode` scale-down — a single **794s** spec, because removing a node with positive capacity must outlast Garage's delayed-resync window (`BLOCK_GC_DELAY + 10s`, `src/block/manager.rs`).

## 3. Size the e2e timeout against that measured barrier

40m left too little margin: the catch-all runs ~27m and `node-local-pools` measured **36m37s**, which was about to breach it regardless. Go timeout 50m, job cap 58m — Go's stays below the job's so the goroutine dump still names the stuck spec.

**Follow-up, not in this PR:** `blockResyncQuietPeriod` is plumbed through `effectiveBlockResyncQuietPeriod` but nothing sets it, so that ~11m barrier is untunable. A `--block-resync-quiet-period` flag would cut this spec by ~11 minutes and give operators the knob.