### PR TITLE
chore(release): prepare v0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ helm install garage-operator oci://ghcr.io/rajsinghtech/charts/garage-operator \
 Released container images and Helm charts are signed with [cosign](https://docs.sigstore.dev/) keyless signing (the GitHub Actions OIDC identity — no long-lived keys), and carry SLSA build provenance. The image additionally carries an SPDX SBOM. All three are stored in GHCR as OCI referrers of the artifact digest.
 
 ```bash
-IMAGE=ghcr.io/rajsinghtech/garage-operator:v0.7.2
+IMAGE=ghcr.io/rajsinghtech/garage-operator:v0.7.3
 
 # Signature
 cosign verify "$IMAGE" \

--- a/charts/garage-operator/Chart.yaml
+++ b/charts/garage-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: garage-operator
 description: A Kubernetes operator for managing Garage distributed S3-compatible object storage
 type: application
-version: 0.7.2
-appVersion: "0.7.2"
+version: 0.7.3
+appVersion: "0.7.3"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/rajsinghtech/garage-operator
 sources:

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)
-  tag: "v0.7.2"
+  tag: "v0.7.3"
 
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.


### PR DESCRIPTION
## v0.7.3

This patch keeps long-running storage drains moving through temporary federation read failures instead of discarding completed repair work and launching duplicate full scans.

The safety boundary is unchanged: quiet/completion timing is cleared on an unreadable observation, and real process or worker replacement still resets the proof.

## Verification

- full make test suite passed on the fix commit
- Helm lint passed
- pre-commit golangci-lint reported zero issues