### PR TITLE
fix(node-local): ignore bookkeeping-only layout drains

### DIFF
--- a/docs/design/2026-07-30-node-local-pools-design.md
+++ b/docs/design/2026-07-30-node-local-pools-design.md
@@ -390,8 +390,8 @@ For a selector change inside one pool:
 1. activate newly matching Nodes;
 2. wait for their pods and GarageNodes;
 3. wait for every replacement in that pool to report `Connected` and `InLayout`;
-4. wait until `GetClusterLayoutHistory` reports no `Draining` version and no
-   other storage or gateway GarageNode is joining/finalizing;
+4. wait until `GetClusterLayoutHistory` reports no data migration still in
+   progress and no other storage or gateway GarageNode is joining/finalizing;
 5. drain old members one at a time;
 6. remove their activation labels after finalization.
 
@@ -615,7 +615,7 @@ responsible for retirement.
 
 | Status/reason | Meaning |
 |---|---|
-| `True/Converged` | Every desired identity is in the committed layout, no layout version is draining, and no retired role remains |
+| `True/Converged` | Every desired identity is in the committed layout, no layout version still requires data synchronization, and no retired role remains |
 | `False/WaitingForMembers` | A selector matches no Nodes, or a desired pod, connected identity, or layout role is not ready |
 | `False/WaitingForReplacement` | Same-pool replacements must commit before an old member drains |
 | `False/WaitingForLayoutSync` | Garage is synchronizing a layout version, another storage/gateway member or pool activation is in flight, or the Admin API cannot prove convergence |

