### PR TITLE
chore(garage): remove dead NodeSyncedToCurrent helper

### DIFF
--- a/internal/controller/layout_drain_settled_test.go
+++ b/internal/controller/layout_drain_settled_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -100,5 +101,54 @@ func TestSettledLayoutHistoryPassesWithNoDrainingVersion(t *testing.T) {
 	}
 	if err := requireSettledLayoutHistoryResponse(history); err != nil {
 		t.Fatalf("a single-version history is settled: %v", err)
+	}
+}
+
+// issue304LayoutHistory is the GetClusterLayoutHistory body reported in #304,
+// verbatim: a completed node cycle whose layout has collapsed back to one live
+// version, so Garage reports the previous version Historical and omits the
+// per-node update trackers entirely.
+const issue304LayoutHistory = `{
+  "currentVersion": 2,
+  "minAck": 2,
+  "versions": [
+    { "version": 2, "status": "Current",    "storageNodes": 4, "gatewayNodes": 0 },
+    { "version": 1, "status": "Historical", "storageNodes": 3, "gatewayNodes": 0 }
+  ],
+  "updateTrackers": null
+}`
+
+// A graceful node cycle wedged permanently in Syncing (#304) because the
+// Syncing → Draining gate asked whether the sibling's own update tracker had
+// caught up. Garage emits updateTrackers only while more than one layout
+// version is live (../garage src/api/admin/layout.rs), and the sibling
+// finishing its sync is exactly the event that collapses the history back to
+// one — so the evidence the gate read was destroyed by the event it existed to
+// detect, and the lookup missed forever.
+//
+// The gate now asks about the history instead of about one node, which holds
+// because the two are the same question upstream. `layout.versions` carries
+// only live versions (retired ones move to `old_versions`), Draining means a
+// live non-current version and Historical means version < min_stored, and the
+// trackers are attached iff `versions.len() > 1`. Absent trackers therefore
+// mean precisely "no version is Draining" — not "unknown" — which is why the
+// conservative tracker-absence branches in DataMigrationSettled and
+// waitForStorageRoleDrain are unreachable against a supported Garage rather
+// than merely unlikely. The reporter's caveat, that a node which never joined
+// also has no tracker, is answered before this gate: reconcileCycle requires
+// the sibling's Status.InLayout against its exact current Pod UID.
+func TestCycleSettledLayoutHistoryDoesNotWedgeOnCollapsedLayout(t *testing.T) {
+	var history garage.LayoutHistoryResponse
+	if err := json.Unmarshal([]byte(issue304LayoutHistory), &history); err != nil {
+		t.Fatalf("decoding the reported payload: %v", err)
+	}
+	if history.UpdateTrackers != nil {
+		t.Fatalf("a null updateTrackers must decode to a nil map, got %v", history.UpdateTrackers)
+	}
+	if draining := history.GetDrainingVersions(); len(draining) != 0 {
+		t.Fatalf("a collapsed history reports no Draining version, got %v", draining)
+	}
+	if err := requireCycleSettledLayoutHistory(&history); err != nil {
+		t.Fatalf("the cycle must leave Syncing once the layout collapses: %v", err)
 	}
 }

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -854,9 +854,11 @@ func (c *Client) GetClusterLayoutHistory(ctx context.Context) (*LayoutHistoryRes
 // assigns it. A node that is gone never advances, so a genuinely dead peer still
 // reports unsettled and still requires the explicit skip-dead-nodes recovery.
 func (h *LayoutHistoryResponse) DataMigrationSettled() bool {
-	// Garage omits the trackers entirely while only one version is active. If a
-	// version reports Draining and they are still absent, we cannot prove
-	// anything — stay conservative.
+	// Garage attaches the trackers iff more than one version is live, and a
+	// Draining entry is by definition a live non-current version, so any caller
+	// that got here has them. Silence from an unexpected Garage proves nothing —
+	// stay conservative rather than read it as done. Reading tracker absence as
+	// a per-node verdict is what wedged the node cycle in #304.
 	if len(h.UpdateTrackers) == 0 {
 		return false
 	}

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -832,21 +832,6 @@ func (c *Client) GetClusterLayoutHistory(ctx context.Context) (*LayoutHistoryRes
 	return &history, nil
 }
 
-// NodeSyncedToCurrent reports whether the named node has caught its layout sync
-// tracker up to the current layout version — i.e. all partitions it owns under
-// the current layout are in sync on it. This is the per-node equivalent of
-// Garage's sync_map_min reaching the active version: a node is safe to rely on
-// for replication (and safe to swap a peer out behind) only once its sync
-// tracker is no longer behind the current version. Returns false when the node
-// has no tracker entry yet (not joined / never synced).
-func (h *LayoutHistoryResponse) NodeSyncedToCurrent(nodeID string) bool {
-	t, ok := h.UpdateTrackers[nodeID]
-	if !ok {
-		return false
-	}
-	return t.Sync >= h.CurrentVersion
-}
-
 // DataMigrationSettled reports whether every node Garage is tracking has
 // completed a full table sync at the current layout version — i.e. the data
 // movement a draining version exists to cover is finished, and only Garage's


### PR DESCRIPTION
# Pull request

## Summary

Closes #304 by removing the dead `LayoutHistoryResponse.NodeSyncedToCurrent` helper and pinning, with a test, the gate that replaced it.

#304 reports a graceful node cycle wedging permanently in `Syncing`. The `Syncing → Draining` gate consulted `NodeSyncedToCurrent`, which reads `updateTrackers`. Garage attaches `updateTrackers` only while more than one layout version is live, and the sibling finishing its sync is exactly the event that collapses the history back to one — so the evidence the gate read was destroyed by the event it existed to detect, and the map lookup missed forever.

That gate was already replaced on `main`: the cycle now advances via `requireCycleSettledLayoutHistory` → `requireSettledLayoutHistoryResponse`, which asks about the *history* (is any version Draining, and if so has data movement finished) rather than about one node's tracker. On the reported payload it returns settled immediately. `NodeSyncedToCurrent` has no callers left anywhere in the tree; it is unreachable code still documenting a misleading guarantee — `nil` trackers ⇒ `false`, indistinguishable from a node that never joined, which is the semantics that produced #304.

Asking about the history is sound because upstream makes the two questions equivalent (`../garage` `src/api/admin/layout.rs`, `src/rpc/layout/history.rs`): `layout.versions` holds only *live* versions (retired ones move to `old_versions`), `Draining` means a live non-current version while `Historical` means `version < min_stored`, and the trackers are attached iff `versions.len() > 1`. Absent trackers therefore mean precisely "no version is Draining" — not "unknown". That also makes the two conservative tracker-absence branches (`DataMigrationSettled`, `waitForStorageRoleDrain`) unreachable against a supported Garage rather than merely unlikely; both are kept as fail-closed defenses, now with a comment saying so.

The reporter's caveat — a node that never joined also has no tracker, so a nil-tracker fast path needs the caller to confirm the sibling holds a role — is answered before this gate is reached: `reconcileCycle` requires the sibling's `Status.InLayout` against its exact current Pod UID (`garageNodeLayoutReadyForPod`).

## Related issue or design

Fixes #304

## Compatibility and operational impact

None. No production code path referenced the removed function. No API, CRD, chart, or runtime behavior changes.

## Validation

- `TestCycleSettledLayoutHistoryDoesNotWedgeOnCollapsedLayout` (new) decodes the `GetClusterLayoutHistory` body from the report verbatim and requires the cycle gate to pass on it, so a change that reintroduces a tracker-presence requirement fails here instead of wedging a cycle in `Syncing`. It also pins `"updateTrackers": null` decoding to a nil map.
- `make lint` — 0 issues.
- `go test ./internal/... ./api/... -count=1` — all pass, including the envtest controller suite.
- `go build ./...`, `go vet ./internal/... ./api/...` — clean.
- `grep -rn NodeSyncedToCurrent` — no remaining references.

Not run: the live reproduction from the issue (fresh Auto cluster, 256 MB, annotate `cycle=true`). The unit pin covers the exact admin API payload that wedged it; the e2e cycle coverage on `main` exercises the surrounding state machine.

## Checklist

- [x] The PR addresses one coherent problem and includes its necessary robustness fixes.
- [x] Tests cover the changed behavior.
- [x] User-facing docs and samples are updated where needed.
- [x] Generated files were regenerated and committed where needed.
- [x] Release-only chart version fields are unchanged.
