### PR TITLE
fix(api): allow empty allBuckets during SSA migration

### DIFF
--- a/api/v1beta1/garagekey_webhook.go
+++ b/api/v1beta1/garagekey_webhook.go
@@ -407,9 +407,11 @@ func validateAllBuckets(ab *AllBucketsPermission) error {
 	if ab == nil {
 		return nil
 	}
-	if !ab.Read && !ab.Write && !ab.Owner {
-		return fmt.Errorf("allBuckets: at least one permission (read, write, or owner) must be granted")
-	}
+	// An all-false object intentionally grants no cluster-wide permissions. It
+	// is also a valid result of removing allBuckets from a server-side-applied
+	// object when the CRD's nested boolean defaults are retained by the merge.
+	// The reconciler treats it as an exact zero-permission baseline and can
+	// still apply any explicit bucketPermissions on top.
 	return nil
 }
 

--- a/api/v1beta1/webhook_test.go
+++ b/api/v1beta1/webhook_test.go
@@ -3467,7 +3467,7 @@ func TestValidateAllBuckets(t *testing.T) {
 		{"write only", &AllBucketsPermission{Write: true}, false},
 		{"owner only", &AllBucketsPermission{Owner: true}, false},
 		{"all permissions", &AllBucketsPermission{Read: true, Write: true, Owner: true}, false},
-		{"no permissions", &AllBucketsPermission{}, true},
+		{"no permissions", &AllBucketsPermission{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3476,6 +3476,27 @@ func TestValidateAllBuckets(t *testing.T) {
 				t.Errorf("validateAllBuckets() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestGarageKeyValidator_AllBucketsDefaultedEmptyAllowsScopedMigration(t *testing.T) {
+	old := &GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: testKey, Namespace: testWebhookNS},
+		Spec: GarageKeySpec{
+			ClusterRef: ClusterReference{Name: testCluster},
+			AllBuckets: &AllBucketsPermission{Read: true, Write: true},
+		},
+	}
+	newObj := old.DeepCopy()
+	newObj.Spec.AllBuckets = &AllBucketsPermission{}
+	newObj.Spec.BucketPermissions = []BucketPermission{{
+		BucketID: "scoped-bucket",
+		Read:     true,
+	}}
+
+	validator := &GarageKeyValidator{Client: fake.NewClientBuilder().WithScheme(fakeScheme(t)).Build()}
+	if _, err := validator.ValidateUpdate(context.Background(), old, newObj); err != nil {
+		t.Fatalf("defaulted allBuckets object blocked scoped migration: %v", err)
 	}
 }
 

--- a/internal/controller/garagekey_controller_test.go
+++ b/internal/controller/garagekey_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
@@ -617,5 +618,66 @@ var _ = Describe("GarageKey Controller", func() {
 				Fail("finalize blocked past the per-call timeout budget")
 			}
 		})
+	})
+})
+
+var _ = Describe("GarageKey server-side apply migration", func() {
+	It("accepts an allBuckets grant reapplied as scoped permissions", func() {
+		const (
+			name       = "all-buckets-migration"
+			fieldOwner = "garagekey-migration-test"
+		)
+		object := &garagev1beta1.GarageKey{ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: testNamespace,
+		}}
+		initial := []byte(`{
+			"apiVersion":"garage.rajsingh.info/v1beta1",
+			"kind":"GarageKey",
+			"metadata":{"name":"all-buckets-migration","namespace":"default"},
+			"spec":{"clusterRef":{"name":"test-cluster"},"allBuckets":{"read":true}}
+		}`)
+		// Apply the original cluster-wide declaration with the same field owner
+		// used for the migration. This makes the second apply model the real
+		// omission of allBuckets from a previously managed configuration.
+		Expect(k8sClient.Patch(ctx, object, client.RawPatch(types.ApplyPatchType, initial),
+			client.FieldOwner(fieldOwner), client.ForceOwnership)).To(Succeed())
+		DeferCleanup(func() {
+			stored := &garagev1beta1.GarageKey{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, stored); err == nil {
+				stored.Finalizers = nil
+				_ = k8sClient.Update(ctx, stored)
+				_ = k8sClient.Delete(ctx, stored)
+			}
+		})
+
+		stored := &garagev1beta1.GarageKey{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, stored)).To(Succeed())
+		Expect(stored.Spec.AllBuckets).NotTo(BeNil())
+		Expect(stored.Spec.AllBuckets.Read).To(BeTrue())
+
+		migration := []byte(`{
+			"apiVersion":"garage.rajsingh.info/v1beta1",
+			"kind":"GarageKey",
+			"metadata":{"name":"all-buckets-migration","namespace":"default"},
+			"spec":{"clusterRef":{"name":"test-cluster"},"bucketPermissions":[{"bucketId":"scoped-bucket","read":true}]}
+		}`)
+		Expect(k8sClient.Patch(ctx, object, client.RawPatch(types.ApplyPatchType, migration),
+			client.FieldOwner(fieldOwner), client.ForceOwnership)).To(Succeed())
+
+		migrated := &garagev1beta1.GarageKey{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, migrated)).To(Succeed())
+		Expect(migrated.Spec.BucketPermissions).To(HaveLen(1))
+		// Depending on field ownership, the apiserver may remove the optional
+		// parent or retain it as an all-false object after the omission. Both
+		// representations mean that no cluster-wide permissions are desired.
+		effective := migrated.DeepCopy()
+		if effective.Spec.AllBuckets == nil {
+			// The envtest apiserver removes the parent for this field-owner
+			// sequence. Exercise the retained/defaulted representation too; that
+			// is the shape produced by the production migration.
+			effective.Spec.AllBuckets = &garagev1beta1.AllBucketsPermission{}
+		}
+		Expect(*effective.Spec.AllBuckets).To(Equal(garagev1beta1.AllBucketsPermission{}))
+		Expect(garagev1beta1.ValidateGarageKeySpec(effective)).To(Succeed())
 	})
 })

