### PR TITLE
test(e2e): fix api-manual-mode DrainPrepared timeout flake

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4100,10 +4100,15 @@ spec:
 			g.Expect(parts[2:]).To(Equal([]string{"True", "PreparedForDeletion"}),
 				"GarageNode drain has not completed its exact block/layout proof: %q", output)
 		}
-		// The production proof includes Garage's 610-second delayed-block-GC
-		// interval plus a clean observation window; this timeout is scoped to
-		// that safety transaction rather than ordinary workload readiness.
-		Eventually(verifyDrainPrepared, 20*time.Minute, 10*time.Second).Should(Succeed())
+		// The production proof is two phases, not one fixed interval: first the
+		// operator launches and waits for verification-node block-repair workers
+		// to go idle (unbounded — observed ~10m on a loaded CI runner before
+		// QuietSince is even set), then only after that does Garage's own
+		// 610-second delayed-block-GC quiet window start. A 20m budget measured
+		// only the second phase and timed out ~2m short in practice
+		// ("waiting 2m4s more through Garage's delayed-resync interval" at the
+		// 20m mark). 30m covers both phases with real margin.
+		Eventually(verifyDrainPrepared, 30*time.Minute, 10*time.Second).Should(Succeed())
 
 		By("deleting the now-prepared GarageNode through admission's exact terminal-proof check")
 		cmd = exec.Command("kubectl", "delete", "garagenode", node2Name,


### PR DESCRIPTION
# Pull request

## Summary

`should prepare and complete deletion after replacement capacity joins` timed out on `main` immediately after PR #333 merged ([run 31971250562](https://github.com/rajsinghtech/garage-operator/actions/runs/31971250562)), hitting the 20-minute `Eventually` budget on the `DrainPrepared` wait.

Debug artifacts from that run show the real timing: the drain request landed at `20:50:18`, but `status.storageDrain.quietSince` didn't get set until `21:00:28` — a ~10-minute gap where the operator was launching and waiting for verification-node block-repair workers to go idle before it could even start Garage's own 610-second delayed-block-GC quiet window. At the 20-minute deadline (`21:10:17`) the GarageNode's `StorageDrainReady` condition read `"waiting 2m4s more through Garage's delayed-resync interval"` — the wait was making real progress, just ~2 minutes short of the fixed budget.

The 20m budget only ever measured the second phase (the 610s quiet window plus margin); it didn't account for the first phase's launch/verification time, which isn't bounded by a fixed constant the way `garageBlockGCDelay` is. Bumped to 30m to cover both phases with real margin.

I did **not** touch the other 20-minute drain-wait `Eventually`s in the file (the `node-local-pools` ones) — those have three consecutive green CI runs and no observed timing gap, so there's no evidence they need the same treatment, and speculatively widening every drain wait in the suite isn't itself a robustness improvement.

## Related issue or design

Found via CI history audit following up on #330/#333 — no filed issue.

## Compatibility and operational impact

None. Test-only change, one `Eventually` timeout increased. The shard's job/Go timeouts have ample headroom (58m job, 50m `E2E_GO_TIMEOUT`; the shard's other 16 specs plus setup/teardown take under 15m on a clean run).

## Validation

Commands run:

- `go build -tags e2e ./test/e2e/...`
- `go vet -tags e2e ./test/e2e/...`

Not run:

- Full e2e suite (`make test-e2e` / kind) — no Docker daemon available in this environment. Relying on the `Ginkgo E2E Tests (api-manual-mode)` CI shard on this PR to confirm.

## Checklist

- [x] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [x] Tests cover the changed behavior.
- [ ] User-facing docs and samples are updated where needed. (not applicable — test-only)
- [ ] Generated files were regenerated and committed where needed. (not applicable)
- [x] Release-only chart version fields are unchanged.