### PR TITLE
fix: surface real connectivity errors and support CLUSTER_DOMAIN env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,6 +62,23 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+// defaultClusterDomain is used when neither --cluster-domain nor
+// CLUSTER_DOMAIN is set.
+const defaultClusterDomain = "cluster.local"
+
+// clusterDomainDefault resolves the --cluster-domain flag's default: the
+// CLUSTER_DOMAIN env var if set, otherwise defaultClusterDomain. This lets a
+// plain kubectl apply -f install.yaml deployment configure the cluster domain
+// via the container's env instead of needing a templating layer (Helm) to add
+// the --cluster-domain arg. An explicit --cluster-domain flag still wins over
+// the env var.
+func clusterDomainDefault() string {
+	if v := os.Getenv("CLUSTER_DOMAIN"); v != "" {
+		return v
+	}
+	return defaultClusterDomain
+}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
@@ -117,10 +134,12 @@ func main() {
 		"Default Garage container image for clusters that don't specify one. "+
 			"If empty, uses the built-in digest-pinned Garage v2.3.0 image.")
 
-	// Cluster domain
+	// Cluster domain. See clusterDomainDefault for the CLUSTER_DOMAIN env var
+	// fallback.
 	var clusterDomain string
-	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local",
-		"Kubernetes cluster domain used for service FQDNs (e.g. cluster.local, eu-cluster.local)")
+	flag.StringVar(&clusterDomain, "cluster-domain", clusterDomainDefault(),
+		"Kubernetes cluster domain used for service FQDNs (e.g. cluster.local, eu-cluster.local). "+
+			"Can also be set via CLUSTER_DOMAIN env var.")
 
 	// operator-namespace is kept for backward compatibility but is no longer used.
 	// Internal key Secrets are now stored in the GarageCluster's own namespace.

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -57,3 +57,25 @@ func TestValidateLeaderElectionSafety(t *testing.T) {
 		})
 	}
 }
+
+// Not run in parallel: t.Setenv forbids it, since concurrent subtests would
+// race on the shared process environment. t.Setenv also restores the prior
+// value (or unsets it) automatically at the end of each subtest.
+func TestClusterDomainDefault(t *testing.T) {
+	// Go's testing package has no t.Unsetenv; t.Setenv("", "") is the
+	// documented way to simulate "unset" for a test while still getting
+	// automatic restoration.
+	t.Run("falls back when unset", func(t *testing.T) {
+		t.Setenv("CLUSTER_DOMAIN", "")
+		if got := clusterDomainDefault(); got != defaultClusterDomain {
+			t.Fatalf("clusterDomainDefault() = %q, want fallback %q", got, defaultClusterDomain)
+		}
+	})
+
+	t.Run("uses the env var when set", func(t *testing.T) {
+		t.Setenv("CLUSTER_DOMAIN", "kubernetes01.example.com")
+		if got := clusterDomainDefault(); got != "kubernetes01.example.com" {
+			t.Fatalf("clusterDomainDefault() = %q, want %q", got, "kubernetes01.example.com")
+		}
+	})
+}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,6 +74,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        # On a cluster with a non-default Kubernetes DNS domain (e.g. Talos's
+        # cluster.network.dnsDomain), uncomment and set this so the operator's
+        # internal admin-API URLs resolve. The Helm chart exposes this as
+        # `clusterDomain` in values.yaml; this manifest has no templating
+        # layer, so set it directly here instead.
+        # - name: CLUSTER_DOMAIN
+        #   value: "cluster.local"
         ports: []
         securityContext:
           readOnlyRootFilesystem: true

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -37,6 +37,35 @@ kubectl describe garagekey app-key -n storage
 
 Confirm the referenced cluster is `Ready`, the Admin token works, and any cross-namespace `GarageReferenceGrant` exists in the destination namespace. A lifecycle rule on Garage `<2.3.0` can be accepted but remains `LifecycleConfigured=False` when the Admin API cannot persist it.
 
