### PR TITLE
fix: target block retries per node and restore chart signing

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -175,7 +175,16 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2
 
-      - name: Log in to GHCR
+      # Helm and cosign use separate credential stores. Authenticate both so
+      # the chart push and its signature/referrer uploads share the same scope.
+      - name: Log in to GHCR for cosign
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GHCR for Helm
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
       - name: Get chart version

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ helm install garage-operator oci://ghcr.io/rajsinghtech/charts/garage-operator \
 Released container images and Helm charts are signed with [cosign](https://docs.sigstore.dev/) keyless signing (the GitHub Actions OIDC identity — no long-lived keys), and carry SLSA build provenance. The image additionally carries an SPDX SBOM. All three are stored in GHCR as OCI referrers of the artifact digest.
 
 ```bash
-IMAGE=ghcr.io/rajsinghtech/garage-operator:v0.7.0
+IMAGE=ghcr.io/rajsinghtech/garage-operator:v0.7.1
 
 # Signature
 cosign verify "$IMAGE" \

--- a/charts/garage-operator/Chart.yaml
+++ b/charts/garage-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: garage-operator
 description: A Kubernetes operator for managing Garage distributed S3-compatible object storage
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.7.1
+appVersion: "0.7.1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/rajsinghtech/garage-operator
 sources:

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)
-  tag: "v0.7.0"
+  tag: "v0.7.1"
 
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.

--- a/hack/e2e-cluster.sh
+++ b/hack/e2e-cluster.sh
@@ -1237,10 +1237,36 @@ test_pvc_creation() {
 test_operator_restart() {
     log_test "Testing operator restart resilience..."
 
+    # Deployment readiness and webhook endpoint readiness do not prove that a
+    # newly elected manager has started its controller workers. Capture a
+    # status field that the GarageNode reconciler refreshes on every connected
+    # observation, then require the replacement manager to advance it before
+    # creating resources for the next test section.
+    local probe_node="garage-storage-0"
+    local before_last_seen
+    before_last_seen=$(kubectl get garagenode "$probe_node" -n "$NAMESPACE" -o jsonpath='{.status.lastSeen}' 2>/dev/null || true)
+
     # Restart operator
     kubectl rollout restart deployment/garage-operator -n "$NAMESPACE"
     kubectl rollout status deployment/garage-operator -n "$NAMESPACE" --timeout=60s
     NAMESPACE="$NAMESPACE" "$ROOT_DIR/hack/wait-for-operator-webhook.sh"
+
+    local controller_ready="false"
+    local controller_deadline=$((SECONDS + 120))
+    while [ $SECONDS -lt $controller_deadline ]; do
+        local after_last_seen
+        after_last_seen=$(kubectl get garagenode "$probe_node" -n "$NAMESPACE" -o jsonpath='{.status.lastSeen}' 2>/dev/null || true)
+        if [ -n "$after_last_seen" ] && [ "$after_last_seen" != "$before_last_seen" ]; then
+            log_info "GarageNode controller observed $probe_node after restart"
+            controller_ready="true"
+            break
+        fi
+        sleep 2
+    done
+    if [ "$controller_ready" != "true" ]; then
+        test_fail "GarageNode controller did not reconcile $probe_node after operator restart"
+        return 1
+    fi
 
     # Wait for cluster to become healthy (operator reconciles after restart)
     # This may take longer if the cluster was recovering from a previous test

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -1740,9 +1740,19 @@ type RetryBlockResyncResult struct {
 
 // RetryBlockResync clears the resync backoff for blocks, causing immediate retry.
 // Pass all=true to retry all errored blocks, or provide specific block hashes.
+// A wildcard retry of specific hashes is first partitioned by the nodes that
+// currently report each error. Garage rejects a hash on every node where that
+// hash is not errored, so sending the same hash list to node="*" cannot work in
+// a healthy replicated cluster. Hashes that are no longer reported are treated
+// as an idempotent no-op.
+//
 // Returns the count summed across all responding nodes; a per-node failure
 // surfaces as a non-nil error (the HTTP status is always 200 for this endpoint).
 func (c *Client) RetryBlockResync(ctx context.Context, nodeID string, all bool, hashes []string) (*RetryBlockResyncResult, error) {
+	if nodeID == "*" && !all {
+		return c.retryBlockResyncByErrorOwner(ctx, hashes)
+	}
+
 	query := map[string]string{"node": nodeID}
 	var body any
 	if all {
@@ -1766,6 +1776,66 @@ func (c *Client) RetryBlockResync(ctx context.Context, nodeID string, all bool, 
 		agg.Count += r.Count
 	}
 	return &agg, nil
+}
+
+func (c *Client) retryBlockResyncByErrorOwner(ctx context.Context, hashes []string) (*RetryBlockResyncResult, error) {
+	requested := make(map[string]struct{}, len(hashes))
+	for _, hash := range hashes {
+		canonical := strings.ToLower(strings.TrimSpace(hash))
+		decoded, err := hex.DecodeString(canonical)
+		if err != nil || len(decoded) != 32 {
+			return nil, fmt.Errorf("invalid block hash %q: expected 64 hexadecimal characters", hash)
+		}
+		requested[canonical] = struct{}{}
+	}
+	if len(requested) == 0 {
+		return nil, fmt.Errorf("at least one block hash is required")
+	}
+
+	blockErrors, err := c.ListBlockErrors(ctx, "*")
+	if err != nil {
+		return nil, fmt.Errorf("listing block errors before retry: %w", err)
+	}
+	if err := aggregateNodeErrors(blockErrors.Error); err != nil {
+		return nil, fmt.Errorf("listing block errors before retry: %w", err)
+	}
+	if len(blockErrors.Success) == 0 {
+		return nil, fmt.Errorf("listing block errors before retry returned no successful nodes")
+	}
+
+	hashesByNode := make(map[string][]string)
+	for nodeID, nodeErrors := range blockErrors.Success {
+		seen := make(map[string]struct{})
+		for _, blockErr := range nodeErrors {
+			canonical := strings.ToLower(strings.TrimSpace(blockErr.BlockHash))
+			if _, wanted := requested[canonical]; !wanted {
+				continue
+			}
+			if _, duplicate := seen[canonical]; duplicate {
+				continue
+			}
+			seen[canonical] = struct{}{}
+			hashesByNode[nodeID] = append(hashesByNode[nodeID], canonical)
+		}
+	}
+
+	nodeIDs := make([]string, 0, len(hashesByNode))
+	for nodeID := range hashesByNode {
+		nodeIDs = append(nodeIDs, nodeID)
+	}
+	sort.Strings(nodeIDs)
+
+	var aggregate RetryBlockResyncResult
+	for _, nodeID := range nodeIDs {
+		nodeHashes := hashesByNode[nodeID]
+		sort.Strings(nodeHashes)
+		result, err := c.RetryBlockResync(ctx, nodeID, false, nodeHashes)
+		if err != nil {
+			return nil, fmt.Errorf("retrying block resync on node %s: %w", nodeID, err)
+		}
+		aggregate.Count += result.Count
+	}
+	return &aggregate, nil
 }
 
 // PurgeBlocksResult is the per-node response payload from PurgeBlocks.

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -695,9 +695,139 @@ func TestLaunchScrubCommand_RequestBody(t *testing.T) {
 	}
 }
 
+func TestRetryBlockResyncPartitionsWildcardHashesByErrorOwner(t *testing.T) {
+	hashA := strings.Repeat("a", 64)
+	hashB := strings.Repeat("b", 64)
+	hashNoLongerErrored := strings.Repeat("c", 64)
+	callOrder := make([]string, 0, 2)
+	retriedByNode := make(map[string][]string)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/ListBlockErrors":
+			if r.Method != http.MethodGet || r.URL.Query().Get("node") != "*" {
+				t.Fatalf("unexpected ListBlockErrors request: %s %s", r.Method, r.URL.String())
+			}
+			_, _ = fmt.Fprintf(w, `{"success":{"node-b":[{"blockHash":%q}],"node-a":[{"blockHash":%q},{"blockHash":%q},{"blockHash":%q}]},"error":{}}`,
+				hashA, hashB, hashA, hashA)
+		case pathRetryBlockResync:
+			nodeID := r.URL.Query().Get("node")
+			if r.Method != http.MethodPost || nodeID == "" || nodeID == "*" {
+				t.Fatalf("specific hashes must target one error-owning node, got: %s %s", r.Method, r.URL.String())
+			}
+			var body struct {
+				BlockHashes []string `json:"blockHashes"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode RetryBlockResync request: %v", err)
+			}
+			callOrder = append(callOrder, nodeID)
+			retriedByNode[nodeID] = body.BlockHashes
+			_, _ = fmt.Fprintf(w, `{"success":{%q:{"count":%d}},"error":{}}`, nodeID, len(body.BlockHashes))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	result, err := NewClient(srv.URL, "token").RetryBlockResync(context.Background(), "*", false,
+		[]string{strings.ToUpper(hashA), hashB, hashA, hashNoLongerErrored})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 3 {
+		t.Fatalf("retry count = %d, want 3 node-local error records", result.Count)
+	}
+	if got := strings.Join(callOrder, ","); got != "node-a,node-b" {
+		t.Fatalf("retry call order = %q, want deterministic node-a,node-b", got)
+	}
+	if got := strings.Join(retriedByNode["node-a"], ","); got != hashA+","+hashB {
+		t.Fatalf("node-a hashes = %q, want only its unique requested errors", got)
+	}
+	if got := strings.Join(retriedByNode["node-b"], ","); got != hashA {
+		t.Fatalf("node-b hashes = %q, want only its requested error", got)
+	}
+}
+
+func TestRetryBlockResyncWildcardSpecificHashesFailsClosed(t *testing.T) {
+	hash := strings.Repeat("d", 64)
+	t.Run("invalid hash is rejected before an API request", func(t *testing.T) {
+		requests := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			requests++
+		}))
+		defer srv.Close()
+
+		_, err := NewClient(srv.URL, "token").RetryBlockResync(context.Background(), "*", false, []string{"not-a-hash"})
+		if err == nil || !strings.Contains(err.Error(), "64 hexadecimal") {
+			t.Fatalf("invalid hash error = %v", err)
+		}
+		if requests != 0 {
+			t.Fatalf("invalid input made %d API request(s), want 0", requests)
+		}
+	})
+
+	t.Run("per-node listing failure prevents every retry", func(t *testing.T) {
+		retryCalls := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == pathRetryBlockResync {
+				retryCalls++
+			}
+			_, _ = io.WriteString(w, `{"success":{"node-a":[]},"error":{"node-b":"not connected"}}`)
+		}))
+		defer srv.Close()
+
+		_, err := NewClient(srv.URL, "token").RetryBlockResync(context.Background(), "*", false, []string{hash})
+		if err == nil || !strings.Contains(err.Error(), "node-b: not connected") {
+			t.Fatalf("listing failure error = %v", err)
+		}
+		if retryCalls != 0 {
+			t.Fatalf("partial error inventory triggered %d retry call(s), want 0", retryCalls)
+		}
+	})
+
+	t.Run("empty successful inventory is rejected", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{"success":{},"error":{}}`)
+		}))
+		defer srv.Close()
+
+		_, err := NewClient(srv.URL, "token").RetryBlockResync(context.Background(), "*", false, []string{hash})
+		if err == nil || !strings.Contains(err.Error(), "no successful nodes") {
+			t.Fatalf("empty inventory error = %v", err)
+		}
+	})
+}
+
+func TestRetryBlockResyncAllStillUsesGarageWildcard(t *testing.T) {
+	handled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handled = true
+		if r.Method != http.MethodPost || r.URL.Path != pathRetryBlockResync || r.URL.Query().Get("node") != "*" {
+			t.Fatalf("unexpected wildcard retry request: %s %s", r.Method, r.URL.String())
+		}
+		var body map[string]bool
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || !body["all"] {
+			t.Fatalf("wildcard retry body = %#v, err=%v", body, err)
+		}
+		_, _ = io.WriteString(w, `{"success":{"node-a":{"count":2},"node-b":{"count":1}},"error":{}}`)
+	}))
+	defer srv.Close()
+
+	result, err := NewClient(srv.URL, "token").RetryBlockResync(context.Background(), "*", true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !handled || result.Count != 3 {
+		t.Fatalf("wildcard retry handled=%v count=%d, want true/3", handled, result.Count)
+	}
+}
+
 const (
 	pathGetClusterLayout   = "/v2/GetClusterLayout"
 	pathApplyClusterLayout = "/v2/ApplyClusterLayout"
+	pathRetryBlockResync   = "/v2/RetryBlockResync"
 )
 
 // TestApplyStagedLayoutChanges exercises the coordinated apply path. Garage


### PR DESCRIPTION
## Summary

- partition exact block-resync retries by the Garage nodes that currently report each error
- treat hashes that have already disappeared from the error inventory as an idempotent no-op
- fail closed if the per-node error inventory is incomplete
- authenticate cosign to GHCR's Docker credential store before signing the OCI Helm chart
- make the single-cluster restart test wait for an API-visible GarageNode controller observation, not only webhook readiness
- bump the chart, app version, default image tag, and README install example to v0.7.1

## Why

The approved cleanup of orphaned blocks from a deleted bucket exposed that Garage rejects a wildcard retry when the same exact hash list is sent to nodes that do not own those errors. The client now inventories the errors first and sends deterministic node-specific retry requests.

The v0.7.0 chart itself was pushed to GHCR, but its tag workflow failed at the signing step because Helm and cosign use separate credential stores. v0.7.1 logs both tools into GHCR so the chart signature and provenance referrer can be uploaded. The existing simple git-cliff release-note process remains unchanged; the generated GitHub notes will be curated by hand after publication.

The first PR matrix run passed all 13 Ginkgo shards but exposed a separate single-cluster startup race after its deliberate operator restart. Logs showed the replacement webhook was ready before controller workers started; a Manual GarageNode landed in that window and never reached workload creation. The test now requires `status.lastSeen` on an existing GarageNode to advance after restart before it creates the next resources.

## Validation

- `make test`
- `go test ./internal/garage -count=1`
- `make lint` (pre-commit hook, 0 issues)
- `helm lint charts/garage-operator`
- `helm template garage-operator charts/garage-operator`
- `bash -n hack/e2e-cluster.sh`
- `git diff --check`

The updated full E2E matrix must pass before v0.7.1 is tagged.
