### PR TITLE
fix(bucket): skip unrelated denied key references

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -352,6 +352,12 @@ const (
 	ConditionBucketMetadataDegraded = "BucketMetadataDegraded"
 )
 
+// GarageKey and GarageBucket permission condition types
+const (
+	// ConditionPermissionsConfigured indicates bucket permissions have been configured
+	ConditionPermissionsConfigured = "PermissionsConfigured"
+)
+
 // GarageKey condition types
 const (
 	// ConditionKeyCreated indicates the key has been created in Garage
@@ -359,9 +365,6 @@ const (
 
 	// ConditionSecretCreated indicates the Kubernetes secret has been created
 	ConditionSecretCreated = "SecretCreated"
-
-	// ConditionPermissionsConfigured indicates bucket permissions have been configured
-	ConditionPermissionsConfigured = "PermissionsConfigured"
 
 	// ConditionKeyExpired indicates the key has expired
 	ConditionKeyExpired = "KeyExpired"
@@ -538,6 +541,10 @@ const (
 	// "Unable to decode entry of key". The operator auto-triggers
 	// Repair:Tables on the parent GarageCluster to re-sync key_table entries.
 	ReasonMetadataDecodeError = "MetadataDecodeError"
+
+	// ReasonReferenceGrantDenied indicates one or more declared references were
+	// denied because the destination namespace has not granted access.
+	ReasonReferenceGrantDenied = "ReferenceGrantDenied"
 )
 
 // Annotation keys for operational tasks

--- a/api/v1beta1/referencegrant_check.go
+++ b/api/v1beta1/referencegrant_check.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var errReferenceGrantDenied = errors.New("reference grant denied")
 
 const (
 	garageBucketKind = "GarageBucket"
@@ -87,13 +90,33 @@ func checkReferenceGrant(ctx context.Context, c client.Reader, fromKind, fromNam
 }
 
 func referenceGrantDenied(fromKind, fromNamespace, toKind, toNamespace, toName string) error {
-	return fmt.Errorf(
+	return &referenceGrantDeniedError{message: fmt.Sprintf(
 		"cross-namespace reference from %s %q/%q to %s %q/%q is not permitted: "+
 			"create a GarageReferenceGrant in namespace %q granting %s/%q access",
 		fromKind, fromNamespace, "<name>",
 		toKind, toNamespace, toName,
 		toNamespace, fromKind, fromNamespace,
-	)
+	)}
+}
+
+// referenceGrantDeniedError preserves the established denial message while
+// allowing reconcilers to distinguish a denied reference from an error while
+// evaluating the grants themselves.
+type referenceGrantDeniedError struct {
+	message string
+}
+
+func (e *referenceGrantDeniedError) Error() string { return e.message }
+
+func (e *referenceGrantDeniedError) Is(target error) bool {
+	return target == errReferenceGrantDenied
+}
+
+// IsReferenceGrantDenied reports whether err is the deliberate fail-closed
+// result for a reference that has no matching GarageReferenceGrant. Errors
+// reading grants or source namespace metadata are not classified as denials.
+func IsReferenceGrantDenied(err error) bool {
+	return errors.Is(err, errReferenceGrantDenied)
 }
 
 // CheckReferenceGrant applies the same cross-namespace authorization during

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -961,7 +961,9 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 	// A denied cross-namespace reference is a per-key authorization result, not
 	// a failure to reconcile this bucket. Record it before reserving ownership so
 	// the warning survives a crash before the first remote permission mutation.
-	setBucketPermissionsCondition(bucket, permissionDenials)
+	if len(permissionDenials) > 0 {
+		setBucketPermissionsCondition(bucket, permissionDenials)
+	}
 	if !stringSlicesEqual(bucket.Status.ManagedKeyGrants, reservedManaged) {
 		bucket.Status.ManagedKeyGrants = reservedManaged
 		if err := r.Status().Update(ctx, bucket); err != nil {
@@ -976,6 +978,9 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		}
 	}
 	if len(permissionErrors) > 0 {
+		if len(permissionDenials) == 0 {
+			setBucketPermissionsReconcileFailure(bucket, permissionErrors)
+		}
 		return fmt.Errorf("failed to set permissions for keys: %v", permissionErrors)
 	}
 	setBucketPermissionsCondition(bucket, permissionDenials)
@@ -1005,6 +1010,18 @@ func setBucketPermissionsCondition(bucket *garagev1beta1.GarageBucket, denied []
 		condition.Message = "Some key permission references were denied: " + strings.Join(details, "; ")
 	}
 	meta.SetStatusCondition(&bucket.Status.Conditions, condition)
+}
+
+func setBucketPermissionsReconcileFailure(bucket *garagev1beta1.GarageBucket, failures []string) {
+	details := append([]string(nil), failures...)
+	sort.Strings(details)
+	meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+		Type:               garagev1beta1.ConditionPermissionsConfigured,
+		Status:             metav1.ConditionFalse,
+		Reason:             garagev1beta1.ReasonReconcileFailed,
+		Message:            "Key permissions could not be configured: " + strings.Join(details, "; "),
+		ObservedGeneration: bucket.Generation,
+	})
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -854,9 +854,10 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 			detail := fmt.Sprintf("spec.keyPermissions[%d] GarageKey %s/%s: %v", i, keyNS, keyPerm.KeyRef.Name, err)
 			if garagev1beta1.IsReferenceGrantDenied(err) {
 				permissionDenials = append(permissionDenials, detail)
-			} else {
-				permissionErrors = append(permissionErrors, detail)
 			}
+			// This is an explicit bucket-owned declaration. Keep its historical
+			// fatal behavior; only unrelated reverse declarations are skippable.
+			permissionErrors = append(permissionErrors, detail)
 			// Resolve only enough exact identity to revoke a grant that may have
 			// committed before its managed-status write. Never preserve desired
 			// permissions from an unauthorized declaration.
@@ -958,9 +959,10 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		}
 	}
 
