### PR TITLE
fix: #351 by filtering garagenode on generation changes

### DIFF
--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -765,7 +765,7 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
-			return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
+			return ctrl.Result{RequeueAfter: RequeueAfterPending}, nil
 		}
 		return r.updateStatus(ctx, node, PhaseFailed, layoutErr)
 	}
@@ -4014,7 +4014,10 @@ func (r *GarageNodeReconciler) updateStatus(ctx context.Context, node *garagev1b
 	if err != nil {
 		return ctrl.Result{RequeueAfter: RequeueAfterError}, nil
 	}
-	return ctrl.Result{}, nil
+	// Still requeue: the only nil-error caller is the identity-less branch of
+	// updateStatusFromGarage, which cannot make progress until another actor
+	// moves, and no longer self-wakes via its own status write.
+	return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 }
 
 func (r *GarageNodeReconciler) updateStatusFromGarage(
@@ -4554,8 +4557,12 @@ func (r *GarageNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				oldCluster.Annotations[annotationStaticCredentialsRevision] != newCluster.Annotations[annotationStaticCredentialsRevision]
 		},
 	}
+	// status.lastSeen is refreshed on every connected observation, so an
+	// unfiltered primary watch re-enters Reconcile on its own status write and
+	// RequeueAfterShort never paces anything. /status writes do not bump
+	// generation; metadata-only edits are picked up by that periodic tick.
 	bldr := ctrl.NewControllerManagedBy(mgr).
-		For(&garagev1beta1.GarageNode{}).
+		For(&garagev1beta1.GarageNode{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -358,6 +358,9 @@ const (
 	RequeueAfterError = 30 * time.Second
 	// RequeueAfterUnhealthy is a fast delay for reconnecting unhealthy clusters
 	RequeueAfterUnhealthy = 10 * time.Second
+	// RequeueAfterPending is a fast retry for a layout mutation a later reconcile
+	// must re-drive (coordinator hand-off, one Apply per critical section)
+	RequeueAfterPending = 5 * time.Second
 	// RequeueAfterShort is a short delay for periodic reconciliation
 	RequeueAfterShort = 1 * time.Minute
 	// RequeueAfterLong is a longer delay for stable resources


### PR DESCRIPTION
# Pull request

## Summary

This fixes a reconcile loop on GarageNode resources

## Related issue or design

Fixes #351

## Compatibility and operational impact

None

## Validation

Commands run:

- `kubectl get garagenode <name> -o json --watch | jq -r '.metadata.resourceVersion + " " + .status.lastSeen'` to check if now resource version updates every minute instead of every second or so.

Not run:

- None.

## Checklist

- [X] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [X] Tests cover the changed behavior.
- [X] User-facing docs and samples are updated where needed.
- [X] Generated files were regenerated and committed where needed.
- [X] Release-only chart version fields are unchanged.
