### PR TITLE
refactor: ensure S3 endpoints are consistently generated regardless of how the cluster was deployed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,11 @@ Implementation:
   not auto-create — set `spec.network.rpcSecretRef` to the external cluster's RPC
   secret, or use `importKey`. The key controller surfaces this as an actionable
   error. A key's generated Secret derives its S3 endpoint from the
-  `connectTo.adminApiEndpoint` host (not a nonexistent managed Service).
+  `connectTo.adminApiEndpoint` host (not a nonexistent managed Service) via
+  `ResolveS3Endpoint` (`internal/controller/helpers.go`), which every consumer
+  shares — parse `status.endpoints.s3` through it rather than `fmt.Sprintf`
+  against it, since the managed writer emits a bare `host:port` and the handle
+  writer a full URL.
 - **Stage 2 (not implemented):** having the operator adopt the external
   StatefulSet + PVCs in place and retire Helm. Blocked on PVC-name mismatch
   (operator `metadata`/`data` vs chart `meta-*`/`data-*`) and the per-node

--- a/internal/controller/garagecluster_management_handle_test.go
+++ b/internal/controller/garagecluster_management_handle_test.go
@@ -747,9 +747,9 @@ func TestReconcileManagementHandle_UnreachableSetsPending(t *testing.T) {
 	}
 }
 
-// A management handle exposes only an Admin API address. It is not enough
-// information to infer the external cluster's S3 endpoint, so endpoint-bearing
-// generated Secrets must fail closed.
+// A management handle that never published an observed S3 endpoint leaves
+// nothing to infer — its Service does not exist — so endpoint-bearing generated
+// Secrets must fail closed with actionable guidance.
 func TestReconcileSecret_ManagementHandleRequiresExplicitEndpoint(t *testing.T) {
 	handle := &garagev1beta2.GarageCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: mhName, Namespace: mhNS},
@@ -767,5 +767,94 @@ func TestReconcileSecret_ManagementHandleRequiresExplicitEndpoint(t *testing.T) 
 	err := r.reconcileSecret(context.Background(), key, handle, "sk")
 	if err == nil || !strings.Contains(err.Error(), "secretTemplate.includeEndpoint=false") {
 		t.Fatalf("reconcileSecret error = %v, want actionable endpoint configuration failure", err)
+	}
+}
+
+// A handle's Secret must use the endpoint the cluster controller derived onto
+// status, not fail closed.
+func TestReconcileSecret_ManagementHandleUsesObservedS3Endpoint(t *testing.T) {
+	handle := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: mhName, Namespace: mhNS},
+		Spec: garagev1beta2.GarageClusterSpec{
+			ConnectTo: &garagev1beta2.ConnectToConfig{AdminAPIEndpoint: mhEndpoint},
+		},
+	}
+	handle.Status.Endpoints = &garagev1beta2.ClusterEndpoints{S3: "http://garage.garage.svc:3900"}
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "k", Namespace: mhNS, UID: types.UID("key-uid")},
+	}
+	key.Status.AccessKeyID = "GKtest"
+
+	s := managementHandleScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(key).WithStatusSubresource(&garagev1beta1.GarageKey{}).Build()
+	r := &GarageKeyReconciler{Client: fc, Scheme: s, ClusterDomain: testClusterDomain}
+
+	if err := r.reconcileSecret(context.Background(), key, handle, "sk"); err != nil {
+		t.Fatalf("reconcileSecret: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "k", Namespace: mhNS}, secret); err != nil {
+		t.Fatalf("get generated secret: %v", err)
+	}
+	for k, want := range map[string]string{
+		defaultEndpointKey: "http://garage.garage.svc:3900",
+		defaultHostKey:     "garage.garage.svc:3900",
+		defaultSchemeKey:   "http",
+	} {
+		if got := string(secret.Data[k]); got != want {
+			t.Errorf("secret[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// status.endpoints.s3 is written in two formats (managed: "host:port", handle:
+// a full URL); both must resolve, and a handle has no Service to fall back to.
+func TestResolveS3Endpoint(t *testing.T) {
+	cluster := func(spec garagev1beta2.GarageClusterSpec, s3 string) *garagev1beta2.GarageCluster {
+		c := &garagev1beta2.GarageCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: mhName, Namespace: mhNS}, Spec: spec,
+		}
+		if s3 != "" {
+			c.Status.Endpoints = &garagev1beta2.ClusterEndpoints{S3: s3}
+		}
+		return c
+	}
+	handle := garagev1beta2.GarageClusterSpec{
+		ConnectTo: &garagev1beta2.ConnectToConfig{AdminAPIEndpoint: mhEndpoint},
+	}
+	managed := garagev1beta2.GarageClusterSpec{Storage: &garagev1beta2.StorageSpec{Replicas: 3}}
+	fqdn := svcFQDN(mhName, mhNS, DefaultS3Port, testClusterDomain)
+
+	tests := []struct {
+		name            string
+		cluster         *garagev1beta2.GarageCluster
+		wantURL, wantIn string
+	}{
+		{"handle URL", cluster(handle, "http://backup.garage.svc:3900"), "http://backup.garage.svc:3900", ""},
+		{"handle https", cluster(handle, "https://s3.example.com:3900"), "https://s3.example.com:3900", ""},
+		{"managed host:port", cluster(managed, fqdn), "http://" + fqdn, ""},
+		{"managed falls back to its Service", cluster(managed, ""), "http://" + fqdn, ""},
+		{"handle has no fallback", cluster(handle, ""), "", "no observed S3 endpoint"},
+		{"unusable value", cluster(handle, "ftp://backup.garage.svc:3900"), "", "invalid Garage S3 endpoint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveS3Endpoint(tt.cluster, testClusterDomain)
+			if tt.wantIn != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantIn) {
+					t.Fatalf("error = %v, want one containing %q", err, tt.wantIn)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveS3Endpoint: %v", err)
+			}
+			if got.String() != tt.wantURL {
+				t.Errorf("endpoint = %q, want %q", got, tt.wantURL)
+			}
+		})
 	}
 }

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"net/url"
 	"sort"
 	"time"
 