+### Bucket/key/token stuck Pending with a `ClusterNotReady` condition mentioning DNS
+
+The `GarageCluster` itself can be `Running` (its pods are reachable directly by
+IP) while `GarageBucket`/`GarageKey`/`GarageAdminToken` resources stay
+`Pending` forever, because those controllers reach the cluster through its
+`<name>.<namespace>.svc.<cluster-domain>` Service DNS name, not a pod IP. On a
+cluster with a non-default Kubernetes DNS domain (e.g. a Talos cluster with
+`cluster.network.dnsDomain` set), the operator's internal admin-API calls use
+the wrong suffix and every lookup fails with `no such host`.
+
+```bash
+kubectl get garagekey app-key -n storage \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}{"\n"}'
+```
+
+If the message contains `no such host` naming a `.svc.cluster.local` address
+that doesn't match your cluster's real DNS domain, set the operator's cluster
+domain to match:
+
+- **Helm**: `--set clusterDomain=<your-domain>` (see the
+  [Helm reference](../reference/helm.md)).
+- **Raw manifest (`install.yaml`/kustomize)**: uncomment and set the
+  `CLUSTER_DOMAIN` env var on the `manager` container in
+  `config/manager/manager.yaml`, or patch the running Deployment directly.
+
+The operator's admin-API flag/env var is `--cluster-domain` / `CLUSTER_DOMAIN`
+(default `cluster.local`); a restart is required after changing it since it is
+read once at startup.
+
 ## `403 No such key` from S3
 
 This often means a gateway identity lost its capacity-less layout role, not that the S3 key Secret is wrong.

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -25,7 +25,7 @@ The chart is `oci://ghcr.io/rajsinghtech/charts/garage-operator`. The complete, 
 | `image.digest` | empty | `sha256:` digest takes precedence over tag |
 | `defaultGarageImage` | empty | Default for Garage CRs omitting `spec.image` |
 | `resources.requests.memory` | `128Mi` | `256Mi` is recommended for stable operation at larger resource counts |
-| `clusterDomain` | `cluster.local` | Override for custom Kubernetes DNS domains |
+| `clusterDomain` | `cluster.local` | Override for custom Kubernetes DNS domains. Renders as the operator's `--cluster-domain` flag (also settable as the `CLUSTER_DOMAIN` env var for non-Helm installs). See [troubleshooting](../operations/troubleshooting.md#bucketkeytoken-stuck-pending-with-a-clusternotready-condition-mentioning-dns) if bucket/key/token resources stay `Pending` with a DNS error. |
 
 ## Scope and COSI
 

--- a/internal/controller/garageadmintoken_controller.go
+++ b/internal/controller/garageadmintoken_controller.go
@@ -111,7 +111,7 @@ func (r *GarageAdminTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Namespace: clusterNamespace,
 	}, cluster); err != nil {
 		if errors.IsNotFound(err) {
-			return r.updateStatusWaiting(ctx, token)
+			return r.updateStatusWaiting(ctx, token, nil)
 		}
 		return r.updateStatus(ctx, token, PhaseFailed, fmt.Errorf("cluster not found: %w", err))
 	}
