### PR TITLE
fix(bucket): safely handle non-empty deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,9 @@ spec:
 ```
 
 `Delete` waits for Garage to confirm the bucket is empty; it never recursively
-deletes completed objects. Before retaining a bucket, record
+deletes completed objects. A non-empty bucket remains in `Deleting` with
+`DeletionBlocked=True`/`BucketNotEmpty` and a backoff retry; remove the content
+or change the terminating resource to `deletionPolicy: Retain`. Before retaining a bucket, record
 `status.bucketId`, then use that value in `spec.bucketId` to re-adopt the bucket
 later. Retain does not preserve the underlying Garage cluster or storage.
 
@@ -1797,7 +1799,7 @@ The operator includes an optional COSI (Container Object Storage Interface) driv
 
 - Only S3 protocol is supported
 - Only Key authentication is supported; `BucketAccess` requests using `ServiceAccount` authentication are rejected by the driver (`ServiceAccount auth not supported by Garage`), and Garage has no IAM authentication mode
-- Bucket and credential deletion run via a protection finalizer when the BucketClaim/BucketAccess (and the resulting Bucket/BucketAccess) are deleted — the operator deletes the Garage bucket and revokes/deletes the key directly (no gRPC sidecar). A non-empty bucket is refused: the operator surfaces a `bucket not empty` error and retries until it is emptied.
+- Bucket and credential deletion run via a protection finalizer when the BucketClaim/BucketAccess (and the resulting Bucket/BucketAccess) are deleted — the operator deletes the Garage bucket and revokes/deletes the key directly (no gRPC sidecar). A non-empty bucket is refused: the operator reports the error and retries until it is emptied. While a `Delete` bucket is blocked, its matching BucketAccess key and Secret remain available for an explicit cleanup controller or administrator; they are revoked after bucket cleanup completes.
 
 ## Documentation
 

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -350,6 +350,12 @@ const (
 	// Repair:Tables on the parent GarageCluster after BucketDecodeErrorThreshold
 	// consecutive failures. Cleared on the first successful GetBucketInfo.
 	ConditionBucketMetadataDegraded = "BucketMetadataDegraded"
+
+	// ConditionDeletionBlocked indicates that a resource's deletion cannot
+	// complete without an explicit user action. It is deliberately separate
+	// from Ready so callers can distinguish a safe data-protection hold from a
+	// general reconciliation failure.
+	ConditionDeletionBlocked = "DeletionBlocked"
 )
 
 // GarageKey condition types
@@ -538,6 +544,10 @@ const (
 	// "Unable to decode entry of key". The operator auto-triggers
 	// Repair:Tables on the parent GarageCluster to re-sync key_table entries.
 	ReasonMetadataDecodeError = "MetadataDecodeError"
+	// ReasonBucketNotEmpty indicates Garage refused a bucket deletion because
+	// objects or other bucket content remain. The operator never purges that
+	// content implicitly.
+	ReasonBucketNotEmpty = "BucketNotEmpty"
 )
 
 // Annotation keys for operational tasks

--- a/docs/design/2026-09-02-safe-bucket-deletion-design.md
+++ b/docs/design/2026-09-02-safe-bucket-deletion-design.md
@@ -1,0 +1,102 @@
+# Safe bucket deletion and COSI cleanup handoff
+
+**Status:** implementation for [#359](https://github.com/rajsinghtech/garage-operator/issues/359)
+and [#353](https://github.com/rajsinghtech/garage-operator/issues/353).
+
+## Problem and evidence
+
+Garage's `DeleteBucket` operation refuses to delete a bucket that still has
+content. The native `GarageBucket` controller already kept its finalizer and
+retried, but only exposed the reason in a log line. That left the Kubernetes
+resource in `Deleting` with no durable, user-visible explanation.
+
+The COSI `Bucket` path had the same remote constraint. In addition, deleting a
+COSI `BucketAccess` immediately revoked its Garage key. When a
+`BucketClaim`/namespace deletion caused the bucket and access to enter deletion
+together, the controller responsible for cleanup could lose its only ordinary
+bucket credential before it had emptied the bucket. #353 is the COSI form of
+the same lifecycle problem; #360 is separate and is intentionally not part of
+this change.
+
+## Decision
+
+Keep the existing `Delete` and `Retain` policies and do not add an implicit
+purge. `Delete` continues to mean “ask Garage to delete the remote bucket,”
+which succeeds only after Garage confirms it is empty. `Retain` remains the
+explicit way to remove Kubernetes management while preserving remote data.
+
+Automatic emptying is rejected because it would turn a normal Kubernetes
+delete into irreversible data loss, require broad object-deletion credentials,
+and provide no archive or recovery window. A new `Purge` API value is also not
+introduced: native users already have `Retain`, while COSI's `Delete`/`Retain`
+enum is owned by the external COSI API and cannot be extended by this driver.
+
+When Garage returns its typed `BucketNotEmpty` conflict:
+
+- Native `GarageBucket` keeps its finalizer, sets
+  `DeletionBlocked=True`/`BucketNotEmpty` and `Ready=False` with an actionable
+  message, and retries with a bounded exponential delay (30 seconds through a
+  five-minute cap).
+- COSI `Bucket` keeps the Garage cleanup finalizer, records the same action in
+  `status.error`, marks `readyToUse=false`, and uses the same backoff. The
+  COSI `Bucket` object therefore remains the durable status surface while the
+  upstream COSI controller waits for deletion.
+- A deleting COSI `BucketAccess` whose recorded status identifies the exact
+  matching `Delete` bucket defers key revocation while that bucket's Garage
+  cleanup finalizer remains. The generated Secret and Garage key remain usable
+  for the explicit emptying action. Once bucket cleanup succeeds, the next
+  access reconcile revokes the key and completes the normal COSI handoff. An
+  access deleted independently, or an access for a `Retain` bucket, follows
+  the existing immediate-revocation path.
+
+The operator never lists, deletes, or purges bucket objects as part of this
+workflow. The user or a cleanup controller must remove objects and incomplete
+multipart uploads through S3 (and any other Garage-supported data API) before
+the retry can succeed. If data must be kept, set `deletionPolicy: Retain` on
+the terminating resource and let cleanup release Kubernetes management.
+
+## Compatibility and API impact
+
+Existing native users keep the historical default: omitted `deletionPolicy`
+means `Delete`, empty buckets are deleted, and non-empty buckets are never
+implicitly emptied. The change adds status and backoff observability without
+changing the remote deletion result. Existing COSI users likewise retain
+normal immediate access revocation except for the narrow, necessary handoff
+where a dependent `Delete` bucket is concurrently waiting for cleanup.
+
+No CRD schema or served API version changes are required. Native status already
+uses generic `metav1.Condition`, so `DeletionBlocked` is an additional
+condition value rather than a new field. COSI `Bucket.status.error` and the
+existing `BucketAccess` status/finalizer fields provide the required surfaces.
+No generated CRDs, conversion code, chart values, or release version fields
+change. A rollback is data-safe, but an older operator will not preserve the
+COSI access handoff and should not be used to finish a cleanup that depends on
+that credential.
+
+## Failure modes and safety
+
+The remote delete is attempted before any cleanup finalizer is removed. A
+non-empty response cannot remove a finalizer, and failures to write status or
+the retry counter also leave the finalizer in place. Retry writes are conflict
+aware and identify the object UID before retrying, so a deleted-and-recreated
+object cannot inherit another object's cleanup count.
+
+Changing to `Retain` is the recovery path when the data must survive. Manual
+finalizer removal is intentionally not documented as a routine fix because it
+can orphan the remote bucket or leave credentials and data outside Kubernetes
+management.
+
+## Test plan
+
+Unit regressions cover:
+
+- native `GarageBucket` finalization preserving the typed Garage error;
+- native status condition, finalizer retention, retry counter, and backoff;
+- COSI `Bucket` status/error, finalizer retention, retry counter, and backoff;
+- COSI `BucketAccess` retaining access while the exact bucket is deleting and
+  revoking it once that bucket cleanup finalizer is gone; and
+- existing empty-bucket, retained-bucket, identity, and finalizer handoff
+  behavior.
+
+The change intentionally does not address unrelated cross-namespace
+reconciliation failures in #360 or add an automatic object-deletion worker.

--- a/docs/how-to/buckets-and-credentials.md
+++ b/docs/how-to/buckets-and-credentials.md
@@ -39,6 +39,25 @@ the `GarageBucket` resource is deleted:
   rules remain in Garage. This works even when the referenced cluster or Admin
   API is unavailable.
 
+`Delete` is safe with data: the operator never empties a bucket implicitly. If
+Garage reports that the bucket is not empty, the finalizer remains and the
+operator sets `DeletionBlocked=True` with reason `BucketNotEmpty` on the
+`GarageBucket`. It retries with backoff, so the resource is visible as
+`Deleting` rather than appearing healthy or being silently purged. Remove the
+objects and incomplete multipart uploads through an S3 client, then allow the
+next retry to delete the now-empty bucket. If the data should remain, change
+the terminating resource to `deletionPolicy: Retain`; the operator then drops
+its Kubernetes finalizer without contacting Garage.
+
+Inspect the actionable condition and retry count with:
+
+```bash
+kubectl get garagebucket app-data -n storage -o jsonpath='{range .status.conditions[?(@.type=="DeletionBlocked")]}{.status} ({.reason}): {.message}{"\n"}{end}{.metadata.annotations.garage\.rajsingh\.info/finalization-retries}'
+```
+
+Do not remove the finalizer manually unless abandoning remote cleanup is
+intentional; doing so can leave the remote bucket and its data unmanaged.
+
 Use `Retain` for buckets containing backups or other data that must outlive the
 Kubernetes resource:
 

--- a/docs/how-to/object-storage-interfaces.md
+++ b/docs/how-to/object-storage-interfaces.md
@@ -112,7 +112,10 @@ Only S3 and Key authentication are supported. `BucketAccess` requests using
 mode. `BucketClaim` creates a Garage bucket and `BucketAccess` creates a
 key/credential Secret through operator-owned shadow `GarageBucket`/`GarageKey`
 resources. `Delete` waits for the bucket to be empty; a non-empty bucket is not
-silently destroyed.
+silently destroyed. The driver records the failure in `Bucket.status.error`,
+keeps the Garage cleanup finalizer, and retries with bounded backoff. Empty the
+bucket and abort incomplete multipart uploads through S3, or change the
+terminating Bucket to `deletionPolicy: Retain` when the remote data must stay.
 
 The generated COSI access Secret contains the canonical keys
 `COSI_PROTOCOL`, `COSI_S3_BUCKET_ID`, `COSI_S3_ENDPOINT`,
@@ -124,7 +127,20 @@ The generated COSI access Secret contains the canonical keys
 Bucket and access deletion is a two-controller handoff. The Garage protection
 finalizer removes the remote bucket/key or revokes permissions, then releases
 the upstream COSI protection finalizer. A retained bucket skips remote bucket
-deletion; a `Delete` bucket must be emptied before cleanup can complete.
+deletion; a `Delete` bucket must be emptied before cleanup can complete. When a
+`Delete` Bucket is terminating, the driver temporarily keeps a matching
+`BucketAccess`, its Garage key, and its generated Secret behind the driver's
+cleanup finalizer. This gives a cleanup controller or administrator a way to
+empty the bucket after a `BucketClaim` deletion has started. Once the bucket's
+Garage cleanup finalizer is gone, access revocation resumes automatically. An
+independently deleted access, or access to a `Retain` bucket, is revoked using
+the normal path.
+
+This is a cleanup handoff, not a purge policy: the operator never lists or
+deletes bucket contents and does not add credentials to unrelated resources.
+If access must be revoked immediately, retain the bucket first; setting
+`deletionPolicy: Retain` lets the access cleanup proceed while preserving the
+remote bucket.
 
 If `cosi.namespace` differs from the target `GarageCluster` namespace, create a `GarageReferenceGrant` in that target namespace for the COSI shadow `GarageBucket` and `GarageKey` kinds.
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -58,6 +58,30 @@ For a retained bucket, save `status.bucketId` before deletion so the bucket can
 later be re-adopted with `spec.bucketId`. Retain does not protect Garage's
 underlying workloads or PVCs.
 
+### COSI Bucket is stuck deleting
+
+Inspect the cluster-scoped COSI objects and the operator-owned cleanup status:
+
+```bash
+kubectl get bucket <bucket-name> -o yaml
+kubectl get bucketaccess -n <claim-namespace> -o yaml
+kubectl get bucketclaim <claim-name> -n <claim-namespace> -o yaml
+```
+
+For a `Delete` bucket, a non-empty Garage response is reported as
+`Bucket.status.error`; the Garage cleanup finalizer remains and the retry
+counter is backed off. Remove all S3 objects and incomplete multipart uploads
+using the credentials in the matching `BucketAccess` Secret. During this
+handoff the operator deliberately keeps that access and Secret until the
+bucket cleanup finalizer completes. It then revokes the key and releases the
+remaining COSI finalizers.
+
+If the bucket data must be preserved instead, change the terminating COSI
+`Bucket` to `deletionPolicy: Retain`. The driver will stop remote deletion and
+revoke the access normally. Do not force-remove COSI or Garage finalizers: that
+can orphan a remote bucket, leave credentials active, or make the data
+unmanageable.
+
 ### Bucket/key/token stuck Pending with a `ClusterNotReady` condition mentioning DNS
 
 The `GarageCluster` itself can be `Running` (its pods are reachable directly by

--- a/docs/reference/custom-resources.md
+++ b/docs/reference/custom-resources.md
@@ -217,7 +217,10 @@ bucket. `size`, incomplete-upload counters, `quotaUsage`, `websiteEnabled`,
 `managedKeyGrants` fields are controller ownership records used for crash-safe
 replacement and revocation; do not edit them. Inspect the `Ready` and
 `LifecycleConfigured` conditions, plus `BucketLookupStuck` or
-`BucketMetadataDegraded` when a bucket is not ready. The older bucket condition
+`BucketMetadataDegraded` when a bucket is not ready. During a requested
+`Delete`, a non-empty remote bucket sets `DeletionBlocked=True` with reason
+`BucketNotEmpty` and leaves the finalizer in place until an operator or
+administrator removes the content. The older bucket condition
 constants (`BucketCreated`, `QuotaConfigured`, `WebsiteConfigured`, and
 `AliasesConfigured`) remain for compatibility and are not emitted independently.
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -75,6 +75,7 @@ package for compatibility but are not emitted as independent status conditions.
 | `GarageBucket` | `Ready` | Bucket reconciliation is complete |
 | `GarageBucket` | `LifecycleConfigured` | Requested lifecycle rules were applied; False reports an application failure |
 | `GarageBucket` | `BucketLookupStuck` / `BucketMetadataDegraded` | True reports repeated Admin lookup timeouts or metadata decode failures |
+| `GarageBucket` | `DeletionBlocked` | True/`BucketNotEmpty` means Garage refused deletion because content remains; remove content or choose `deletionPolicy: Retain` |
 | `GarageKey` | `Ready` | Key, permissions, and requested Secret state are reconciled |
 | `GarageNode` | `Ready` | Node identity/workload and observed Garage state are reconciled |
 | `GarageNode` | `DrainPrepared` | True means the exact drain transaction has made deletion safe |

--- a/internal/controller/finalization_identity_test.go
+++ b/internal/controller/finalization_identity_test.go
@@ -29,6 +29,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -113,6 +114,100 @@ func TestGarageBucketFinalizationDisagreementFailsClosed(t *testing.T) {
 	}
 	if calls.Load() != 0 {
 		t.Fatalf("DeleteBucket calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestGarageBucketFinalizationPreservesBucketNotEmptyError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`BucketNotEmpty`))
+	}))
+	defer server.Close()
+
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "bucket", Namespace: testNamespace},
+		Status:     garagev1beta1.GarageBucketStatus{BucketID: "non-empty-id"},
+	}
+	err := (&GarageBucketReconciler{}).finalize(t.Context(), bucket, garage.NewClient(server.URL, "token"))
+	if err == nil || !garage.IsBucketNotEmpty(err) {
+		t.Fatalf("finalize error = %v, want a typed BucketNotEmpty error", err)
+	}
+	if !strings.Contains(err.Error(), "delete all objects before removing") {
+		t.Fatalf("finalize error = %v, want actionable deletion guidance", err)
+	}
+}
+
+func TestGarageBucketNonEmptyDeletionSurfacesConditionAndBacksOff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`BucketNotEmpty`))
+	}))
+	defer server.Close()
+	handle, secret := finalizationRetryHandle(server.URL)
+	now := metav1.Now()
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bucket", Namespace: "tenant", Finalizers: []string{garageBucketFinalizer},
+			DeletionTimestamp: &now,
+			Annotations:       map[string]string{FinalizationRetryAnnotation: "1"},
+		},
+		Spec: garagev1beta1.GarageBucketSpec{ClusterRef: garagev1beta1.ClusterReference{
+			Name: handle.Name, Namespace: handle.Namespace,
+		}},
+		Status: garagev1beta1.GarageBucketStatus{BucketID: "non-empty-id"},
+	}
+	wrapped, _ := finalizationRetryClient(t, []client.Object{handle, secret, bucket})
+	reconciler := &GarageBucketReconciler{Client: wrapped, Scheme: wrapped.Scheme()}
+
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(bucket)})
+	if err != nil {
+		t.Fatalf("Reconcile error = %v, want status-driven retry", err)
+	}
+	if result.RequeueAfter != FinalizationRetryDelay(2) {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, FinalizationRetryDelay(2))
+	}
+
+	fresh := &garagev1beta1.GarageBucket{}
+	if err := wrapped.Get(t.Context(), client.ObjectKeyFromObject(bucket), fresh); err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got := fresh.Annotations[FinalizationRetryAnnotation]; got != "2" {
+		t.Fatalf("retry annotation = %q, want 2", got)
+	}
+	if fresh.Status.Phase != PhaseDeleting {
+		t.Fatalf("phase = %q, want %q", fresh.Status.Phase, PhaseDeleting)
+	}
+	blocked := meta.FindStatusCondition(fresh.Status.Conditions, garagev1beta1.ConditionDeletionBlocked)
+	if blocked == nil {
+		t.Fatalf("conditions = %#v, want %s condition", fresh.Status.Conditions, garagev1beta1.ConditionDeletionBlocked)
+	}
+	if blocked.Status != metav1.ConditionTrue || blocked.Reason != garagev1beta1.ReasonBucketNotEmpty {
+		t.Fatalf("deletion condition = %#v, want true/%s", blocked, garagev1beta1.ReasonBucketNotEmpty)
+	}
+	if !strings.Contains(blocked.Message, "remove all objects") || !strings.Contains(blocked.Message, "never empties") {
+		t.Fatalf("deletion condition message = %q, want actionable safe-deletion guidance", blocked.Message)
+	}
+	ready := meta.FindStatusCondition(fresh.Status.Conditions, PhaseReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != garagev1beta1.ReasonBucketNotEmpty {
+		t.Fatalf("ready condition = %#v, want false/%s", ready, garagev1beta1.ReasonBucketNotEmpty)
+	}
+	if !controllerutil.ContainsFinalizer(fresh, garageBucketFinalizer) {
+		t.Fatal("bucket cleanup finalizer was removed while the bucket was non-empty")
+	}
+}
+
+func TestFinalizationRetryDelayIsBounded(t *testing.T) {
+	if got := FinalizationRetryDelay(0); got != RequeueAfterError {
+		t.Fatalf("retry delay for zero retries = %s, want %s", got, RequeueAfterError)
+	}
+	if got := FinalizationRetryDelay(2); got != 2*RequeueAfterError {
+		t.Fatalf("retry delay for two retries = %s, want %s", got, 2*RequeueAfterError)
+	}
+	if got := FinalizationRetryDelay(10); got != RequeueAfterLong {
+		t.Fatalf("retry delay for ten retries = %s, want cap %s", got, RequeueAfterLong)
+	}
+	if got := FinalizationRetryDelay(-1); got != RequeueAfterError {
+		t.Fatalf("retry delay for malformed negative count = %s, want %s", got, RequeueAfterError)
 	}
 }
 

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -285,8 +285,44 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					}
 					log.Error(patchErr, "Failed to update retry count annotation")
 				}
-				log.Error(err, "Failed to finalize bucket, retaining finalizer",
-					"retries", GetFinalizationRetryCount(bucket))
+				retryCount := GetFinalizationRetryCount(bucket)
+				log.Error(err, "Failed to finalize bucket, retaining finalizer", "retries", retryCount)
+				if garage.IsBucketNotEmpty(err) {
+					message := fmt.Sprintf(
+						"bucket %q is not empty; remove all objects and incomplete multipart uploads before deleting the GarageBucket. "+
+							"The operator never empties buckets automatically. Set deletionPolicy: Retain to preserve the remote bucket instead.",
+						bucket.Name,
+					)
+					apply := func() {
+						bucket.Status.Phase = PhaseDeleting
+						meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+							Type:               garagev1beta1.ConditionDeletionBlocked,
+							Status:             metav1.ConditionTrue,
+							Reason:             garagev1beta1.ReasonBucketNotEmpty,
+							Message:            message,
+							ObservedGeneration: bucket.Generation,
+						})
+						meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+							Type:               PhaseReady,
+							Status:             metav1.ConditionFalse,
+							Reason:             garagev1beta1.ReasonBucketNotEmpty,
+							Message:            message,
+							ObservedGeneration: bucket.Generation,
+						})
+					}
+					apply()
+					if statusErr := UpdateStatusWithRetry(ctx, r.Client, bucket, apply); statusErr != nil {
+						return ctrl.Result{}, statusErr
+					}
+					return ctrl.Result{RequeueAfter: FinalizationRetryDelay(retryCount)}, nil
+				}
+				meta.SetStatusCondition(&bucket.Status.Conditions, metav1.Condition{
+					Type:               garagev1beta1.ConditionDeletionBlocked,
+					Status:             metav1.ConditionFalse,
+					Reason:             garagev1beta1.ReasonReconcileFailed,
+					Message:            "bucket deletion is retrying after a finalization error",
+					ObservedGeneration: bucket.Generation,
+				})
 				_, _ = r.updateStatus(ctx, bucket, PhaseDeleting, fmt.Errorf("finalization failed: %w", err))
 				return ctrl.Result{RequeueAfter: RequeueAfterError}, nil
 			}
@@ -1307,7 +1343,7 @@ func (r *GarageBucketReconciler) finalize(ctx context.Context, bucket *garagev1b
 		}
 		// Specific error for bucket not empty - give user actionable message
 		if garage.IsBucketNotEmpty(err) {
-			return fmt.Errorf("bucket %q is not empty - delete all objects before removing the GarageBucket resource", bucket.Name)
+			return fmt.Errorf("bucket %q is not empty - delete all objects before removing the GarageBucket resource: %w", bucket.Name, err)
 		}
 		// For other errors, return generic message
 		return fmt.Errorf("failed to delete bucket: %w", err)

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -384,6 +384,28 @@ const (
 	finalizeRPCTimeout = 15 * time.Second
 )
 
+// FinalizationRetryDelay returns a bounded exponential delay for a cleanup
+// retry. The retry count is persisted on the object so a controller restart
+// does not reset a repeatedly failing finalizer to a hot loop. It is exported
+// because the COSI reconcilers use the same cleanup protocol as native
+// GarageBucket resources.
+func FinalizationRetryDelay(retries int) time.Duration {
+	if retries <= 1 {
+		return RequeueAfterError
+	}
+	delay := RequeueAfterError
+	for i := 1; i < retries; i++ {
+		if delay >= RequeueAfterLong/2 {
+			return RequeueAfterLong
+		}
+		delay *= 2
+	}
+	if delay > RequeueAfterLong {
+		return RequeueAfterLong
+	}
+	return delay
+}
+
 // GetGarageClient creates a Garage Admin API client for the given cluster.
 // This is a shared helper used by all controllers that need to interact with Garage.
 // GetAdminToken prefers the operator's table-backed token after it has reached

--- a/internal/cosi/bucket_controller.go
+++ b/internal/cosi/bucket_controller.go
@@ -35,6 +35,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cosiv1alpha2 "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
+
+	garagecontroller "github.com/rajsinghtech/garage-operator/internal/controller"
+	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets,verbs=get;list;watch;update;patch
@@ -151,6 +154,9 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rec
 	if !bucket.GetDeletionTimestamp().IsZero() {
 		if bucket.Status.BucketID != "" {
 			if err := r.Provisioner.DeleteBucket(ctx, bucket.Status.BucketID, params); err != nil {
+				if garage.IsBucketNotEmpty(err) {
+					return r.handleBucketNotEmpty(ctx, bucket)
+				}
 				return r.fail(ctx, bucket, err)
 			}
 		}
@@ -321,4 +327,28 @@ func (r *BucketReconciler) fail(ctx context.Context, bucket *cosiv1alpha2.Bucket
 	bucket.Status.Error = cosiv1alpha2.NewTimestampedError(time.Now(), in.Error())
 	_ = r.Status().Update(ctx, bucket)
 	return reconcile.Result{}, in
+}
+
+func (r *BucketReconciler) handleBucketNotEmpty(ctx context.Context, bucket *cosiv1alpha2.Bucket) (reconcile.Result, error) {
+	retryCount, err := recordFinalizationRetry(ctx, r.Client, bucket)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("record non-empty bucket cleanup retry: %w", err)
+	}
+	message := fmt.Sprintf(
+		"bucket %q is not empty; remove all objects and incomplete multipart uploads before deleting it. "+
+			"The operator never empties buckets automatically; choose deletionPolicy: Retain before deletion when the data must be preserved.",
+		bucket.Name,
+	)
+	apply := func() {
+		bucket.Status.ReadyToUse = ptr.To(false)
+		bucket.Status.Error = cosiv1alpha2.NewTimestampedError(time.Now(), message)
+	}
+	apply()
+	if err := garagecontroller.UpdateStatusWithRetry(ctx, r.Client, bucket, apply); err != nil {
+		return reconcile.Result{}, fmt.Errorf("record non-empty bucket status: %w", err)
+	}
+	return reconcile.Result{RequeueAfter: garagecontroller.FinalizationRetryDelay(retryCount)}, nil
 }

--- a/internal/cosi/bucketaccess_controller.go
+++ b/internal/cosi/bucketaccess_controller.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cosiv1alpha2 "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
+
+	garagecontroller "github.com/rajsinghtech/garage-operator/internal/controller"
 )
 
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketaccesses,verbs=get;list;watch;update;patch
@@ -80,6 +82,15 @@ func (r *BucketAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	if access.Status.DriverName != r.DriverName {
 		return reconcile.Result{}, nil
+	}
+	if !access.GetDeletionTimestamp().IsZero() && ctrlutil.ContainsFinalizer(access, GarageProtectionFinalizer) {
+		bucketName, err := r.findDeletingBucketForAccess(ctx, access)
+		if err != nil {
+			return r.fail(ctx, access, fmt.Errorf("check referenced bucket cleanup before revoking access: %w", err))
+		}
+		if bucketName != "" {
+			return r.deferAccessRevocation(ctx, access, bucketName)
+		}
 	}
 	identity, err := r.Provisioner.ResolveBucketAccessIdentity(
 		ctx, access.Namespace, access.Name, string(access.UID), access.Status.AccountID, r.DriverName,
@@ -293,6 +304,104 @@ func (r *BucketAccessReconciler) resolveBucketIDs(ctx context.Context, access *c
 		ids = append(ids, s.BucketID)
 	}
 	return ids
+}
+
+// findDeletingBucketForAccess uses the COSI status mapping as its primary
+// source because BucketClaims may already be gone when namespace deletion
+// drives cleanup. It falls back to live claims for older accesses whose
+// status was not recorded by an earlier operator version.
+func (r *BucketAccessReconciler) findDeletingBucketForAccess(ctx context.Context, access *cosiv1alpha2.BucketAccess) (string, error) {
+	if access.Status.AccountID == "" {
+		return "", nil
+	}
+
+	if len(access.Status.AccessedBuckets) > 0 {
+		for _, reference := range access.Status.AccessedBuckets {
+			if reference.BucketName == "" || reference.BucketID == "" {
+				continue
+			}
+			bucket := &cosiv1alpha2.Bucket{}
+			if err := r.Get(ctx, types.NamespacedName{Name: reference.BucketName}, bucket); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return "", err
+			}
+			if bucket.Status.BucketID != reference.BucketID ||
+				bucket.Spec.DriverName != r.DriverName ||
+				bucket.Spec.BucketClaimRef.Namespace != access.Namespace ||
+				bucket.Spec.BucketClaimRef.Name != reference.BucketClaimName {
+				continue
+			}
+			if bucketNeedsAccessPreserved(bucket) && ctrlutil.ContainsFinalizer(bucket, GarageProtectionFinalizer) {
+				return bucket.Name, nil
+			}
+		}
+		return "", nil
+	}
+
+	for _, reference := range access.Spec.BucketClaims {
+		claim := &cosiv1alpha2.BucketClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: reference.BucketClaimName, Namespace: access.Namespace}, claim); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", err
+		}
+		if claim.Status.BoundBucketName == "" {
+			continue
+		}
+		bucket := &cosiv1alpha2.Bucket{}
+		if err := r.Get(ctx, types.NamespacedName{Name: claim.Status.BoundBucketName}, bucket); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", err
+		}
+		if bucket.Status.BucketID == "" || bucket.Spec.DriverName != r.DriverName ||
+			bucket.Spec.BucketClaimRef.Namespace != claim.Namespace ||
+			bucket.Spec.BucketClaimRef.Name != claim.Name ||
+			(bucket.Spec.BucketClaimRef.UID != "" && bucket.Spec.BucketClaimRef.UID != claim.UID) {
+			continue
+		}
+		if bucketNeedsAccessPreserved(bucket) && ctrlutil.ContainsFinalizer(bucket, GarageProtectionFinalizer) {
+			return bucket.Name, nil
+		}
+	}
+	return "", nil
+}
+
+func bucketNeedsAccessPreserved(bucket *cosiv1alpha2.Bucket) bool {
+	if bucket.Spec.DeletionPolicy == cosiv1alpha2.BucketDeletionPolicyRetain {
+		return false
+	}
+	_, claimBeingDeleted := bucket.Annotations[cosiv1alpha2.BucketClaimBeingDeletedAnnotation]
+	return !bucket.GetDeletionTimestamp().IsZero() || claimBeingDeleted
+}
+
+func (r *BucketAccessReconciler) deferAccessRevocation(ctx context.Context, access *cosiv1alpha2.BucketAccess, bucketName string) (reconcile.Result, error) {
+	retryCount, err := recordFinalizationRetry(ctx, r.Client, access)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("record blocked BucketAccess cleanup retry: %w", err)
+	}
+	message := fmt.Sprintf(
+		"BucketAccess deletion is waiting for Bucket %q: its Garage bucket is not empty. "+
+			"remove all objects and incomplete multipart uploads using this access, then cleanup will continue. "+
+			"The operator never empties bucket contents automatically.",
+		bucketName,
+	)
+	apply := func() {
+		access.Status.ReadyToUse = ptr.To(false)
+		access.Status.Error = cosiv1alpha2.NewTimestampedError(time.Now(), message)
+	}
+	apply()
+	if err := garagecontroller.UpdateStatusWithRetry(ctx, r.Client, access, apply); err != nil {
+		return reconcile.Result{}, fmt.Errorf("record blocked BucketAccess status: %w", err)
+	}
+	return reconcile.Result{RequeueAfter: garagecontroller.FinalizationRetryDelay(retryCount)}, nil
 }
 
 // reserveSecret creates an empty owner-ref'd Secret. If a Secret of that name

--- a/internal/cosi/fake_client_test.go
+++ b/internal/cosi/fake_client_test.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	cosiv1alpha2 "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
+
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 )
 
@@ -15,7 +17,10 @@ import (
 // status-subresource behavior that COSI's reservation protocol relies on.
 func newCOSIClientBuilder() *fake.ClientBuilder {
 	return fake.NewClientBuilder().
-		WithStatusSubresource(&garagev1beta1.GarageBucket{}, &garagev1beta1.GarageKey{}).
+		WithStatusSubresource(
+			&garagev1beta1.GarageBucket{}, &garagev1beta1.GarageKey{},
+			&cosiv1alpha2.Bucket{}, &cosiv1alpha2.BucketAccess{},
+		).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if obj.GetUID() == "" {

--- a/internal/cosi/finalizer.go
+++ b/internal/cosi/finalizer.go
@@ -16,8 +16,49 @@ limitations under the License.
 
 package cosi
 
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	garagecontroller "github.com/rajsinghtech/garage-operator/internal/controller"
+)
+
 // GarageProtectionFinalizer is independent from COSI's shared protection
 // finalizer. The upstream controller may remove its finalizer as soon as its
 // bookkeeping is complete; this one keeps the object alive until Garage-side
 // cleanup has completed.
 const GarageProtectionFinalizer = "garage.rajsingh.info/cosi-protection"
+
+// recordFinalizationRetry persists the bounded-retry counter shared by the
+// native and COSI cleanup paths. Callers must handle a NotFound error as a
+// completed deletion race.
+func recordFinalizationRetry(ctx context.Context, c client.Client, object client.Object) (int, error) {
+	originalUID := object.GetUID()
+	for attempt := 0; attempt < garagecontroller.StatusUpdateMaxRetries; attempt++ {
+		base, ok := object.DeepCopyObject().(client.Object)
+		if !ok {
+			return 0, fmt.Errorf("cannot snapshot finalization retry for %T", object)
+		}
+		garagecontroller.IncrementFinalizationRetryCount(object)
+		count := garagecontroller.GetFinalizationRetryCount(object)
+		if err := c.Patch(ctx, object, client.MergeFrom(base)); err == nil {
+			return count, nil
+		} else if !apierrors.IsConflict(err) {
+			return count, err
+		}
+
+		if attempt == garagecontroller.StatusUpdateMaxRetries-1 {
+			return count, fmt.Errorf("failed to update finalization retry after %d conflicts", garagecontroller.StatusUpdateMaxRetries)
+		}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(object), object); err != nil {
+			return count, fmt.Errorf("re-fetch finalization object after conflict: %w", err)
+		}
+		if originalUID != "" && object.GetUID() != originalUID {
+			return count, fmt.Errorf("refusing to retry finalization counter across object recreation: UID changed from %q to %q", originalUID, object.GetUID())
+		}
+	}
+	return 0, fmt.Errorf("finalization retry update exhausted for %T", object)
+}

--- a/internal/cosi/validation_test.go
+++ b/internal/cosi/validation_test.go
@@ -26,12 +26,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	cosiv1alpha2 "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
 	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+	garagecontroller "github.com/rajsinghtech/garage-operator/internal/controller"
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
@@ -245,6 +247,178 @@ func TestNamespaceScopedBucketReconcilerCleansPreviouslyOwnedOutOfScopeBuckets(t
 			require.False(t, freshShadow.DeletionTimestamp.IsZero(), "Retain cleanup must start forgetting the owned shadow")
 		})
 	}
+}
+
+func TestBucketReconcilerNonEmptyDeletionSurfacesStatusAndBacksOff(t *testing.T) {
+	now := metav1.Now()
+	bucket := &cosiv1alpha2.Bucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-empty-bucket", Finalizers: []string{cosiv1alpha2.ProtectionFinalizer, GarageProtectionFinalizer},
+			DeletionTimestamp: &now,
+			Annotations:       map[string]string{garagecontroller.FinalizationRetryAnnotation: "1"},
+		},
+		Spec: cosiv1alpha2.BucketSpec{
+			DriverName:     cosiTestDriver,
+			DeletionPolicy: cosiv1alpha2.BucketDeletionPolicyDelete,
+			Parameters: map[string]string{
+				paramClusterRef:       testMyCluster,
+				paramClusterNamespace: testGarageSystem,
+			},
+		},
+		Status: cosiv1alpha2.BucketStatus{BucketID: testBucketID},
+	}
+	cluster := createReadyCluster()
+	kubeClient := newCOSIClientBuilder().WithScheme(newTestScheme()).WithObjects(bucket, cluster).Build()
+	mockClient := newMockGarageClient()
+	mockClient.deleteBucketErr = &garage.APIError{StatusCode: 409, Message: "BucketNotEmpty"}
+	provisioner := NewProvisionerWithFactory(kubeClient, testGarageSystem,
+		func(context.Context, client.Client, *garagev1beta2.GarageCluster) (GarageClient, error) {
+			return mockClient, nil
+		})
+	reconciler := &BucketReconciler{
+		Client: kubeClient, Scheme: kubeClient.Scheme(), DriverName: cosiTestDriver,
+		Namespace: testGarageSystem, Provisioner: provisioner,
+	}
+
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(bucket)})
+	require.NoError(t, err)
+	require.Equal(t, garagecontroller.FinalizationRetryDelay(2), result.RequeueAfter)
+	require.Equal(t, []string{testBucketID}, mockClient.deleteBucketCalls)
+
+	fresh := &cosiv1alpha2.Bucket{}
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(bucket), fresh))
+	require.Equal(t, "2", fresh.Annotations[garagecontroller.FinalizationRetryAnnotation])
+	require.Contains(t, fresh.Finalizers, GarageProtectionFinalizer)
+	require.NotNil(t, fresh.Status.ReadyToUse)
+	require.False(t, *fresh.Status.ReadyToUse)
+	require.NotNil(t, fresh.Status.Error)
+	require.NotNil(t, fresh.Status.Error.Message)
+	require.Contains(t, *fresh.Status.Error.Message, "remove all objects")
+	require.Contains(t, *fresh.Status.Error.Message, "never empties")
+}
+
+func TestBucketAccessDeletionRetainsAccessUntilBucketCleanupFinishes(t *testing.T) {
+	const (
+		accessName = "cleanup-access"
+		bucketName = "cleanup-bucket"
+		accountID  = "GKcleanup"
+	)
+	now := metav1.Now()
+	bucket := &cosiv1alpha2.Bucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       bucketName,
+			Finalizers: []string{GarageProtectionFinalizer},
+			Annotations: map[string]string{
+				// COSI intentionally uses an empty annotation value. Presence,
+				// rather than a non-empty value, is the deletion signal.
+				cosiv1alpha2.BucketClaimBeingDeletedAnnotation: "",
+			},
+		},
+		Spec: cosiv1alpha2.BucketSpec{
+			DriverName:     cosiTestDriver,
+			DeletionPolicy: cosiv1alpha2.BucketDeletionPolicyDelete,
+			BucketClaimRef: cosiv1alpha2.BucketClaimReference{Name: "claim", Namespace: "tenant"},
+		},
+		Status: cosiv1alpha2.BucketStatus{BucketID: testBucketID},
+	}
+	access := &cosiv1alpha2.BucketAccess{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: accessName, Namespace: "tenant", UID: "cleanup-access-uid",
+			Finalizers:        []string{GarageProtectionFinalizer},
+			DeletionTimestamp: &now,
+			Annotations:       map[string]string{garagecontroller.FinalizationRetryAnnotation: "1"},
+		},
+		Status: cosiv1alpha2.BucketAccessStatus{
+			ReadyToUse: ptr.To(true), DriverName: cosiTestDriver, AccountID: accountID,
+			AccessedBuckets: []cosiv1alpha2.AccessedBucket{{
+				BucketName: bucketName, BucketID: testBucketID, BucketClaimName: "claim",
+			}},
+			Parameters: map[string]string{
+				paramClusterRef:       testMyCluster,
+				paramClusterNamespace: testGarageSystem,
+			},
+		},
+	}
+	cluster := createReadyCluster()
+	kubeClient := newCOSIClientBuilder().WithScheme(newTestScheme()).WithObjects(bucket, access, cluster).Build()
+	mockClient := newMockGarageClient()
+	mockClient.keys[accountID] = &garage.Key{AccessKeyID: accountID}
+	provisioner := NewProvisionerWithFactory(kubeClient, testGarageSystem,
+		func(context.Context, client.Client, *garagev1beta2.GarageCluster) (GarageClient, error) {
+			return mockClient, nil
+		})
+	reconciler := &BucketAccessReconciler{
+		Client: kubeClient, Scheme: kubeClient.Scheme(), DriverName: cosiTestDriver,
+		Namespace: testGarageSystem, Provisioner: provisioner,
+	}
+
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(access)})
+	require.NoError(t, err)
+	require.Equal(t, garagecontroller.FinalizationRetryDelay(2), result.RequeueAfter)
+	require.Empty(t, mockClient.deleteKeyCalls)
+	require.Empty(t, mockClient.denyBucketKeyCalls)
+
+	fresh := &cosiv1alpha2.BucketAccess{}
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(access), fresh))
+	require.Contains(t, fresh.Finalizers, GarageProtectionFinalizer)
+	require.Equal(t, "2", fresh.Annotations[garagecontroller.FinalizationRetryAnnotation])
+	require.NotNil(t, fresh.Status.ReadyToUse)
+	require.False(t, *fresh.Status.ReadyToUse)
+	require.NotNil(t, fresh.Status.Error)
+	require.NotNil(t, fresh.Status.Error.Message)
+	require.Contains(t, *fresh.Status.Error.Message, "remove all objects")
+	require.Contains(t, *fresh.Status.Error.Message, bucketName)
+}
+
+func TestBucketAccessDeletionRevokesAfterBucketCleanupFinalizerIsGone(t *testing.T) {
+	const (
+		accessName = "released-access"
+		bucketName = "released-bucket"
+		accountID  = "GKreleased"
+	)
+	now := metav1.Now()
+	bucket := &cosiv1alpha2.Bucket{
+		ObjectMeta: metav1.ObjectMeta{Name: bucketName, Finalizers: []string{"example.test/finished"}, DeletionTimestamp: &now},
+		Spec: cosiv1alpha2.BucketSpec{
+			DriverName:     cosiTestDriver,
+			DeletionPolicy: cosiv1alpha2.BucketDeletionPolicyDelete,
+			BucketClaimRef: cosiv1alpha2.BucketClaimReference{Name: "claim", Namespace: "tenant"},
+		},
+		Status: cosiv1alpha2.BucketStatus{BucketID: testBucketID},
+	}
+	access := &cosiv1alpha2.BucketAccess{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: accessName, Namespace: "tenant", UID: "released-access-uid",
+			Finalizers: []string{GarageProtectionFinalizer}, DeletionTimestamp: &now,
+		},
+		Status: cosiv1alpha2.BucketAccessStatus{
+			ReadyToUse: ptr.To(false), DriverName: cosiTestDriver, AccountID: accountID,
+			AccessedBuckets: []cosiv1alpha2.AccessedBucket{{
+				BucketName: bucketName, BucketID: testBucketID, BucketClaimName: "claim",
+			}},
+			Parameters: map[string]string{
+				paramClusterRef:       testMyCluster,
+				paramClusterNamespace: testGarageSystem,
+			},
+		},
+	}
+	cluster := createReadyCluster()
+	kubeClient := newCOSIClientBuilder().WithScheme(newTestScheme()).WithObjects(bucket, access, cluster).Build()
+	mockClient := newMockGarageClient()
+	mockClient.keys[accountID] = &garage.Key{AccessKeyID: accountID}
+	mockClient.buckets[testBucketID] = &garage.Bucket{ID: testBucketID}
+	provisioner := NewProvisionerWithFactory(kubeClient, testGarageSystem,
+		func(context.Context, client.Client, *garagev1beta2.GarageCluster) (GarageClient, error) {
+			return mockClient, nil
+		})
+	reconciler := &BucketAccessReconciler{
+		Client: kubeClient, Scheme: kubeClient.Scheme(), DriverName: cosiTestDriver,
+		Namespace: testGarageSystem, Provisioner: provisioner,
+	}
+
+	_, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(access)})
+	require.NoError(t, err)
+	require.Equal(t, []string{accountID}, mockClient.deleteKeyCalls)
 }
 
 func TestBucketAccessClusterPreflightRejectsMixedClustersBeforeMutation(t *testing.T) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
           - Node-local pools: design/2026-07-30-node-local-pools-design.md
           - AWS shared credentials file: design/2026-08-14-aws-shared-credentials-file-design.md
           - GarageBucket deletion policy: design/2026-08-22-garagebucket-deletion-policy-design.md
+          - Safe bucket deletion: design/2026-09-02-safe-bucket-deletion-design.md
       - Releases: https://github.com/rajsinghtech/garage-operator/releases
 
 validation:


### PR DESCRIPTION
## Summary

Fixes #359
Fixes #353

Make non-empty bucket deletion visible and safely recoverable on both the native
`GarageBucket` and COSI `Bucket` paths.

Garage rejects `DeleteBucket` with `BucketNotEmpty` when objects or incomplete
multipart uploads remain. The native controller previously retained its
finalizer and retried, but exposed only the log message. The COSI controller
returned the raw reconciliation error. In both cases the resource could remain
terminating without a durable, actionable status surface.

## Design decision

This keeps the existing `Delete` and `Retain` semantics and never empties a
bucket automatically. Automatic purging would turn an ordinary Kubernetes
delete into irreversible data loss, require elevated object-deletion
credentials, and provide no recovery window. COSI owns its `Delete`/`Retain`
enum, so adding a driver-specific `Purge` value would not be portable.

When Garage reports `BucketNotEmpty`:

- Native `GarageBucket` retains its finalizer, sets
  `DeletionBlocked=True` with reason `BucketNotEmpty`, sets `Ready=False`, and
  retries with persisted bounded exponential backoff (30 seconds to five
  minutes).
- COSI `Bucket` retains the Garage cleanup finalizer, sets
  `status.readyToUse=false`, records an actionable `status.error`, and uses the
  same backoff.
- A deleting COSI `BucketAccess` retains its Garage key and generated Secret
  while the exact matching `Delete` bucket is still behind the Garage cleanup
  finalizer. This lets the user's cleanup controller or administrator empty
  the bucket. Access is revoked normally after bucket cleanup finishes; access
  deletion for a `Retain` bucket or an unrelated bucket is unchanged.

The operator never lists, deletes, or purges bucket content. Users must remove
objects and incomplete multipart uploads explicitly, or switch the terminating
resource to `deletionPolicy: Retain` when the data must remain.

## Compatibility and API impact

- Empty buckets still delete as before.
- Existing non-empty buckets remain protected rather than being deleted.
- Existing native defaulting (`Delete`) is unchanged.
- Normal COSI access revocation is unchanged except for the narrow cleanup
  handoff needed to preserve a credential for a concurrently deleting,
  `Delete`-policy bucket.
- No CRD schema, served API version, conversion, generated artifact, chart
  version, appVersion, or image tag changes are needed.
- #360 (unrelated cross-namespace key denial) is intentionally not bundled.

The release risk is limited and data-safe: the main behavioral change is that
non-empty deletion is now observable/backed off, and a matching COSI access can
remain active until the protected bucket cleanup completes. The latter is
documented as an explicit cleanup handoff and is bounded by the bucket's
finalizer, not by an implicit purge.

## Tests

Regression coverage includes native finalization/status/backoff, COSI Bucket
status/error/backoff, COSI BucketAccess retention and post-cleanup revocation,
empty annotation handling, finalizer handoff, and existing deletion behavior.

The pre-fix native regression fails with no `DeletionBlocked` condition; the
pre-fix COSI regression returns `bucket not empty: API error ...` instead of a
status-driven retry.

Validation run locally:

- `go mod tidy -diff`
- `go build ./...`
- `make test`
- `make test-race`
- `make lint` (0 issues)
- `make verify-generate`
- `make validate-manifests` (44 resources valid)
- `make helm-verify-crd-bases`
- Helm lint and template
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `mkdocs build --strict --site-dir /tmp/garage-operator-site`

No files in the release-version fields were changed. The related upstream
issues #359 and #353 are addressed here; #360 remains separate.
