### PR TITLE
fix(renovate): tidy Go modules after updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
   "baseBranchPatterns": [
     "main"
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Enable Renovate's `gomodTidy` post-update option so Go dependency updates regenerate `go.mod` and `go.sum` before their CI checks run. This prevents obsolete checksums and stale indirect requirements from blocking every Go dependency PR at `go mod tidy -diff`.

## Related issue or design

This addresses the repeated tidy failures observed on Renovate PRs #316, #317, #319, and #335.

## Compatibility and operational impact

No operator code or shipped artifact changes. Renovate will add the normal `go mod tidy` result to dependency-update commits.

`gomodUpdateImportPaths` is intentionally not enabled: Renovate documents it for major module import-path migrations, which is unrelated to this failure mode.

## Validation

Commands run:

- `jq empty renovate.json`
- In a detached copy of Renovate PR #317's head, `go mod tidy -diff` reproduced the two obsolete Ginkgo v2.32.0 checksum lines from CI.
- Running `go mod tidy` in that detached copy removed exactly those two lines; a subsequent `go mod tidy -diff` exited 0.
- Verified all GitHub Actions Go setup steps use `go-version-file: go.mod`; the module declares Go 1.26.0.

Documentation: https://docs.renovatebot.com/configuration-options/#gomodtidy

## Checklist

- [x] The PR addresses one coherent problem and includes its necessary robustness fixes.
- [ ] Tests cover the changed behavior.
- [x] User-facing docs and samples are updated where needed.
- [x] Generated files were regenerated and committed where needed.
- [x] Release-only chart version fields are unchanged.