--- a/internal/controller/garagekey_permissions_test.go
+++ b/internal/controller/garagekey_permissions_test.go
@@ -407,6 +407,115 @@ func TestReconcileManagedBucketPermissions_RemovesPriorAllBucketsWithExplicitGra
 	}
 }
 
+func TestReconcileManagedBucketPermissions_AllBucketsDefaultedEmptyPreservesScopedGrant(t *testing.T) {
+	const (
+		explicitBucketID = "bucket-explicit-migration"
+		staleBucketID    = "bucket-stale-migration"
+		keyID            = "GKmigration"
+	)
+	s := runtime.NewScheme()
+	if err := garagev1beta1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "key", Namespace: testNamespace},
+		Spec: garagev1beta1.GarageKeySpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: testClusterName},
+			AllBuckets: &garagev1beta1.AllBucketsPermission{Read: true, Write: true},
+		},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: keyID},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(key).
+		WithStatusSubresource(&garagev1beta1.GarageKey{}).Build()
+	var allows []garage.AllowBucketKeyRequest
+	var denies []garage.DenyBucketKeyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/v2/ListBuckets":
+			_, _ = w.Write([]byte(`[{"id":"bucket-explicit-migration"},{"id":"bucket-stale-migration"}]`))
+			return
+		case testAllowBucketKeyPath:
+			var body garage.AllowBucketKeyRequest
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode allow request: %v", err)
+			}
+			allows = append(allows, body)
+		case testDenyBucketKeyPath:
+			var body garage.DenyBucketKeyRequest
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode deny request: %v", err)
+			}
+			denies = append(denies, body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	r := &GarageKeyReconciler{Client: c, Scheme: s}
+	garageClient := garage.NewClient(server.URL, "token")
+	remote := &garage.Key{AccessKeyID: keyID}
+
+	// Establish the remote state from the original allBuckets declaration.
+	if err := r.reconcileManagedBucketPermissions(t.Context(), key, garageClient, remote); err != nil {
+		t.Fatalf("initial allBuckets reconcile: %v", err)
+	}
+	if len(allows) != 2 {
+		t.Fatalf("initial allow requests = %d, want one per bucket", len(allows))
+	}
+
+	// Model the server-side-apply result: the omitted field can remain as an
+	// all-false object after nested CRD defaults are applied.
+	migrated := &garagev1beta1.GarageKey{}
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(key), migrated); err != nil {
+		t.Fatal(err)
+	}
+	migrated.Spec.AllBuckets = &garagev1beta1.AllBucketsPermission{}
+	migrated.Spec.BucketPermissions = []garagev1beta1.BucketPermission{{
+		BucketID: explicitBucketID,
+		Read:     true,
+	}}
+	if err := c.Update(t.Context(), migrated); err != nil {
+		t.Fatal(err)
+	}
+
+	allows = nil
+	denies = nil
+	remote.Buckets = []garage.KeyBucket{
+		{ID: explicitBucketID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+		{ID: staleBucketID, Permissions: garage.BucketKeyPerms{Read: true, Write: true}},
+	}
+	if err := r.reconcileManagedBucketPermissions(t.Context(), migrated, garageClient, remote); err != nil {
+		t.Fatalf("scoped migration reconcile: %v", err)
+	}
+	if len(allows) != 0 {
+		t.Fatalf("migration unexpectedly allowed permissions: %+v", allows)
+	}
+	gotDenies := make(map[string]garage.BucketKeyPerms, len(denies))
+	for _, deny := range denies {
+		gotDenies[deny.BucketID] = deny.Permissions
+	}
+	wantDenies := map[string]garage.BucketKeyPerms{
+		explicitBucketID: {Write: true},
+		staleBucketID:    {Read: true, Write: true},
+	}
+	if len(gotDenies) != len(wantDenies) {
+		t.Fatalf("deny requests = %+v, want %+v", gotDenies, wantDenies)
+	}
+	for bucketID, want := range wantDenies {
+		if gotDenies[bucketID] != want {
+			t.Fatalf("deny for %s = %+v, want %+v", bucketID, gotDenies[bucketID], want)
+		}
+	}
+	if !migrated.Status.ClusterWide {
+		t.Fatal("cluster-wide ownership was released before the defaulted allBuckets cleanup completed")
+	}
+	if len(migrated.Status.ManagedBucketGrants) != 1 || migrated.Status.ManagedBucketGrants[0] != explicitBucketID {
+		t.Fatalf("managed grants = %v, want [%s]", migrated.Status.ManagedBucketGrants, explicitBucketID)
+	}
+}
+
 func TestGetOrCreateKey_COSIAnnotationPinsExactID(t *testing.T) {
 	const cosiID = "GKcosiexact"
 	for _, tc := range []struct {


### PR DESCRIPTION
## Summary

Allow an effective all-false `spec.allBuckets` object so a server-side-apply migration from cluster-wide permissions to scoped `bucketPermissions` can converge.

The CRD's nested boolean defaults can leave `allBuckets` as a non-nil all-false struct when SSA omits the field. The webhook previously rejected that representation, making the field effectively unremovable through the GitOps/SSA path.

The reconciler already treats a non-nil all-false object as a zero cluster-wide baseline: it does not grant any bucket permissions, revokes stale grants from the prior allBuckets declaration, and still applies explicit scoped permissions.

## Reproduction

Against `ghcr.io/rajsinghtech/garage-operator:v0.7.6`:

1. JSON patch removing `/spec/allBuckets`: admitted, with the expected no-permissions warning.
2. Server-side apply omitting `allBuckets` while adding scoped `bucketPermissions`: denied with `allBuckets: at least one permission (read, write, or owner) must be granted`.
3. Server-side apply with `allBuckets: null`: denied with the same error.
4. Explicit `allBuckets: {read: true}`: admitted, but retains cluster-wide read and therefore is not a least-privilege migration.

## Compatibility and scope

- Existing non-empty `allBuckets` permissions are unchanged.
- An all-false object means no cluster-wide access, matching the already-admitted state where the field is removed.
- No CRD schema, generated artifact, API version, or release-version change is required: the existing schema already permits all three booleans to be false.
- #359 (native GarageBucket deletion) and #360 (unrelated cross-namespace key denial) are related but intentionally out of scope.

## Tests

Added coverage for:

- webhook validation of the all-false effective SSA representation;
- the server-side-apply migration sequence from allBuckets to scoped permissions;
- reconciliation revoking stale cluster-wide grants while preserving the scoped grant.

Validation run locally:

- `make CONTROLLER_GEN=/tmp/controller-gen GOFLAGS=-timeout=20m test`
- `make CONTROLLER_GEN=/tmp/controller-gen test-race`
- `make GOLANGCI_LINT=/tmp/golangci-lint lint`
- `make CONTROLLER_GEN=/tmp/controller-gen verify-generate`
- `make validate-manifests`
- Helm lint/template
- `actionlint`
- `go mod tidy -diff`
- `go build ./...`

The checked-in helper binaries require an unavailable Nix loader in this environment; equivalent native binaries were used for local validation.