### PR TITLE
fix: preserve Auto PVCs during lost-source recovery

### DIFF
--- a/docs/operations/maintenance-and-recovery.md
+++ b/docs/operations/maintenance-and-recovery.md
@@ -23,7 +23,23 @@ The annotation remains a cancellation request until the role enters its irrevers
 
 ## Lost source identity
 
-If the process and its data are permanently gone, pair the exact identity acknowledgement with the drain request:
+First determine whether the Garage identity survived.
+
+If the metadata identity and `status.nodeId` are intact and only data blocks
+need repair, keep the same `GarageNode` and its metadata/data claims in place.
+After restoring the disk or path, run the targeted Garage repair from a healthy
+Admin endpoint:
+
+```bash
+garage repair -a --yes blocks
+```
+
+If the metadata was lost or replaced and the process reports a new Garage ID,
+do not disable the admission webhooks, remove the `GarageNode` finalizer, or
+delete the old claims. The operator retains the old positive-capacity
+`status.nodeId`, refuses to assign the replacement identity, and fences the
+replacement until the old role has been handled. Pair the exact identity
+acknowledgement with the drain request:
 
 ```bash
 kubectl annotate garagenode garage-storage-a -n storage \
@@ -31,7 +47,42 @@ kubectl annotate garagenode garage-storage-a -n storage \
   garage.rajsingh.info/acknowledge-lost-source=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
-The operator verifies that Garage reports the exact identity down, then waits for explicit dead-node role removal and destination-only repair/resync evidence. This cannot restore blocks that existed only on the lost source.
+The operator verifies that Garage reports the exact identity down and that the
+replacement has no committed or staged role. From a healthy Garage Admin
+endpoint, remove and review the exact dead role, then apply that one staged
+change:
+
+```bash
+garage layout remove 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+garage layout show
+garage layout apply
+```
+
+If a dead identity still prevents the layout from settling, review the entire
+layout before using the explicit cluster-wide recovery request:
+
+```bash
+kubectl annotate garagecluster garage -n storage \
+  garage.rajsingh.info/skip-dead-nodes=true
+```
+
+Add `garage.rajsingh.info/allow-missing-data=true` only when the old data is
+provably unrecoverable and the surviving replicas are sufficient. The
+`skip-dead-nodes` operation is global rather than target-scoped, and
+`allow-missing-data` can authorize data loss.
+
+Wait for `DrainPrepared=True` with reason `PreparedForDeletion`, review the
+parent `status.storageDrain`, and only then delete the exact `GarageNode`:
+
+```bash
+kubectl delete garagenode garage-storage-a -n storage
+```
+
+For an operator-owned Auto-mode storage slot, the finalizer records exact
+retained PVC UIDs in the parent before releasing the old `GarageNode`. The
+parent can then recreate the same slot and transfer only those exact claims;
+leave retained metadata/data PVCs in place until that handoff completes. This
+cannot restore blocks that existed only on the lost source.
 
 ## Federated site deletion
 

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -456,6 +456,9 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				_, _ = r.updateStatus(ctx, node, PhaseDeleting, fmt.Errorf("finalization failed (retry %d): %w", retryCount, err))
 				return ctrl.Result{RequeueAfter: RequeueAfterError}, nil
 			}
+			if err := r.prepareAutoModePVCHandoffBeforeFinalization(ctx, node, cluster); err != nil {
+				return r.updateStatus(ctx, node, PhaseDeleting, err)
+			}
 			if err := r.cleanupOwnerlessManagedNodePVCs(ctx, node, cluster); err != nil {
 				return r.updateStatus(ctx, node, PhaseDeleting, err)
 			}
@@ -1915,6 +1918,55 @@ func translatePVCRetentionPolicy(rp *garagev1beta2.PVCRetentionPolicy) *appsv1.S
 		out.WhenScaled = appsv1.DeletePersistentVolumeClaimRetentionPolicyType
 	}
 	return out
+}
+
+// prepareAutoModePVCHandoffBeforeFinalization records the exact retained PVC
+// identities of an operator-owned Auto-mode node before its GarageNode UID is
+// allowed to disappear. Normal Auto scale-down prepares this status from the
+// parent controller before issuing DELETE, but a user-approved lost-source
+// deletion reaches this finalizer directly. Without the second boundary, the
+// replacement Auto slot sees a retained claim pinned to the old GarageNode UID
+// without the parent status authorization required to transfer it.
+//
+// A deleting parent has no replacement slot to recreate, so its cleanup path is
+// deliberately excluded. Manual nodes and any object without the exact
+// controller reference are likewise left to their existing PVC policy.
+func (r *GarageNodeReconciler) prepareAutoModePVCHandoffBeforeFinalization(
+	ctx context.Context,
+	node *garagev1beta1.GarageNode,
+	cluster *garagev1beta2.GarageCluster,
+) error {
+	if node == nil || cluster == nil || !cluster.DeletionTimestamp.IsZero() ||
+		node.Spec.ClusterRef.Name != cluster.Name ||
+		!hasExactGarageClusterControllerReference(node, cluster) ||
+		node.Labels[labelAppManagedBy] != managedByOperatorValue ||
+		node.Labels[labelAutoNodeSlot] == "" ||
+		(node.Labels[labelTier] != tierStorage && node.Labels[labelTier] != tierGateway) {
+		return nil
+	}
+
+	liveCluster := cluster
+	if reader := r.nodeLocalPoolReader(); reader != nil {
+		fresh := &garagev1beta2.GarageCluster{}
+		if err := reader.Get(ctx, client.ObjectKeyFromObject(cluster), fresh); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("reading GarageCluster before publishing retained Auto-mode PVC handoff: %w", err)
+		}
+		if !fresh.DeletionTimestamp.IsZero() {
+			return nil
+		}
+		liveCluster = fresh
+	}
+
+	clusterReconciler := &GarageClusterReconciler{
+		Client: r.Client, APIReader: r.APIReader, Scheme: r.Scheme,
+	}
+	if err := clusterReconciler.prepareRetainedAutoModePVCHandoffs(ctx, liveCluster, node); err != nil {
+		return fmt.Errorf("preparing retained Auto-mode PVC handoff for GarageNode %s: %w", node.Name, err)
+	}
+	return nil
 }
 
 // cleanupOwnerlessManagedNodePVCs closes the gap between reserving an exact

--- a/internal/controller/garagenode_pvc_reservation_test.go
+++ b/internal/controller/garagenode_pvc_reservation_test.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -88,6 +89,132 @@ func TestRetainedAutoModePVCHandoffAuthorizesStorageAndGatewayExactUIDs(t *testi
 				t.Fatalf("%s handoff authorized the wrong GarageNode UID", tier)
 			}
 		})
+	}
+}
+
+func TestIssue349LostAutoModeStorageDeletionHandsOffRetainedPVC(t *testing.T) {
+	ctx := context.Background()
+	scheme := managedPVCTestScheme(t)
+	controller := true
+	cluster := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "store", Namespace: "default", UID: "cluster-uid"},
+		Spec: garagev1beta2.GarageClusterSpec{
+			LayoutPolicy: LayoutPolicyAuto,
+			Storage: &garagev1beta2.StorageSpec{
+				Replicas: 1,
+				Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+				Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+			},
+		},
+	}
+	oldNode := &garagev1beta1.GarageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "store-storage-0", Namespace: "default", UID: "old-node-uid",
+			Labels: map[string]string{
+				labelCluster:      cluster.Name,
+				labelTier:         tierStorage,
+				labelAppManagedBy: managedByOperatorValue,
+				labelAutoNodeSlot: "store-storage-0",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: garagev1beta2.GroupVersion.String(),
+				Kind:       kindGarageCluster,
+				Name:       cluster.Name,
+				UID:        cluster.UID,
+				Controller: &controller,
+			}},
+		},
+		Spec: garagev1beta1.GarageNodeSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: cluster.Name},
+			Capacity:   ptrQuantity(resource.MustParse("10Gi")),
+		},
+		Status: garagev1beta1.GarageNodeStatus{
+			NodeID: "old-garage-node-id",
+			ManagedPVCs: []garagev1beta1.ManagedNodePVCStatus{{
+				Name: "metadata-store-storage-0-0", UID: "metadata-pvc-uid",
+			}},
+		},
+	}
+	claim := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name: "metadata-store-storage-0-0", Namespace: "default", UID: "metadata-pvc-uid",
+		Annotations: map[string]string{managedPVCNodeUIDAnnotation: string(oldNode.UID)},
+	}}
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&garagev1beta1.GarageNode{}, &garagev1beta2.GarageCluster{}).
+		WithObjects(cluster, oldNode, claim).Build()
+
+	nodeReconciler := &GarageNodeReconciler{Client: fc, APIReader: fc, Scheme: scheme}
+	if err := nodeReconciler.prepareAutoModePVCHandoffBeforeFinalization(ctx, oldNode, cluster); err != nil {
+		t.Fatalf("lost-source finalization did not preserve the retained PVC handoff: %v", err)
+	}
+	freshCluster := &garagev1beta2.GarageCluster{}
+	if err := fc.Get(ctx, client.ObjectKeyFromObject(cluster), freshCluster); err != nil {
+		t.Fatal(err)
+	}
+	wantHandoff := garagev1beta2.AutoModePVCHandoffStatus{
+		SlotName:              "store-storage-0",
+		PVCName:               claim.Name,
+		PVCUID:                string(claim.UID),
+		PreviousGarageNodeUID: string(oldNode.UID),
+	}
+	if len(freshCluster.Status.AutoModePVCHandoffs) != 1 || freshCluster.Status.AutoModePVCHandoffs[0] != wantHandoff {
+		t.Fatalf("unexpected lost-source PVC handoff: got %#v, want %#v", freshCluster.Status.AutoModePVCHandoffs, []garagev1beta2.AutoModePVCHandoffStatus{wantHandoff})
+	}
+
+	// The finalizer has now released the old GarageNode. The Auto parent can
+	// recreate the same slot, but only after reserving and binding the exact
+	// retained claim incarnation recorded above.
+	if err := fc.Delete(ctx, oldNode); err != nil {
+		t.Fatalf("deleting the finalized old GarageNode: %v", err)
+	}
+	clusterReconciler := &GarageClusterReconciler{Client: fc, APIReader: fc, Scheme: scheme}
+	desired, err := clusterReconciler.buildAutoModeStorageNode(cluster, 0, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired.UID = "replacement-node-uid"
+	hasHandoff, err := clusterReconciler.reserveAutoModeReplacement(ctx, freshCluster, desired)
+	if err != nil {
+		t.Fatalf("reserving the retained PVC for the replacement slot: %v", err)
+	}
+	if !hasHandoff {
+		t.Fatal("replacement slot did not see the finalization handoff")
+	}
+	if err := fc.Create(ctx, desired); err != nil {
+		t.Fatalf("creating replacement GarageNode: %v", err)
+	}
+	if err := clusterReconciler.bindAutoModeReplacement(ctx, freshCluster, desired, desired.Name); err != nil {
+		t.Fatalf("binding replacement GarageNode: %v", err)
+	}
+
+	if err := nodeReconciler.ensureManagedNodePVCProvenance(ctx, claim, desired, freshCluster); err != nil {
+		t.Fatalf("accepting the exact retained PVC on the replacement GarageNode: %v", err)
+	}
+	persistedClaim := &corev1.PersistentVolumeClaim{}
+	if err := fc.Get(ctx, client.ObjectKeyFromObject(claim), persistedClaim); err != nil {
+		t.Fatal(err)
+	}
+	if got := persistedClaim.Annotations[managedPVCNodeUIDAnnotation]; got != string(desired.UID) {
+		t.Fatalf("retained PVC was not transferred to replacement GarageNode UID: got %q, want %q", got, desired.UID)
+	}
+	if !controllerutil.ContainsFinalizer(persistedClaim, managedPVCFinalizer) {
+		t.Fatal("replacement claim did not receive its exact-identity barrier")
+	}
+	persistedNode := &garagev1beta1.GarageNode{}
+	if err := fc.Get(ctx, client.ObjectKeyFromObject(desired), persistedNode); err != nil {
+		t.Fatal(err)
+	}
+	wantPVCRecord := garagev1beta1.ManagedNodePVCStatus{Name: claim.Name, UID: claim.UID}
+	if len(persistedNode.Status.ManagedPVCs) != 1 || persistedNode.Status.ManagedPVCs[0] != wantPVCRecord {
+		t.Fatalf("replacement GarageNode did not record the exact PVC UID: got %#v, want %#v", persistedNode.Status.ManagedPVCs, []garagev1beta1.ManagedNodePVCStatus{wantPVCRecord})
+	}
+
+	changed, err := clusterReconciler.reconcileCurrentAutoModePVCHandoffs(ctx, freshCluster, persistedNode, desired.Name)
+	if err != nil {
+		t.Fatalf("consuming the retained PVC handoff: %v", err)
+	}
+	if !changed || len(freshCluster.Status.AutoModePVCHandoffs) != 0 {
+		t.Fatalf("retained PVC handoff was not cleared after exact replacement consumption: changed=%v status=%#v", changed, freshCluster.Status.AutoModePVCHandoffs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve exact retained PVC handoffs when a user-approved lost-source Auto-mode GarageNode reaches finalization
- re-read the parent authoritatively and keep Manual nodes and deleting parents on their existing paths
- add an issue #349 regression covering old-node deletion, same-slot recreation, exact PVC transfer, and handoff cleanup
- document data-only repair, exact dead-role layout removal, and the cluster-wide recovery warnings

## Verification

- `go test ./...`
- `go vet ./...`
- `make test` could not start because the workspace `bin/controller-gen` binary is not executable (`required file not found`); generated files were restored and the full Go suite passed.