-	// A denied cross-namespace reference is a per-key authorization result, not
-	// a failure to reconcile this bucket. Record it before reserving ownership so
-	// the warning survives a crash before the first remote permission mutation.
+	// A denied reverse cross-namespace reference is a per-key authorization
+	// result, not a failure to reconcile this bucket. Record it before reserving
+	// ownership so the warning survives a crash before the first remote
+	// permission mutation. Explicit bucket-owned declarations remain fatal above.
 	if len(permissionDenials) > 0 {
 		setBucketPermissionsCondition(bucket, permissionDenials)
 	}

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -843,6 +843,7 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 	bucketDesired := make(map[string]garage.BucketKeyPerms, len(bucket.Spec.KeyPermissions))
 	unauthorizedTargets := make(map[string]struct{})
 	var permissionErrors []string
+	var permissionDenials []string
 	for i, keyPerm := range bucket.Spec.KeyPermissions {
 		keyNS := bucket.Namespace
 		if keyPerm.KeyRef.Namespace != "" {
@@ -850,7 +851,12 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		}
 		if err := garagev1beta1.CheckReferenceGrant(ctx, r.authorizationReader(), "GarageBucket", bucket.Namespace,
 			garageKeyKind, keyNS, keyPerm.KeyRef.Name); err != nil {
-			permissionErrors = append(permissionErrors, fmt.Sprintf("spec.keyPermissions[%d]: %v", i, err))
+			detail := fmt.Sprintf("spec.keyPermissions[%d] GarageKey %s/%s: %v", i, keyNS, keyPerm.KeyRef.Name, err)
+			if garagev1beta1.IsReferenceGrantDenied(err) {
+				permissionDenials = append(permissionDenials, detail)
+			} else {
+				permissionErrors = append(permissionErrors, detail)
+			}
 			// Resolve only enough exact identity to revoke a grant that may have
 			// committed before its managed-status write. Never preserve desired
 			// permissions from an unauthorized declaration.
@@ -894,12 +900,6 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 	// allow commits and the process dies before the remainder of reconciliation,
 	// a later spec removal still has an exact durable target to revoke.
 	reservedManaged := mergeManagedGrantIDs(bucket.Status.ManagedKeyGrants, bucketManaged)
-	if !stringSlicesEqual(bucket.Status.ManagedKeyGrants, reservedManaged) {
-		bucket.Status.ManagedKeyGrants = reservedManaged
-		if err := r.Status().Update(ctx, bucket); err != nil {
-			return fmt.Errorf("failed to reserve managed key grants: %w", err)
-		}
-	}
 
 	// Merge the GarageKey-owned portion. The exact desired Garage state is the
 	// union of both CR directions, which avoids controller-order flap wars.
@@ -909,7 +909,7 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		desired[id] = perms
 		targets[id] = struct{}{}
 	}
-	for _, id := range bucket.Status.ManagedKeyGrants {
+	for _, id := range reservedManaged {
 		targets[id] = struct{}{}
 	}
 	for id := range unauthorizedTargets {
@@ -939,7 +939,12 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		if perms, ok := keyPermissionsForBucket(key, bucket, existingBucket); ok {
 			if err := garagev1beta1.CheckReferenceGrant(ctx, r.authorizationReader(), garageKeyKind, key.Namespace,
 				"GarageBucket", bucket.Namespace, bucket.Name); err != nil {
-				permissionErrors = append(permissionErrors, fmt.Sprintf("GarageKey %s/%s: %v", key.Namespace, key.Name, err))
+				detail := fmt.Sprintf("GarageKey %s/%s: %v", key.Namespace, key.Name, err)
+				if garagev1beta1.IsReferenceGrantDenied(err) {
+					permissionDenials = append(permissionDenials, detail)
+				} else {
+					permissionErrors = append(permissionErrors, detail)
+				}
 				continue
 			}
 			// The GarageKey controller owns this declaration's durable
@@ -953,6 +958,17 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		}
 	}
 
+	// A denied cross-namespace reference is a per-key authorization result, not
+	// a failure to reconcile this bucket. Record it before reserving ownership so
+	// the warning survives a crash before the first remote permission mutation.
+	setBucketPermissionsCondition(bucket, permissionDenials)
+	if !stringSlicesEqual(bucket.Status.ManagedKeyGrants, reservedManaged) {
+		bucket.Status.ManagedKeyGrants = reservedManaged
+		if err := r.Status().Update(ctx, bucket); err != nil {
+			return fmt.Errorf("failed to reserve managed key grants: %w", err)
+		}
+	}
+
 	for accessKeyID := range targets {
 		if err := reconcileExactBucketKeyPermissions(ctx, garageClient, bucketID, accessKeyID, currentPerms[accessKeyID], desired[accessKeyID]); err != nil {
 			log.Error(err, "Failed to reconcile exact key permissions", "accessKeyId", accessKeyID, "bucketId", bucketID)
@@ -962,6 +978,7 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 	if len(permissionErrors) > 0 {
 		return fmt.Errorf("failed to set permissions for keys: %v", permissionErrors)
 	}
+	setBucketPermissionsCondition(bucket, permissionDenials)
 
 	if !stringSlicesEqual(bucket.Status.ManagedKeyGrants, bucketManaged) {
 		bucket.Status.ManagedKeyGrants = bucketManaged
@@ -970,6 +987,24 @@ func (r *GarageBucketReconciler) reconcileKeyPermissions(ctx context.Context, bu
 		}
 	}
 	return nil
+}
+
+func setBucketPermissionsCondition(bucket *garagev1beta1.GarageBucket, denied []string) {
+	condition := metav1.Condition{
+		Type:               garagev1beta1.ConditionPermissionsConfigured,
+		Status:             metav1.ConditionTrue,
+		Reason:             garagev1beta1.ReasonReconcileSuccess,
+		Message:            "All declared key permissions are configured",
+		ObservedGeneration: bucket.Generation,
+	}
+	if len(denied) > 0 {
+		details := append([]string(nil), denied...)
+		sort.Strings(details)
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = garagev1beta1.ReasonReferenceGrantDenied
+		condition.Message = "Some key permission references were denied: " + strings.Join(details, "; ")
+	}
+	meta.SetStatusCondition(&bucket.Status.Conditions, condition)
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/controller/referencegrant_runtime_test.go
+++ b/internal/controller/referencegrant_runtime_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -303,6 +304,85 @@ func TestRuntimeAuthorizationAllowsNamespaceSelectorGrant(t *testing.T) {
 	}
 	if len(fresh.Status.Conditions) > 0 && strings.Contains(fresh.Status.Conditions[0].Message, "GarageReferenceGrant") {
 		t.Fatalf("selector grant was not accepted: status=%+v", fresh.Status)
+	}
+}
+
+func TestGarageBucketReconcileSkipsDeniedCrossNamespaceKey(t *testing.T) {
+	const (
+		bucketNamespace  = "bhaiya"
+		foreignNamespace = "hermes"
+		clusterName      = "garage"
+		bucketID         = "bucket-id"
+		allowedKeyID     = "GKallowed"
+		deniedKeyID      = "GKdenied"
+	)
+	scheme := runtimeGrantScheme(t)
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "workspace", Namespace: bucketNamespace},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+			KeyPermissions: []garagev1beta1.KeyPermission{{
+				KeyRef: garagev1beta1.KeyRef{Name: "allowed"}, Read: true,
+			}},
+		},
+	}
+	allowed := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "allowed", Namespace: bucketNamespace},
+		Spec: garagev1beta1.GarageKeySpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+		},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: allowedKeyID},
+	}
+	foreign := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "hermes-s3-key", Namespace: foreignNamespace},
+		Spec: garagev1beta1.GarageKeySpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName, Namespace: bucketNamespace},
+			AllBuckets: &garagev1beta1.AllBucketsPermission{Read: true},
+		},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: deniedKeyID, ClusterWide: true},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(bucket, allowed, foreign).
+		WithStatusSubresource(&garagev1beta1.GarageBucket{}).Build()
+	var allows []garage.AllowBucketKeyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v2/AllowBucketKey" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var allow garage.AllowBucketKeyRequest
+		if err := json.NewDecoder(request.Body).Decode(&allow); err != nil {
+			t.Errorf("decode AllowBucketKey request: %v", err)
+		}
+		allows = append(allows, allow)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	r := &GarageBucketReconciler{Client: c, Scheme: scheme}
+	if err := r.reconcileKeyPermissions(t.Context(), bucket, garage.NewClient(server.URL, "token"), &garage.Bucket{ID: bucketID}); err != nil {
+		t.Fatalf("reconcileKeyPermissions: %v", err)
+	}
+	if len(allows) != 1 || allows[0].AccessKeyID != allowedKeyID || allows[0].BucketID != bucketID || !allows[0].Permissions.Read {
+		t.Fatalf("AllowBucketKey calls = %+v, want only the grantable key", allows)
+	}
+
+	fresh := &garagev1beta1.GarageBucket{}
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(bucket), fresh); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	condition := meta.FindStatusCondition(fresh.Status.Conditions, garagev1beta1.ConditionPermissionsConfigured)
+	if condition == nil {
+		t.Fatalf("missing permission condition: %+v", fresh.Status.Conditions)
+	}
+	if condition.Status != metav1.ConditionFalse || condition.Reason != garagev1beta1.ReasonReferenceGrantDenied {
+		t.Fatalf("permission condition = %+v, want False/%s", condition, garagev1beta1.ReasonReferenceGrantDenied)
+	}
+	if !strings.Contains(condition.Message, foreignNamespace+"/hermes-s3-key") || !strings.Contains(condition.Message, "GarageReferenceGrant") {
+		t.Fatalf("permission condition message = %q, want denied key and grant guidance", condition.Message)
+	}
+	if !stringSliceContains(fresh.Status.ManagedKeyGrants, allowedKeyID) {
+		t.Fatalf("ManagedKeyGrants = %v, want grantable key %q", fresh.Status.ManagedKeyGrants, allowedKeyID)
 	}
 }
 


### PR DESCRIPTION
Fixes #360

## Summary

- Treat a denied reverse `GarageKey -> GarageBucket` reference as a per-key authorization result.
- Continue reconciling authorized bucket permissions instead of failing the entire `GarageBucket`.
- Surface skipped references in the existing `PermissionsConfigured=False` status condition with reason `ReferenceGrantDenied`.
- Keep explicit `GarageBucket.spec.keyPermissions` denials fatal for backward compatibility.
- Add a typed reference-grant denial classifier so grant-evaluation/read errors remain fatal.

The operator does not create a `GarageReferenceGrant`. In the production case behind #360, following the webhook's suggested workaround would grant a foreign web-UI key read/write access to every private bucket in the destination namespace. Skipping the unrelated denied key is therefore the safe behavior; the condition keeps that skipped declaration visible.

## Compatibility and API

No CRD schema or API-version change is needed. Existing status conditions are used, and version fields are untouched.

## Validation

- `CGO_ENABLED=0 go test ./... -timeout 900s`
- `CGO_ENABLED=0 make test`
- `CGO_ENABLED=0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`