@@ -127,8 +127,13 @@ func (r *GarageAdminTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Reconcile the admin token secret
 	if err := r.reconcileSecret(ctx, token, cluster); err != nil {
+		// The same transient-looking error shape also covers a permanent
+		// misconfiguration (e.g. an unresolvable cluster-domain) that will
+		// retry forever without ever becoming a PhaseFailed, so keep the real
+		// error text on the condition — it's the only place that distinction
+		// is visible to the user.
 		if isTransientConnectivityError(err) {
-			return r.updateStatusWaiting(ctx, token)
+			return r.updateStatusWaiting(ctx, token, err)
 		}
 		return r.updateStatus(ctx, token, PhaseFailed, err)
 	}
@@ -397,13 +402,18 @@ func validateGarageAdminTokenSecretDigest(token *garagev1beta1.GarageAdminToken,
 	return nil
 }
 
-func (r *GarageAdminTokenReconciler) updateStatusWaiting(ctx context.Context, token *garagev1beta1.GarageAdminToken) (ctrl.Result, error) {
+// updateStatusWaiting records a ClusterNotReady wait. cause, when non-nil, is
+// the connectivity error that triggered the wait; its text is folded into the
+// condition message (see waitingForClusterMessage) so a permanent
+// misconfiguration (e.g. an unresolvable cluster-domain) is visible on the CR
+// itself rather than only in operator debug logs.
+func (r *GarageAdminTokenReconciler) updateStatusWaiting(ctx context.Context, token *garagev1beta1.GarageAdminToken, cause error) (ctrl.Result, error) {
 	token.Status.Phase = PhasePending
 	meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
 		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1beta1.ReasonClusterNotReady,
-		Message:            msgWaitingForCluster,
+		Message:            waitingForClusterMessage(cause),
 		ObservedGeneration: token.Generation,
 	})
 	if statusErr := r.Status().Update(ctx, token); statusErr != nil {

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -144,7 +144,7 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Now check cluster error for non-deletion cases
 	if clusterErr != nil {
 		if errors.IsNotFound(clusterErr) {
-			return r.updateStatusWaiting(ctx, key)
+			return r.updateStatusWaiting(ctx, key, nil)
 		}
 		return r.updateStatus(ctx, key, PhaseFailed, fmt.Errorf("cluster not found: %w", clusterErr))
 	}
@@ -230,9 +230,13 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Transient connectivity errors (DNS not ready, connection refused) are
 	// expected while the cluster Service is being created. Treat them as a
-	// waiting state rather than a permanent error.
+	// waiting state rather than a permanent error, but keep the real error
+	// text on the condition: the same error shape also covers a permanent
+	// misconfiguration (e.g. an unresolvable cluster-domain) that will retry
+	// forever without ever becoming a PhaseFailed, so the message is the only
+	// place that distinction is visible to the user.
 	if keyErr != nil && isTransientConnectivityError(keyErr) {
-		return r.updateStatusWaiting(ctx, key)
+		return r.updateStatusWaiting(ctx, key, keyErr)
 	}
 
 	// Only create/update the Kubernetes secret if the key was successfully created
@@ -1502,13 +1506,18 @@ func (r *GarageKeyReconciler) garageKeyFinalizationID(ctx context.Context, key *
 	return resolved, nil
 }
 
-func (r *GarageKeyReconciler) updateStatusWaiting(ctx context.Context, key *garagev1beta1.GarageKey) (ctrl.Result, error) {
+// updateStatusWaiting records a ClusterNotReady wait. cause, when non-nil, is
+// the connectivity error that triggered the wait; its text is folded into the
+// condition message (see waitingForClusterMessage) so a permanent
+// misconfiguration (e.g. an unresolvable cluster-domain) is visible on the CR
+// itself rather than only in operator debug logs.
+func (r *GarageKeyReconciler) updateStatusWaiting(ctx context.Context, key *garagev1beta1.GarageKey, cause error) (ctrl.Result, error) {
 	key.Status.Phase = PhasePending
 	meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
 		Type:               PhaseReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             garagev1beta1.ReasonClusterNotReady,
-		Message:            msgWaitingForCluster,
+		Message:            waitingForClusterMessage(cause),
 		ObservedGeneration: key.Generation,
 	})
 	if statusErr := UpdateStatusWithRetry(ctx, r.Client, key); statusErr != nil {
@@ -1552,7 +1561,7 @@ func (r *GarageKeyReconciler) updateStatusFromGarage(ctx context.Context, key *g
 	garageKey, err := garageClient.GetKey(ctx, garage.GetKeyRequest{ID: key.Status.AccessKeyID})
 	if err != nil {
 		if isTransientConnectivityError(err) {
-			return r.updateStatusWaiting(ctx, key)
+			return r.updateStatusWaiting(ctx, key, err)
 		}
 		if garage.IsNotFound(err) {
 			// Key was deleted externally. Clear the cached ID so the next reconcile

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -449,6 +449,31 @@ func svcFQDN(name, namespace string, port int32, clusterDomain string) string {
 	return fmt.Sprintf("%s.%s.svc.%s:%d", name, namespace, clusterDomain, port)
 }
 
+// waitingForClusterMessage builds the message for a ClusterNotReady condition.
+// When cause is non-nil, its text is appended so a connectivity failure that
+// never actually resolves (e.g. a wrong --cluster-domain producing a permanent
+// "no such host" DNS error) is visible on the CR's own status instead of being
+// indistinguishable from an ordinary "Service not created yet" wait — the two
+// look identical to isTransientConnectivityError, but only the operator's debug
+// logs previously showed which one was happening.
+func waitingForClusterMessage(cause error) string {
+	if cause == nil {
+		return msgWaitingForCluster
+	}
+	return fmt.Sprintf("%s: %s", msgWaitingForCluster, cause.Error())
+}
+
+// transientConnectivityErrSubstrings are the dial/DNS error substrings
+// isTransientConnectivityError matches on. Exported as a var (not inlined)
+// so tests can build a representative error without duplicating the literal
+// "i/o timeout" a third time, which trips goconst.
+var transientConnectivityErrSubstrings = []string{
+	"no such host",
+	"connection refused",
+	"dial tcp",
+	"i/o timeout",
+}
+
 // isTransientConnectivityError returns true for errors that indicate the cluster
 // service is temporarily unreachable (DNS not yet propagated, pod not yet ready,
 // etc.) and should be retried without surfacing as a permanent error condition.
@@ -462,12 +487,7 @@ func isTransientConnectivityError(err error) bool {
 		return true
 	}
 	msg := err.Error()
-	for _, substr := range []string{
-		"no such host",
-		"connection refused",
-		"dial tcp",
-		"i/o timeout",
-	} {
+	for _, substr := range transientConnectivityErrSubstrings {
 		if strings.Contains(msg, substr) {
 			return true
 		}

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -1146,6 +1146,46 @@ func TestFindSelfNode(t *testing.T) {
 	}
 }
 
+func TestWaitingForClusterMessage(t *testing.T) {
+	if got := waitingForClusterMessage(nil); got != msgWaitingForCluster {
+		t.Errorf("waitingForClusterMessage(nil) = %q, want %q", got, msgWaitingForCluster)
+	}
+
+	cause := fmt.Errorf("dial tcp: lookup garage.garage.svc.cluster.local: no such host")
+	got := waitingForClusterMessage(cause)
+	if !strings.Contains(got, msgWaitingForCluster) {
+		t.Errorf("waitingForClusterMessage(%v) = %q, missing base message %q", cause, got, msgWaitingForCluster)
+	}
+	if !strings.Contains(got, "no such host") {
+		t.Errorf("waitingForClusterMessage(%v) = %q, missing cause detail", cause, got)
+	}
+}
+
+func TestIsTransientConnectivityError(t *testing.T) {
+	if len(transientConnectivityErrSubstrings) == 0 {
+		t.Fatal("transientConnectivityErrSubstrings is empty")
+	}
+	for _, substr := range transientConnectivityErrSubstrings {
+		t.Run(substr, func(t *testing.T) {
+			err := fmt.Errorf("dial tcp 10.0.0.1:3903: %s", substr)
+			if !isTransientConnectivityError(err) {
+				t.Errorf("isTransientConnectivityError(%v) = false, want true", err)
+			}
+		})
+	}
+	t.Run("nil", func(t *testing.T) {
+		if isTransientConnectivityError(nil) {
+			t.Error("isTransientConnectivityError(nil) = true, want false")
+		}
+	})
+	t.Run("unrelated error", func(t *testing.T) {
+		err := fmt.Errorf("bucket %q is not empty", "app-data")
+		if isTransientConnectivityError(err) {
+			t.Errorf("isTransientConnectivityError(%v) = true, want false", err)
+		}
+	})
+}
+
 func TestAdminEndpoint(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
# Pull request

## Summary

Fixes #331. The reporter saw a `GarageCluster` reach `Running`/`Ready` while `GarageKey`/`GarageBucket` resources referencing it stayed `Pending` forever with no clear error — traced to the operator's internal admin-API calls using a hardcoded `.svc.cluster.local` suffix on a cluster with a non-default Kubernetes DNS domain.

Investigation found the `--cluster-domain` flag that fixes the DNS suffix has actually existed since v0.2.1 itself (the version in the report), fully wired through the Helm chart — so this isn't a "please upgrade" issue. The real, still-present gaps this PR fixes:

1. **`isTransientConnectivityError()` treated a permanent DNS failure (`no such host`) identically to a genuinely transient one** (connection refused, i/o timeout, 503), and `updateStatusWaiting()` always overwrote the real error with a static `"waiting for cluster to be reachable"` message. This made a permanently misconfigured cluster domain indistinguishable, on the CR itself, from an ordinary "Service not created yet" — the real error was only visible in operator debug logs, exactly matching the report. Fixed by threading the actual error text into the condition message in the `GarageKey` and `GarageAdminToken` controllers. Retry timing/behavior is unchanged — this only changes what's shown. `GarageBucket` already surfaced its connectivity errors correctly via `PhaseFailed`, so it needed no behavior change.

2. **`--cluster-domain` was only reachable via the Helm chart's `clusterDomain` value.** The raw manifest/kustomize install path (`config/manager/manager.yaml`, and by extension the `install.yaml` release asset) had no way to set it at all. Added a `CLUSTER_DOMAIN` env var fallback (mirroring the existing `WATCH_NAMESPACE` pattern) and a commented example in the manifest.

3. **Documented the failure mode** in the troubleshooting guide with the exact `kubectl` command to spot it, and cross-referenced it from the Helm values reference table.

## Related issue or design

Fixes #331.

## Compatibility and operational impact

None. `--cluster-domain` still defaults to `cluster.local` and still wins over the new `CLUSTER_DOMAIN` env var when both are set, so existing Helm/CLI-arg deployments are unaffected. The condition message change is additive (existing message text is a prefix of the new one) and doesn't change `Reason`, `Phase`, or requeue timing, so it shouldn't break anything scraping the old exact string.

## Validation

Commands run:

- `go build ./...`
- `go vet ./...`
- `go test ./cmd/... -count=1`
- `go test ./api/... -count=1`
- `go test ./internal/controller/... -run 'TestWaitingForClusterMessage|TestIsTransientConnectivityError|TestBuildSecretData' -v -count=1`
- `gofmt -l .` (clean)

Not run:

- Full Ginkgo envtest suite (needs kube-apiserver/etcd, CI-only per project convention).
- e2e suite (needs a live Kind cluster, unavailable in this environment).

## Checklist

- [x] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [x] Tests cover the changed behavior.
- [x] User-facing docs and samples are updated where needed.
- [ ] Generated files were regenerated and committed where needed. (not applicable — `dist/install.yaml` is a gitignored build artifact regenerated by CI/release)
- [x] Release-only chart version fields are unchanged.