### PR TITLE
chore(release): prepare v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ helm install garage-operator oci://ghcr.io/rajsinghtech/charts/garage-operator \
 Released container images and Helm charts are signed with [cosign](https://docs.sigstore.dev/) keyless signing (the GitHub Actions OIDC identity — no long-lived keys), and carry SLSA build provenance. The image additionally carries an SPDX SBOM. All three are stored in GHCR as OCI referrers of the artifact digest.
 
 ```bash
-IMAGE=ghcr.io/rajsinghtech/garage-operator:v0.7.1
+IMAGE=ghcr.io/rajsinghtech/garage-operator:v0.7.2
 
 # Signature
 cosign verify "$IMAGE" \

--- a/charts/garage-operator/Chart.yaml
+++ b/charts/garage-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: garage-operator
 description: A Kubernetes operator for managing Garage distributed S3-compatible object storage
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.7.2
+appVersion: "0.7.2"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/rajsinghtech/garage-operator
 sources:

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)
-  tag: "v0.7.1"
+  tag: "v0.7.2"
 
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.


### PR DESCRIPTION
## Summary

- bump the operator Helm chart and app version to 0.7.2
- default the chart to the v0.7.2 image
- update the signed-image verification example

This is the metadata-only release preparation for the layout-lock contention fix in #312. The existing tag-driven git-cliff release process is unchanged.

## Verification

- helm lint charts/garage-operator
- git diff --check