@@ -1031,8 +1032,9 @@ func resolveSecretConfig(key *garagev1beta1.GarageKey) secretConfig {
 	return cfg
 }
 
-// buildSecretData constructs the secret data map based on configuration
-func (r *GarageKeyReconciler) buildSecretData(ctx context.Context, cfg secretConfig, key *garagev1beta1.GarageKey, cluster *garagev1beta2.GarageCluster, secretAccessKey string) map[string][]byte {
+// buildSecretData constructs the secret data map based on configuration.
+// s3 is nil when the Secret carries no endpoint keys.
+func (r *GarageKeyReconciler) buildSecretData(ctx context.Context, cfg secretConfig, key *garagev1beta1.GarageKey, cluster *garagev1beta2.GarageCluster, secretAccessKey string, s3 *url.URL) map[string][]byte {
 	data := map[string][]byte{
 		cfg.accessKeyIDKey: []byte(key.Status.AccessKeyID),
 	}
@@ -1041,14 +1043,10 @@ func (r *GarageKeyReconciler) buildSecretData(ctx context.Context, cfg secretCon
 		data[cfg.secretAccessKeyKey] = []byte(secretAccessKey)
 	}
 
-	if cfg.includeEndpoint {
-		s3Port := getS3Port(cluster)
-		scheme := "http"
-		host := svcFQDN(cluster.Name, cluster.Namespace, s3Port, r.ClusterDomain)
-		endpoint := fmt.Sprintf("%s://%s", scheme, host)
-		data[cfg.endpointKey] = []byte(endpoint)
-		data[cfg.hostKey] = []byte(host)
-		data[cfg.schemeKey] = []byte(scheme)
+	if cfg.includeEndpoint && s3 != nil {
+		data[cfg.endpointKey] = []byte(s3.String())
+		data[cfg.hostKey] = []byte(s3.Host)
+		data[cfg.schemeKey] = []byte(s3.Scheme)
 	}
 
 	if cfg.includeRegion {
@@ -1155,8 +1153,12 @@ func (r *GarageKeyReconciler) reconcileSecret(ctx context.Context, key *garagev1
 	}
 
 	cfg := resolveSecretConfig(key)
-	if cfg.includeEndpoint && cluster.IsManagementHandle() {
-		return fmt.Errorf("cannot infer an external S3 endpoint from management-handle spec.connectTo.adminApiEndpoint; set secretTemplate.includeEndpoint=false and configure the consumer's explicit S3 endpoint")
+	var s3 *url.URL
+	if cfg.includeEndpoint {
+		var err error
+		if s3, err = ResolveS3Endpoint(cluster, r.ClusterDomain); err != nil {
+			return fmt.Errorf("%w; set secretTemplate.includeEndpoint=false and configure the consumer's explicit S3 endpoint", err)
+		}
 	}
 	if key.UID == "" {
 		return fmt.Errorf("cannot reconcile generated Secret before GarageKey UID is assigned")
@@ -1169,7 +1171,7 @@ func (r *GarageKeyReconciler) reconcileSecret(ctx context.Context, key *garagev1
 	if err := r.markPreviousGeneratedSecret(ctx, key, previousRef); err != nil {
 		return err
 	}
-	secretData := r.buildSecretData(ctx, cfg, key, cluster, secretAccessKey)
+	secretData := r.buildSecretData(ctx, cfg, key, cluster, secretAccessKey, s3)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -450,6 +451,32 @@ func GetStaticAdminToken(ctx context.Context, c client.Client, cluster *garagev1
 // Example: svcFQDN("garage", "default", 3903, "cluster.local") → "garage.default.svc.cluster.local:3903"
 func svcFQDN(name, namespace string, port int32, clusterDomain string) string {
 	return fmt.Sprintf("%s.%s.svc.%s:%d", name, namespace, clusterDomain, port)
+}
+
+// The S3 endpoint is published on status.endpoints.s3: from the Service for
+// managed clusters, from spec.connectTo for management handles, in two
+// different formats. ResolveS3Endpoint turns either into a usable endpoint so
+// callers do not have to care which kind of cluster they have.
+func ResolveS3Endpoint(cluster *garagev1beta2.GarageCluster, clusterDomain string) (*url.URL, error) {
+	raw := ""
+	if cluster.Status.Endpoints != nil {
+		raw = cluster.Status.Endpoints.S3
+	}
+	if raw == "" {
+		if cluster.IsManagementHandle() {
+			return nil, fmt.Errorf("management-handle GarageCluster %s/%s has no observed S3 endpoint in status", cluster.Namespace, cluster.Name)
+		}
+		raw = svcFQDN(cluster.Name, cluster.Namespace, getS3Port(cluster), clusterDomain)
+	}
+	const schemeHTTP, schemeHTTPS = "http", "https"
+	if !strings.Contains(raw, "://") {
+		raw = schemeHTTP + "://" + raw
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != schemeHTTP && parsed.Scheme != schemeHTTPS) {
+		return nil, fmt.Errorf("invalid Garage S3 endpoint %q", raw)
+	}
+	return parsed, nil
 }
 
 // waitingForClusterMessage builds the message for a ClusterNotReady condition.

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -808,7 +808,11 @@ func TestBuildSecretData(t *testing.T) {
 
 			r := &GarageKeyReconciler{Client: fc, Scheme: s, ClusterDomain: testClusterDomain}
 
-			result := r.buildSecretData(context.Background(), tt.cfg, tt.key, tt.cluster, tt.secretAccessKey)
+			s3, err := ResolveS3Endpoint(tt.cluster, r.ClusterDomain)
+			if err != nil {
+				t.Fatalf("ResolveS3Endpoint: %v", err)
+			}
+			result := r.buildSecretData(context.Background(), tt.cfg, tt.key, tt.cluster, tt.secretAccessKey, s3)
 
 			for _, key := range tt.wantKeys {
 				if _, ok := result[key]; !ok {

--- a/internal/cosi/provisioner.go
+++ b/internal/cosi/provisioner.go
@@ -22,9 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"net/url"
 	"sort"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1043,27 +1041,11 @@ func (p *Provisioner) buildPerBucketResults(ctx context.Context, slots []BucketA
 }
 
 func (p *Provisioner) getS3Endpoint(cluster *garagev1beta2.GarageCluster) (string, error) {
-	raw := ""
-	if cluster.Status.Endpoints != nil && cluster.Status.Endpoints.S3 != "" {
-		raw = cluster.Status.Endpoints.S3
-	} else {
-		if cluster.IsManagementHandle() {
-			return "", fmt.Errorf("management-handle GarageCluster %s/%s has no observed S3 endpoint in status", cluster.Namespace, cluster.Name)
-		}
-		port := int32(3900)
-		if cluster.Spec.S3API != nil && cluster.Spec.S3API.BindPort > 0 {
-			port = cluster.Spec.S3API.BindPort
-		}
-		raw = fmt.Sprintf("%s.%s.svc.%s:%d", cluster.Name, cluster.Namespace, p.clusterDomain, port)
+	parsed, err := controller.ResolveS3Endpoint(cluster, p.clusterDomain)
+	if err != nil {
+		return "", err
 	}
-	if !strings.Contains(raw, "://") {
-		raw = "http://" + raw
-	}
-	parsed, err := url.Parse(raw)
-	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return "", fmt.Errorf("invalid Garage S3 endpoint %q", raw)
-	}
-	return raw, nil
+	return parsed.String(), nil
 }
 
 func (p *Provisioner) getS3Region(cluster *garagev1beta2.GarageCluster) string {


### PR DESCRIPTION
# Pull request

## Summary

When using a management cluster (so connectTo), any BucketKeys generated will fail to generate a proper S3 endpoint. However, the COSI data path has a way to construct the S3 endpoint and all information is present. As such, this PR unifies the S3 construction paths.

## Related issue or design

This resolves the issue when creating GarageKeys for management handle clusters
```
cannot infer an external S3 endpoint from management-handle
      spec.connectTo.adminApiEndpoint; set secretTemplate.includeEndpoint=false
      and configure the consumer's explicit S3 endpoint
```

## Compatibility and operational impact

None

## Validation

Commands run:

- For a management handle (so GarageCluster with connectTo) create a GarageKey and watch it succeed

Not run:

- None.

<!-- Include sanitized runtime evidence for reconciliation changes. -->

## Checklist

- [X] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [X] Tests cover the changed behavior.
- [X] User-facing docs and samples are updated where needed.
- [X Generated files were regenerated and committed where needed.
- [X] Release-only chart version fields are unchanged.
