### PR TITLE
fix(controller): keep healthy node-local clusters Ready during lock contention

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -502,6 +502,9 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// finalizers drain roles, then their activation labels/resources are
 	// cleaned up.
 	if err := r.reconcileNodeLocalPools(ctx, cluster, nodeLocalPoolConfigHashes); err != nil {
+		if stderrors.Is(err, errLayoutMutationPending) {
+			return r.updateStatusAfterNodeLocalPoolContention(ctx, cluster, err)
+		}
 		return r.updateStatus(ctx, cluster, PhaseFailed, err)
 	}
 	if storageDrainConditionActive(cluster) {
@@ -3583,6 +3586,48 @@ func (r *GarageClusterReconciler) reconcileManagementHandle(ctx context.Context,
 		Reason:  garagev1beta1.ReasonReconcileSuccess,
 		Message: "external Garage Admin API reachable; managing buckets/keys/layout via spec.connectTo",
 	})
+}
+
+// updateStatusAfterNodeLocalPoolContention handles the expected overlap between
+// a GarageNode health pass and the parent controller's node-local activation
+// revalidation. The losing reconciler must retry without presenting the healthy
+// cluster as Failed. If this generation had already converged, preserve that
+// durable condition and refresh the ordinary live status projection. During an
+// actual membership transition, publish an explicit waiting condition instead.
+func (r *GarageClusterReconciler) updateStatusAfterNodeLocalPoolContention(
+	ctx context.Context,
+	cluster *garagev1beta2.GarageCluster,
+	cause error,
+) (ctrl.Result, error) {
+	logf.FromContext(ctx).V(1).Info(
+		"Node-local pool reconciliation is waiting for the active Garage layout operation",
+		"error", cause.Error(),
+	)
+
+	condition := findNodeLocalPoolsReadyCondition(cluster)
+	converged := condition != nil &&
+		condition.Status == metav1.ConditionTrue &&
+		condition.ObservedGeneration == cluster.Generation
+	if !converged {
+		if err := r.setNodeLocalPoolsCondition(
+			ctx,
+			cluster,
+			metav1.ConditionFalse,
+			garagev1beta1.ReasonNodeLocalPoolWaitingForLayoutSync,
+			"waiting for the active Garage layout operation before continuing node-local-pool reconciliation",
+		); err != nil {
+			return ctrl.Result{}, fmt.Errorf("recording node-local-pool layout contention: %w", err)
+		}
+	}
+
+	result, err := r.updateStatusFromCluster(ctx, cluster)
+	if err != nil {
+		return result, err
+	}
+	if result.RequeueAfter == 0 || result.RequeueAfter > RequeueAfterError {
+		result.RequeueAfter = RequeueAfterError
+	}
+	return result, nil
 }
 
 func (r *GarageClusterReconciler) updateStatus(ctx context.Context, cluster *garagev1beta2.GarageCluster, phase string, err error) (ctrl.Result, error) {

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -631,6 +632,88 @@ var _ = Describe("GarageCluster Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(RequeueAfterShort),
 				"absence of optional Admin auth must not be treated as a transient health failure")
+		})
+
+		It("keeps a converged node-local cluster Ready when a sibling layout reconcile owns the mutex", func() {
+			const clusterName = "node-local-layout-contention"
+			clusterKey := types.NamespacedName{Name: clusterName, Namespace: testNamespace}
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Storage: &garagev1beta2.StorageSpec{LayoutPolicy: LayoutPolicyManual},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, cluster) })
+
+			transitionTime := metav1.Now()
+			cluster.Status.Phase = PhaseFailed
+			cluster.Status.Conditions = []metav1.Condition{
+				{
+					Type:               garagev1beta1.ConditionNodeLocalPoolsReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             garagev1beta1.ReasonNodeLocalPoolsConverged,
+					Message:            "node-local-pool members are connected",
+					ObservedGeneration: cluster.Generation,
+					LastTransitionTime: transitionTime,
+				},
+				{
+					Type:               garagev1beta1.ConditionStorageRolloutReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             garagev1beta1.ReasonStorageRolloutConverged,
+					Message:            "all managed identities are ready",
+					ObservedGeneration: cluster.Generation,
+					LastTransitionTime: transitionTime,
+				},
+				{
+					Type:               PhaseReady,
+					Status:             metav1.ConditionFalse,
+					Reason:             garagev1beta1.ReasonReconcileFailed,
+					Message:            "another reconciler is changing Garage layout",
+					ObservedGeneration: cluster.Generation,
+					LastTransitionTime: transitionTime,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, cluster)).To(Succeed())
+
+			node := &garagev1beta1.GarageNode{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName + "-worker", Namespace: testNamespace},
+				Spec: garagev1beta1.GarageNodeSpec{
+					Backing:            garagev1beta1.NodeBackingNodeLocalPool,
+					Capacity:           ptrQuantity(resource.MustParse("100Gi")),
+					ClusterRef:         garagev1beta1.ClusterReference{Name: clusterName},
+					NodeLocalPoolName:  "local",
+					KubernetesNodeName: "worker",
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+			node.Status.NodeID = testTerminalNodeID
+			node.Status.Connected = true
+			node.Status.InLayout = true
+			node.Status.ObservedGeneration = node.Generation
+			Expect(k8sClient.Status().Update(ctx, node)).To(Succeed())
+
+			reconciler := &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			result, err := reconciler.updateStatusAfterNodeLocalPoolContention(
+				ctx,
+				cluster,
+				fmt.Errorf("%w: another reconciler is changing Garage layout", errLayoutMutationPending),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(RequeueAfterError))
+
+			updated := &garagev1beta2.GarageCluster{}
+			Expect(k8sClient.Get(ctx, clusterKey, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(PhaseRunning))
+			ready := meta.FindStatusCondition(updated.Status.Conditions, PhaseReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal("ClusterReady"))
+			poolReady := meta.FindStatusCondition(updated.Status.Conditions, garagev1beta1.ConditionNodeLocalPoolsReady)
+			Expect(poolReady).NotTo(BeNil())
+			Expect(poolReady.Status).To(Equal(metav1.ConditionTrue))
+			Expect(poolReady.Reason).To(Equal(garagev1beta1.ReasonNodeLocalPoolsConverged))
 		})
 
 		It("counts unlabeled clusterRef-matched GarageNodes toward readiness in Auto mode (#237)", func() {


### PR DESCRIPTION
## Summary

- treat expected node-local layout mutex contention as retryable instead of setting the GarageCluster phase to Failed
- preserve a current-generation converged NodeLocalPoolsReady condition and refresh live cluster status
- report WaitingForLayoutSync when membership has not converged yet
- retry after 30 seconds without bypassing the layout mutex or allowing a competing mutation

## Live reproduction

After the Ottawa node-local pools converged, all 22 Garage nodes were connected, all 16 storage nodes were up, all 256 partitions were healthy, layout version 177 was fully acknowledged, and every enabled block-resync worker was idle with zero persistent errors. The parent GarageCluster nevertheless oscillated to Failed because its periodic HostPath-claim revalidation overlapped an ordinary GarageNode health reconciliation holding the per-cluster layout mutex.

The contention is expected single-flight behavior. The losing reconcile must stop and retry, but it should not overwrite an already-converged and healthy status with ReconcileFailed.

## Safety

This does not weaken serialization. The losing parent reconcile still returns before later workload, federation, or layout operations. Only status reporting changes: converged health is refreshed, while an unfinished membership transition receives an explicit waiting condition.

## Verification

- focused Ottawa regression passes
- go test ./internal/controller/... -count=1
- go test ./... -count=1
- make lint (0 issues)