--- a/docs/node-local-pools.md
+++ b/docs/node-local-pools.md
@@ -229,7 +229,11 @@ kubectl get garagenodes \
 ```
 
 The cluster is ready only after every desired pool identity is connected, in
-the committed layout, and Garage reports no active `Draining` layout version.
+the committed layout, and Garage reports no active data migration. Garage may
+retain a `Draining` history entry after every node has reached the current
+`Sync` tracker because `sync_ack` is housekeeping; that bookkeeping-only state
+does not block readiness or another serialized layout mutation. A node whose
+`Sync` tracker trails the current version still blocks.
 A declared pool whose selector matches no Nodes reports `WaitingForMembers`
 instead of silently appearing ready.
 
@@ -352,7 +356,7 @@ it touches another:
    UID;
 3. the identity is connected and has a committed role;
 4. every storage node and partition is healthy; and
-5. layout history has no draining version.
+5. layout history has no data migration still in progress.
 
 Surge is intentionally unsupported because two pods must never mount the same
 metadata volume and `node_key`. `StorageRolloutReady=False/RollingOut` reports
@@ -732,8 +736,8 @@ but it is an offline, one-node-at-a-time handoff and is not automated:
    verify the node-local-pool-backed GarageNode reports the recorded node ID,
    `Connected=True`, `InLayout=True`, `NodeLocalPoolsReady=True`, and
    `StorageRolloutReady=True`;
-7. repeat for the next node only after Garage reports no `Draining` layout
-   version.
+7. repeat for the next node only after Garage reports no data migration still
+   in progress.
 
 Because LocalPath directories differ per PVC, existing nodes normally require
 one pool entry per Kubernetes Node. A later fresh deployment can use one

--- a/hack/e2e-multicluster.sh
+++ b/hack/e2e-multicluster.sh
@@ -2163,7 +2163,11 @@ test_manual_mode_federation_multicluster() {
     log_info "  Waiting for bidirectional federation to establish..."
     local c1_connected=0
     local c2_connected=0
-    local federation_deadline=$((SECONDS + 60))
+    # The Manual-mode GarageNode controllers may still be finishing a local
+    # layout commit when remoteClusters is patched. A competing layout writer
+    # is retried on the controller's one-minute safety interval, so a 60-second
+    # test deadline can expire just before that retry under CI load.
+    local federation_deadline=$((SECONDS + 120))
     while [ "$SECONDS" -lt "$federation_deadline" ]; do
         c1_connected=$(kubectl --context "kind-$CLUSTER1_NAME" get garagecluster garage \
             -n "$NAMESPACE" -o jsonpath='{.status.health.connectedNodes}' 2>/dev/null || echo "0")

--- a/internal/controller/block_resync_barrier_test.go
+++ b/internal/controller/block_resync_barrier_test.go
@@ -252,6 +252,66 @@ func TestLayoutBarrierRecognizesUIDValuedPendingNodeLocalPoolActivation(t *testi
 	}
 }
 
+func TestLayoutBarrierAllowsBookkeepingOnlyDrainingHistory(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{ObjectMeta: metav1.ObjectMeta{
+		Name: testGarageValue, Namespace: testGarageValue, UID: testClusterUID,
+	}}
+	scheme := deletionTestScheme(t)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &GarageClusterReconciler{
+		Client: kubeClient, APIReader: kubeClient, ClusterScoped: true,
+		layoutHistoryGetter: func(context.Context, *garagev1beta2.GarageCluster) (*garage.LayoutHistoryResponse, error) {
+			return &garage.LayoutHistoryResponse{
+				CurrentVersion: 2,
+				Versions: []garage.LayoutVersion{
+					{Version: 2, Status: garage.LayoutVersionStatusCurrent},
+					{Version: 1, Status: garage.LayoutVersionStatusDraining},
+				},
+				UpdateTrackers: map[string]garage.NodeUpdateTrackers{
+					testTerminalNodeID: {Ack: 2, Sync: 2, SyncAck: 1},
+				},
+			}, nil
+		},
+	}
+
+	ready, bootstrap, message, err := reconciler.clusterLayoutReadyForMutation(
+		context.Background(), cluster, false,
+	)
+	if err != nil || !ready || bootstrap || message != "" {
+		t.Fatalf("bookkeeping-only layout drain blocked mutation: ready=%v bootstrap=%v message=%q err=%v", ready, bootstrap, message, err)
+	}
+}
+
+func TestLayoutBarrierStillBlocksLaggingDrainingHistory(t *testing.T) {
+	cluster := &garagev1beta2.GarageCluster{ObjectMeta: metav1.ObjectMeta{
+		Name: testGarageValue, Namespace: testGarageValue, UID: testClusterUID,
+	}}
+	scheme := deletionTestScheme(t)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &GarageClusterReconciler{
+		Client: kubeClient, APIReader: kubeClient, ClusterScoped: true,
+		layoutHistoryGetter: func(context.Context, *garagev1beta2.GarageCluster) (*garage.LayoutHistoryResponse, error) {
+			return &garage.LayoutHistoryResponse{
+				CurrentVersion: 2,
+				Versions: []garage.LayoutVersion{
+					{Version: 2, Status: garage.LayoutVersionStatusCurrent},
+					{Version: 1, Status: garage.LayoutVersionStatusDraining},
+				},
+				UpdateTrackers: map[string]garage.NodeUpdateTrackers{
+					testTerminalNodeID: {Ack: 2, Sync: 1, SyncAck: 1},
+				},
+			}, nil
+		},
+	}
+
+	ready, bootstrap, message, err := reconciler.clusterLayoutReadyForMutation(
+		context.Background(), cluster, false,
+	)
+	if err != nil || ready || bootstrap || !strings.Contains(message, "version(s) 1") {
+		t.Fatalf("lagging layout drain was not retained as a barrier: ready=%v bootstrap=%v message=%q err=%v", ready, bootstrap, message, err)
+	}
+}
+
 func TestStorageDrainRequiredArraysMarshalAsArrays(t *testing.T) {
 	proof := &blockResyncProof{
 		Actor: storageDrainActor{

--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -383,7 +383,7 @@ func (r *GarageClusterReconciler) reconcileAutoModeStorageNodes(ctx context.Cont
 	}
 	return r.setStorageTopologyReadyCondition(ctx, cluster, metav1.ConditionTrue,
 		garagev1beta1.ReasonStorageTopologyConverged,
-		"Auto-mode storage GarageNodes match the desired membership and Garage reports no active layout transition")
+		"Auto-mode storage GarageNodes match the desired membership and Garage reports no active data migration")
 }
 
 // countLiveStorageNodes counts operator-owned storage GarageNodes that would

--- a/internal/controller/garagecluster_layout_barrier.go
+++ b/internal/controller/garagecluster_layout_barrier.go
@@ -73,7 +73,10 @@ func (r *GarageClusterReconciler) getClusterLayoutHistory(
 //   - no same-cluster GarageNode (storage or gateway) is deleting;
 //   - no same-cluster GarageNode is still discovering/joining its desired role;
 //   - no node-local-pool activation is waiting to materialize a GarageNode; and
-//   - Garage reports no layout version in Draining state.
+//   - Garage reports no layout version that still requires data
+//     synchronization. A Draining version whose every node has already
+//     reached the current Sync tracker is only stale sync_ack bookkeeping and
+//     must not wedge the controller.
 //
 // ignoredNodeNames contains the one GarageNode a caller is about to delete. A
 // stale identity may itself never have reached the layout, but it must not
@@ -204,6 +207,15 @@ func (r *GarageClusterReconciler) clusterLayoutReadyForMutation(
 			nil
 	}
 	if len(draining) == 0 {
+		return true, false, "", nil
+	}
+	// Garage's sync_ack tracker is housekeeping: on a single-node cluster it
+	// can remain behind forever after the local full sync completes because
+	// there is no peer advertisement to trigger the tracker merge. The layout
+	// mutation coordinator already uses this distinction; keep the
+	// cluster-level barrier consistent with it so readiness and topology
+	// mutations do not livelock on bookkeeping-only Draining history.
+	if history.DataMigrationSettled() {
 		return true, false, "", nil
 	}
 	sort.Slice(draining, func(i, j int) bool {

--- a/internal/controller/node_local_pool_lifecycle_phases.go
+++ b/internal/controller/node_local_pool_lifecycle_phases.go
@@ -1043,5 +1043,5 @@ func (t *nodeLocalPoolLifecycleTransition) projectReadiness() nodeLocalPoolLifec
 			garagev1beta1.ReasonNodeLocalPoolWaitingForLayoutSync, waitingMessage))
 	}
 	return nodeLocalPoolPhaseStop(r.setNodeLocalPoolsCondition(ctx, cluster, metav1.ConditionTrue,
-		garagev1beta1.ReasonNodeLocalPoolsConverged, "node-local-pool members are connected and Garage reports no active layout transition"))
+		garagev1beta1.ReasonNodeLocalPoolsConverged, "node-local-pool members are connected and Garage reports no active data migration"))
 }


### PR DESCRIPTION
Summary:

- Treat a Garage layout history entry as converged when every update tracker has Sync at the current version, even if sync_ack bookkeeping still trails.
- Keep real lagging peers blocked when Sync is behind current.
- Align node-local/auto-mode readiness messages and documentation with the data-migration distinction.
- Add regression coverage for the exact single-node replacement shape from #336.

The underlying Garage v2.3 behavior can leave sync_ack stale on a single-node cluster because it only advances on startup or peer advertisements. This change avoids permanently wedging the operator while preserving the safety barrier for incomplete data sync.

Fixes #336

Tests:

- Focused controller regression tests pass.
- internal/garage tests pass.
- Controller and garage packages compile; the environment's normal Go test launcher required running the compiled binaries through the available system loader.