### PR TITLE
fix(bucket): reserve a global alias only when the add will happen

### DIFF
--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -21,6 +21,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -628,6 +629,8 @@ func (r *GarageBucketReconciler) clearBucketReservationAlias(
 }
 
 func (r *GarageBucketReconciler) reconcileGlobalAlias(ctx context.Context, bucket *garagev1beta1.GarageBucket, garageClient *garage.Client, bucketID, alias string, currentAliases []string) error {
+	found := slices.Contains(currentAliases, alias)
+
 	// Clean an abandoned reserved add before replacing its durable identity.
 	if pending := bucket.Status.PendingGlobalAlias; pending != "" && pending != alias && pending != bucket.Status.ManagedGlobalAlias {
 		for _, current := range currentAliases {
@@ -646,20 +649,17 @@ func (r *GarageBucketReconciler) reconcileGlobalAlias(ctx context.Context, bucke
 			return fmt.Errorf("failed to clear abandoned global alias reservation: %w", err)
 		}
 	}
-	if bucket.Status.PendingGlobalAlias != alias {
+	// Reserve only when the add is actually about to happen. The reservation
+	// exists to record intent before mutating remote state; when the alias is
+	// already live there is nothing to record, and writing it here would be
+	// undone by the handoff below on every single reconcile.
+	if !found && bucket.Status.PendingGlobalAlias != alias {
 		bucket.Status.PendingGlobalAlias = alias
 		if err := UpdateStatusWithRetry(ctx, r.Client, bucket); err != nil {
 			return fmt.Errorf("failed to reserve global alias: %w", err)
 		}
 	}
 
-	found := false
-	for _, a := range currentAliases {
-		if a == alias {
-			found = true
-			break
-		}
-	}
 	if !found {
 		_, err := garageClient.AddBucketAlias(ctx, garage.AddBucketAliasRequest{
 			BucketID:    bucketID,

--- a/internal/controller/garagebucket_controller_test.go
+++ b/internal/controller/garagebucket_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -809,6 +810,129 @@ func TestUpdateStatusFromGarageUsesAuthoritativeMutationSnapshot(t *testing.T) {
 		fresh.Status.LocalAliases[0].KeyName != "snapshot-key" ||
 		fresh.Status.LocalAliases[0].Alias != alias {
 		t.Fatalf("localAliases=%+v, want exact authoritative alias status", fresh.Status.LocalAliases)
+	}
+}
+
+// Adopting a bucket whose alias is already live must not write a reservation.
+// The reservation records intent before an add; when no add happens there is
+// nothing to record, and writing it costs an extra status round trip that the
+// handoff below immediately undoes.
+func TestReconcileGlobalAlias_AdoptionDoesNotReserve(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = garagev1beta1.AddToScheme(s)
+	const alias = "adopted-global"
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "bucket-adopt", Namespace: testNamespace},
+		Status:     garagev1beta1.GarageBucketStatus{},
+	}
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(bucket).
+		WithStatusSubresource(&garagev1beta1.GarageBucket{}).Build()
+	r := &GarageBucketReconciler{Client: fc, Scheme: s}
+
+	var adminCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		adminCalls.Add(1)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	before := &garagev1beta1.GarageBucket{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, before); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.reconcileGlobalAlias(context.Background(), bucket, garage.NewClient(srv.URL, "tok"), "bucket-id", alias, []string{alias}); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := adminCalls.Load(); n != 0 {
+		t.Fatalf("admin API calls=%d, want 0 when the alias is already live", n)
+	}
+	// Exactly one write: the ownership handoff. A reservation write here would
+	// be dead weight, since the alias needed no add.
+	after := &garagev1beta1.GarageBucket{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, after); err != nil {
+		t.Fatal(err)
+	}
+	writes := mustAtoi(t, after.ResourceVersion) - mustAtoi(t, before.ResourceVersion)
+	if writes != 1 {
+		t.Fatalf("status writes=%d (rv %s -> %s), want 1 (the ownership handoff only)",
+			writes, before.ResourceVersion, after.ResourceVersion)
+	}
+	if bucket.Status.ManagedGlobalAlias != alias {
+		t.Fatalf("managedGlobalAlias=%q, want %q", bucket.Status.ManagedGlobalAlias, alias)
+	}
+	if bucket.Status.PendingGlobalAlias != "" {
+		t.Fatalf("pendingGlobalAlias=%q, want empty", bucket.Status.PendingGlobalAlias)
+	}
+	if after.Status.ManagedGlobalAlias != alias {
+		t.Fatalf("persisted managedGlobalAlias=%q, want %q", after.Status.ManagedGlobalAlias, alias)
+	}
+}
+
+// mustAtoi parses a fake-client resourceVersion, which is a plain counter.
+func mustAtoi(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		t.Fatalf("resourceVersion %q is not an integer: %v", s, err)
+	}
+	return n
+}
+
+// A settled bucket must be a complete no-op: no status write, no admin call.
+// The reserve/commit pair is self-cancelling (commit resets PendingGlobalAlias
+// to "", which re-arms the reserve guard), so unless the reserve is gated on an
+// add actually happening it writes status twice per reconcile, and each write
+// wakes the watch that schedules the next reconcile — an unbounded loop that
+// hammers the Garage admin API.
+func TestReconcileGlobalAlias_SettledBucketIsNoOp(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = garagev1beta1.AddToScheme(s)
+	const alias = "settled-global"
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "bucket-settled", Namespace: testNamespace},
+		Status: garagev1beta1.GarageBucketStatus{
+			ManagedGlobalAlias: alias,
+			GlobalAlias:        alias,
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(bucket).
+		WithStatusSubresource(&garagev1beta1.GarageBucket{}).Build()
+	r := &GarageBucketReconciler{Client: fc, Scheme: s}
+
+	var adminCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		adminCalls.Add(1)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	before := &garagev1beta1.GarageBucket{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, before); err != nil {
+		t.Fatal(err)
+	}
+
+	// Repeat: a loop only shows up once the first pass has cleared Pending.
+	for i := range 3 {
+		if err := r.reconcileGlobalAlias(context.Background(), bucket, garage.NewClient(srv.URL, "tok"), "bucket-id", alias, []string{alias, "user-managed"}); err != nil {
+			t.Fatalf("pass %d: %v", i, err)
+		}
+	}
+
+	if n := adminCalls.Load(); n != 0 {
+		t.Fatalf("admin API calls=%d, want 0 for a settled bucket", n)
+	}
+	if bucket.Status.PendingGlobalAlias != "" {
+		t.Fatalf("pendingGlobalAlias=%q, want empty", bucket.Status.PendingGlobalAlias)
+	}
+	after := &garagev1beta1.GarageBucket{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: bucket.Name, Namespace: bucket.Namespace}, after); err != nil {
+		t.Fatal(err)
+	}
+	if after.ResourceVersion != before.ResourceVersion {
+		t.Fatalf("resourceVersion %s -> %s, want no status write for a settled bucket",
+			before.ResourceVersion, after.ResourceVersion)
 	}
 }
 


### PR DESCRIPTION
## Summary

`reconcileGlobalAlias` gates its reservation write on `pending != alias`, which is true whenever `pendingGlobalAlias` is empty. That condition never asks the question the reservation exists to answer — *is an add about to happen?* — so it fires on buckets that need no add at all, and the ownership handoff then resets `pending` to `""`, re-arming the guard for the next pass.

This changes the guard to `!found && pending != alias`, so the reservation is written only when the alias is genuinely missing and an `AddBucketAlias` is about to follow. The `currentAliases` membership test already existed a few lines below; it is hoisted to the top of the function and reused.

Two behaviors change, both toward fewer writes:

| path | before | after |
| --- | --- | --- |
| settled bucket (alias live, ownership recorded) | 2 status writes per reconcile, forever | 0 |
| adoption (alias live, ownership not yet recorded) | 2 status writes | 1 |

The settled case is the serious one. Each status write wakes the controller's own watch, which schedules the next reconcile, which writes twice more. The result is an unbounded reconcile loop on every bucket that has a global alias — roughly 75 `GetBucketInfo` admin API calls per bucket per minute, indefinitely, scaling linearly with bucket count.

The end-of-reconcile no-op guard (`apiequality.Semantic.DeepEqual(*oldStatus, bucket.Status)` → `RequeueAfterDrift`) cannot catch it. Both writes happen inside this helper and the net status delta across the reconcile is zero, so the caller correctly concludes nothing changed and backs off to five minutes — after the intermediate writes have already fired the watch events that restart it immediately.

v0.7.3 was unaffected because the function opened by returning when the alias was already present. That early return implicitly encoded the missing condition; the two-phase reservation added in v0.7.4 replaced it without carrying the condition over. Restoring the early return would also stop the loop, but it gates around the defect rather than repairing it — the reserve guard would still be wrong, the adoption path would still pay for a reservation it never uses, and the self-cancelling pair would survive behind the gate.

## Related issue or design

Fixes #327

## Compatibility and operational impact

- **API:** none. No changes to types, kubebuilder markers, CRDs, schemas, or samples; `make manifests generate` produces no diff.
- **Status semantics:** unchanged. `pendingGlobalAlias` keeps its meaning — an in-flight reservation held only across an add. The difference is that it is no longer written when there is no add to protect.
- **Crash safety:** preserved. The reservation is still persisted before `AddBucketAlias` in every case where an add occurs, so an interrupted rename still cannot leave a bucket alias-less. Recovery paths are unchanged: a reservation abandoned by a changed desired alias is still detected and cleaned by the block above, and a crash between add and handoff still resolves on the next reconcile via the ownership comparison below.
- **Adds and renames:** behaviorally identical. Only the settled and adoption paths lose writes, and in both of those no remote mutation was ever performed.
- **Rollback:** trivial and stateless. Reverting restores the previous write pattern; no migration, no persisted state depends on the change.
- **Upgrade:** no action required. Buckets stuck in the loop settle on the first reconcile after the new binary starts.

## Validation

Commands run:

- `make fmt vet` — clean
- `make lint` (golangci-lint v2.12.2) — 0 issues
- `make test` — all packages pass, including the 320-spec envtest suite
- `make test-race` — all packages pass, no data races
- `make manifests generate` — no drift, working tree clean afterwards

Not run:

- `make test-e2e` and the other Kind-based e2e targets — no isolated Kind environment available locally. CI covers these.

Two regression tests are added, both verified to fail against unpatched v0.7.4 and pass with the change:

```
--- FAIL: TestReconcileGlobalAlias_SettledBucketIsNoOp
    resourceVersion 999 -> 1005, want no status write for a settled bucket
--- FAIL: TestReconcileGlobalAlias_AdoptionDoesNotReserve
    status writes=2 (rv 999 -> 1001), want 1 (the ownership handoff only)
```

`SettledBucketIsNoOp` reconciles a settled bucket three times and asserts zero admin API calls and an unchanged `resourceVersion` — three passes because a single pass cannot distinguish the loop from ordinary convergence. `AdoptionDoesNotReserve` covers a bucket whose alias is already live but whose ownership is not yet recorded, and asserts exactly one write.

### Runtime evidence

This exact build has been running on two clusters (one amd64, one arm64) since 2026-08-15.

Before, on a cluster with 18 buckets — `status.pendingGlobalAlias` flapping about twice a second, with nothing else in the object changing:

```
545433927 my-bucket
545433928 null
545433978 my-bucket
545433979 null
```

Admin API volume on that instance was ~1,400 `GetBucketInfo` calls per minute, against a pre-v0.7.4 baseline of 50–110 per *hour*.

After: 0 calls per minute on both clusters, 0 of 18 buckets showing any `resourceVersion` change over a 60s window, all buckets `Ready`, and the operator logging no errors. Reconciles continue normally at the drift interval, so the controller is idle rather than wedged.

## Checklist

- [x] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [x] Tests cover the changed behavior.
- [x] User-facing docs and samples are updated where needed. *(No user-facing surface changes; the only files mentioning these status fields are the generated CRD schemas, whose descriptions are unchanged.)*
- [x] Generated files were regenerated and committed where needed. *(`make manifests generate` produces no diff.)*
- [x] Release-only chart version fields are unchanged.
