### PR TITLE
test(e2e): corroborate the drain barrier while it is still asserted

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7858,8 +7858,30 @@ spec:
 		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 		const adminToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+		// Corroborate the barrier against Garage while the operator is still
+		// asserting it, immediately after the check above — not behind the rejoin
+		// below. The two advance on independent clocks: the operator releases once
+		// data movement is done, while Garage retires a version only once its
+		// bookkeeping catches up, and either can finish first. Demanding both a
+		// committed rejoin and a still-visible Draining version in one poll asserts
+		// an overlap nothing guarantees, which is a flake, not a property.
+		By("corroborating the reported barrier against a directly observed draining version")
 		Eventually(func(g Gomega) {
-			rejoinLayout, rejoinHistory := readGarageLayoutSnapshot(
+			_, barrierHistory := readGarageLayoutSnapshot(
+				g, testNamespace, "node-local-rejoin-draining-snapshot", clusterName, adminToken,
+			)
+			historyStatuses := make([]string, 0, len(barrierHistory.Versions))
+			for _, version := range barrierHistory.Versions {
+				historyStatuses = append(historyStatuses, version.Status)
+			}
+			g.Expect(historyStatuses).To(ContainElement("Draining"),
+				"GarageNode reported a history barrier without a directly observed draining version")
+		}, time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the rejoin Apply committed the retained disk identity")
+		Eventually(func(g Gomega) {
+			rejoinLayout, _ := readGarageLayoutSnapshot(
 				g, testNamespace, "node-local-rejoin-applied-snapshot", clusterName, adminToken,
 			)
 			rejoinRoleIDs := make([]string, 0, len(rejoinLayout.Roles))
@@ -7870,12 +7892,6 @@ spec:
 				"the rejoin layout Apply did not commit the retained disk identity")
 			g.Expect(rejoinLayout.StagedRoleChanges).To(BeEmpty(),
 				"rejoin left an uncommitted Garage layout mutation")
-			historyStatuses := make([]string, 0, len(rejoinHistory.Versions))
-			for _, version := range rejoinHistory.Versions {
-				historyStatuses = append(historyStatuses, version.Status)
-			}
-			g.Expect(historyStatuses).To(ContainElement("Draining"),
-				"GarageNode reported a history barrier without a directly observed draining version")
 		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 		By("waiting for Garage's prior layout version to finish synchronizing before reporting rejoin convergence")


### PR DESCRIPTION
`main` at 3b67b55 failed `node-local-pools` on *should drain selector-based scale-down and rejoin with the hostPath identity*:

```
Expected
    <[]string | len:5>: ["Current", "Historical", "Historical", "Historical", "Historical"]
to contain element matching
    <string>: Draining
```

The spec required Garage to still report a `Draining` version **at the same poll** in which the rejoin Apply had already committed. Those advance on independent clocks: the operator releases its barrier once data movement is done (a node's `sync` tracker reaching the current version), while Garage retires a version only once `sync_ack` bookkeeping catches up. Either can finish first, so the overlap the assertion demanded is not a property — it's a coin flip that usually lands right.

Split it: corroboration now runs immediately after the GarageNode reports the barrier, where the operator's claim and Garage's history describe the same instant. The rejoin check keeps its own window. The property being tested — *"GarageNode reported a history barrier without a directly observed draining version"* — is unchanged.

Not a regression: this spec passed twice on #306 with the same product code.