### PR TITLE
fix: isolate denied reverse references from GarageKeys

### DIFF
--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"net/url"
 	"sort"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -730,6 +730,7 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 	explicitlyManaged := make(map[string]struct{})
 	unauthorizedTargets := make(map[string]struct{})
 	var permissionErrors []string
+	var permissionDenials []string
 	if key.Spec.AllBuckets != nil {
 		buckets, err := garageClient.ListBuckets(ctx)
 		if err != nil {
@@ -777,7 +778,6 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 	sort.Strings(keyManaged)
 	reservedManaged := mergeManagedGrantIDs(key.Status.ManagedBucketGrants, keyManaged)
 	reservedClusterWide := key.Status.ClusterWide || key.Spec.AllBuckets != nil
-	var permissionDenials []string
 
 	desired := make(map[string]garage.BucketKeyPerms, len(keyDesired))
 	targets := make(map[string]struct{})
@@ -846,10 +846,12 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 	// result, not a failure to reconcile this key. Record it before reserving
 	// ownership so the warning survives a crash before the first remote
 	// permission mutation. Explicit key-owned declarations remain fatal above.
+	permissionConditionChanged := false
 	if len(permissionDenials) > 0 {
-		setKeyPermissionsCondition(key, permissionDenials)
+		permissionConditionChanged = setKeyPermissionsCondition(key, permissionDenials)
 	}
-	if !stringSlicesEqual(key.Status.ManagedBucketGrants, reservedManaged) || key.Status.ClusterWide != reservedClusterWide || len(permissionDenials) > 0 {
+	reservationChanged := !stringSlicesEqual(key.Status.ManagedBucketGrants, reservedManaged) || key.Status.ClusterWide != reservedClusterWide
+	if reservationChanged || permissionConditionChanged {
 		key.Status.ManagedBucketGrants = reservedManaged
 		key.Status.ClusterWide = reservedClusterWide
 		if err := r.Status().Update(ctx, key); err != nil {
@@ -868,12 +870,12 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 		}
 		return fmt.Errorf("failed to reconcile bucket permissions: %v", permissionErrors)
 	}
-	setKeyPermissionsCondition(key, permissionDenials)
+	permissionConditionChanged = setKeyPermissionsCondition(key, permissionDenials)
 
 	// allBuckets ownership is represented compactly by status.clusterWide;
 	// recording every Garage bucket ID here would make status grow without bound.
 	desiredClusterWide := key.Spec.AllBuckets != nil
-	if !stringSlicesEqual(key.Status.ManagedBucketGrants, keyManaged) || key.Status.ClusterWide != desiredClusterWide {
+	if !stringSlicesEqual(key.Status.ManagedBucketGrants, keyManaged) || key.Status.ClusterWide != desiredClusterWide || permissionConditionChanged {
 		key.Status.ManagedBucketGrants = keyManaged
 		key.Status.ClusterWide = desiredClusterWide
 		if err := r.Status().Update(ctx, key); err != nil {
@@ -883,7 +885,8 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 	return nil
 }
 
-func setKeyPermissionsCondition(key *garagev1beta1.GarageKey, denied []string) {
+func setKeyPermissionsCondition(key *garagev1beta1.GarageKey, denied []string) bool {
+	previous := append([]metav1.Condition(nil), key.Status.Conditions...)
 	condition := metav1.Condition{
 		Type:               garagev1beta1.ConditionPermissionsConfigured,
 		Status:             metav1.ConditionTrue,
@@ -899,6 +902,7 @@ func setKeyPermissionsCondition(key *garagev1beta1.GarageKey, denied []string) {
 		condition.Message = "Some bucket permission references were denied: " + strings.Join(details, "; ")
 	}
 	meta.SetStatusCondition(&key.Status.Conditions, condition)
+	return !apiequality.Semantic.DeepEqual(previous, key.Status.Conditions)
 }
 
 func setKeyPermissionsReconcileFailure(key *garagev1beta1.GarageKey, failures []string) {

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -776,13 +776,7 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 	sort.Strings(keyManaged)
 	reservedManaged := mergeManagedGrantIDs(key.Status.ManagedBucketGrants, keyManaged)
 	reservedClusterWide := key.Status.ClusterWide || key.Spec.AllBuckets != nil
-	if !stringSlicesEqual(key.Status.ManagedBucketGrants, reservedManaged) || key.Status.ClusterWide != reservedClusterWide {
-		key.Status.ManagedBucketGrants = reservedManaged
-		key.Status.ClusterWide = reservedClusterWide
-		if err := r.Status().Update(ctx, key); err != nil {
-			return fmt.Errorf("failed to reserve managed bucket grants: %w", err)
-		}
-	}
+	var permissionDenials []string
 
 	desired := make(map[string]garage.BucketKeyPerms, len(keyDesired))
 	targets := make(map[string]struct{})
@@ -790,7 +784,7 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 		desired[id] = p
 		targets[id] = struct{}{}
 	}
-	for _, id := range key.Status.ManagedBucketGrants {
+	for _, id := range reservedManaged {
 		targets[id] = struct{}{}
 	}
 	for id := range unauthorizedTargets {
@@ -828,7 +822,12 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 		if p, ok := bucketPermissionsForKey(bucket, key); ok {
 			if err := garagev1beta1.CheckReferenceGrant(ctx, r.authorizationReader(), "GarageBucket", bucket.Namespace,
 				garageKeyKind, key.Namespace, key.Name); err != nil {
-				permissionErrors = append(permissionErrors, fmt.Sprintf("GarageBucket %s/%s: %v", bucket.Namespace, bucket.Name, err))
+				detail := fmt.Sprintf("GarageBucket %s/%s: %v", bucket.Namespace, bucket.Name, err)
+				if garagev1beta1.IsReferenceGrantDenied(err) {
+					permissionDenials = append(permissionDenials, detail)
+				} else {
+					permissionErrors = append(permissionErrors, detail)
+				}
 				continue
 			}
 			// The GarageBucket controller owns this declaration's durable
@@ -842,14 +841,33 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 		}
 	}
 
+	// A denied reverse cross-namespace reference is a per-key authorization
+	// result, not a failure to reconcile this key. Record it before reserving
+	// ownership so the warning survives a crash before the first remote
+	// permission mutation. Explicit key-owned declarations remain fatal above.
+	if len(permissionDenials) > 0 {
+		setKeyPermissionsCondition(key, permissionDenials)
+	}
+	if !stringSlicesEqual(key.Status.ManagedBucketGrants, reservedManaged) || key.Status.ClusterWide != reservedClusterWide || len(permissionDenials) > 0 {
+		key.Status.ManagedBucketGrants = reservedManaged
+		key.Status.ClusterWide = reservedClusterWide
+		if err := r.Status().Update(ctx, key); err != nil {
+			return fmt.Errorf("failed to reserve managed bucket grants: %w", err)
+		}
+	}
+
 	for bucketID := range targets {
 		if err := reconcileExactBucketKeyPermissions(ctx, garageClient, bucketID, garageKey.AccessKeyID, current[bucketID], desired[bucketID]); err != nil {
 			permissionErrors = append(permissionErrors, fmt.Sprintf("%s: %v", bucketID, err))
 		}
 	}
 	if len(permissionErrors) > 0 {
+		if len(permissionDenials) == 0 {
+			setKeyPermissionsReconcileFailure(key, permissionErrors)
+		}
 		return fmt.Errorf("failed to reconcile bucket permissions: %v", permissionErrors)
 	}
+	setKeyPermissionsCondition(key, permissionDenials)
 
 	// allBuckets ownership is represented compactly by status.clusterWide;
 	// recording every Garage bucket ID here would make status grow without bound.
@@ -862,6 +880,36 @@ func (r *GarageKeyReconciler) reconcileManagedBucketPermissions(ctx context.Cont
 		}
 	}
 	return nil
+}
+
+func setKeyPermissionsCondition(key *garagev1beta1.GarageKey, denied []string) {
+	condition := metav1.Condition{
+		Type:               garagev1beta1.ConditionPermissionsConfigured,
+		Status:             metav1.ConditionTrue,
+		Reason:             garagev1beta1.ReasonReconcileSuccess,
+		Message:            "All declared bucket permissions are configured",
+		ObservedGeneration: key.Generation,
+	}
+	if len(denied) > 0 {
+		details := append([]string(nil), denied...)
+		sort.Strings(details)
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = garagev1beta1.ReasonReferenceGrantDenied
+		condition.Message = "Some bucket permission references were denied: " + strings.Join(details, "; ")
+	}
+	meta.SetStatusCondition(&key.Status.Conditions, condition)
+}
+
+func setKeyPermissionsReconcileFailure(key *garagev1beta1.GarageKey, failures []string) {
+	details := append([]string(nil), failures...)
+	sort.Strings(details)
+	meta.SetStatusCondition(&key.Status.Conditions, metav1.Condition{
+		Type:               garagev1beta1.ConditionPermissionsConfigured,
+		Status:             metav1.ConditionFalse,
+		Reason:             garagev1beta1.ReasonReconcileFailed,
+		Message:            "Bucket permissions could not be configured: " + strings.Join(details, "; "),
+		ObservedGeneration: key.Generation,
+	})
 }
 
 func bucketPermissionsForKey(bucket *garagev1beta1.GarageBucket, key *garagev1beta1.GarageKey) (garage.BucketKeyPerms, bool) {

--- a/internal/controller/referencegrant_runtime_test.go
+++ b/internal/controller/referencegrant_runtime_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -64,6 +65,18 @@ func runtimeClusterGrant(fromKind, fromNamespace, targetNamespace, clusterName s
 			To:   []garagev1beta1.ReferenceGrantTo{{Kind: "GarageCluster", Name: clusterName}},
 		},
 	}
+}
+
+type errorReferenceGrantReader struct {
+	client.Reader
+	err error
+}
+
+func (r errorReferenceGrantReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, ok := list.(*garagev1beta1.GarageReferenceGrantList); ok {
+		return r.err
+	}
+	return r.Reader.List(ctx, list, opts...)
 }
 
 func TestRuntimeSpecValidationFailsBeforeGarageMutation(t *testing.T) {
@@ -383,6 +396,193 @@ func TestGarageBucketReconcileSkipsDeniedCrossNamespaceKey(t *testing.T) {
 	}
 	if !stringSliceContains(fresh.Status.ManagedKeyGrants, allowedKeyID) {
 		t.Fatalf("ManagedKeyGrants = %v, want grantable key %q", fresh.Status.ManagedKeyGrants, allowedKeyID)
+	}
+}
+
+func TestGarageKeyReconcileSkipsDeniedCrossNamespaceBucket(t *testing.T) {
+	const (
+		keyNamespace     = "keys"
+		bucketNamespace  = "buckets"
+		clusterNamespace = "storage"
+		clusterName      = "garage"
+		ownBucketID      = "owned-bucket-id"
+		foreignBucketID  = "foreign-bucket-id"
+		keyID            = "GKowned"
+	)
+	scheme := runtimeGrantScheme(t)
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "key", Namespace: keyNamespace},
+		Spec: garagev1beta1.GarageKeySpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName, Namespace: clusterNamespace},
+			BucketPermissions: []garagev1beta1.BucketPermission{{
+				BucketID: ownBucketID, Read: true,
+			}},
+		},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: keyID},
+	}
+	foreign := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign-bucket", Namespace: bucketNamespace},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName, Namespace: clusterNamespace},
+			KeyPermissions: []garagev1beta1.KeyPermission{{
+				KeyRef: garagev1beta1.KeyRef{Name: key.Name, Namespace: key.Namespace},
+				Write:  true,
+			}},
+		},
+		Status: garagev1beta1.GarageBucketStatus{BucketID: foreignBucketID},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(key, foreign).
+		WithStatusSubresource(&garagev1beta1.GarageKey{}).Build()
+	var allows []garage.AllowBucketKeyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != testAllowBucketKeyPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var allow garage.AllowBucketKeyRequest
+		if err := json.NewDecoder(request.Body).Decode(&allow); err != nil {
+			t.Errorf("decode AllowBucketKey request: %v", err)
+		}
+		allows = append(allows, allow)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	r := &GarageKeyReconciler{Client: c, Scheme: scheme}
+	if err := r.reconcileManagedBucketPermissions(t.Context(), key, garage.NewClient(server.URL, "token"),
+		&garage.Key{AccessKeyID: keyID}); err != nil {
+		t.Fatalf("reconcileManagedBucketPermissions: %v", err)
+	}
+	if len(allows) != 1 || allows[0].AccessKeyID != keyID || allows[0].BucketID != ownBucketID ||
+		allows[0].Permissions != (garage.BucketKeyPerms{Read: true}) {
+		t.Fatalf("AllowBucketKey calls = %+v, want only the key's own permission", allows)
+	}
+
+	fresh := &garagev1beta1.GarageKey{}
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(key), fresh); err != nil {
+		t.Fatalf("get key: %v", err)
+	}
+	condition := meta.FindStatusCondition(fresh.Status.Conditions, garagev1beta1.ConditionPermissionsConfigured)
+	if condition == nil {
+		t.Fatalf("missing permission condition: %+v", fresh.Status.Conditions)
+	}
+	if condition.Status != metav1.ConditionFalse || condition.Reason != garagev1beta1.ReasonReferenceGrantDenied {
+		t.Fatalf("permission condition = %+v, want False/%s", condition, garagev1beta1.ReasonReferenceGrantDenied)
+	}
+	if !strings.Contains(condition.Message, bucketNamespace+"/foreign-bucket") ||
+		!strings.Contains(condition.Message, "GarageReferenceGrant") {
+		t.Fatalf("permission condition message = %q, want denied bucket and grant guidance", condition.Message)
+	}
+	if len(fresh.Status.ManagedBucketGrants) != 1 || fresh.Status.ManagedBucketGrants[0] != ownBucketID {
+		t.Fatalf("ManagedBucketGrants = %v, want key-owned bucket %q", fresh.Status.ManagedBucketGrants, ownBucketID)
+	}
+}
+
+func TestGarageKeyReconcileKeepsExplicitBucketDenialFatal(t *testing.T) {
+	const (
+		keyNamespace    = "keys"
+		bucketNamespace = "storage"
+		clusterName     = "garage"
+		bucketID        = "explicit-bucket-id"
+		keyID           = "GKexplicit"
+	)
+	scheme := runtimeGrantScheme(t)
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "key", Namespace: keyNamespace},
+		Spec: garagev1beta1.GarageKeySpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName, Namespace: bucketNamespace},
+			BucketPermissions: []garagev1beta1.BucketPermission{{
+				BucketRef: &garagev1beta1.BucketRef{Name: "bucket", Namespace: bucketNamespace},
+				Read:      true,
+			}},
+		},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: keyID},
+	}
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "bucket", Namespace: bucketNamespace},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+		},
+		Status: garagev1beta1.GarageBucketStatus{BucketID: bucketID},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(key, bucket).
+		WithStatusSubresource(&garagev1beta1.GarageKey{}).Build()
+	var denies []garage.DenyBucketKeyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != testDenyBucketKeyPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var deny garage.DenyBucketKeyRequest
+		if err := json.NewDecoder(request.Body).Decode(&deny); err != nil {
+			t.Errorf("decode DenyBucketKey request: %v", err)
+		}
+		denies = append(denies, deny)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	r := &GarageKeyReconciler{Client: c, Scheme: scheme}
+	err := r.reconcileManagedBucketPermissions(t.Context(), key, garage.NewClient(server.URL, "token"),
+		&garage.Key{AccessKeyID: keyID, Buckets: []garage.KeyBucket{{
+			ID: bucketID, Permissions: garage.BucketKeyPerms{Read: true},
+		}}})
+	if err == nil || !strings.Contains(err.Error(), "GarageReferenceGrant") {
+		t.Fatalf("error = %v, want explicit key-owned reference denial", err)
+	}
+	if len(denies) != 1 || denies[0].BucketID != bucketID || denies[0].AccessKeyID != keyID ||
+		!denies[0].Permissions.Read {
+		t.Fatalf("DenyBucketKey calls = %+v, want exact cleanup of the denied explicit target", denies)
+	}
+	condition := meta.FindStatusCondition(key.Status.Conditions, garagev1beta1.ConditionPermissionsConfigured)
+	if condition == nil || condition.Reason != garagev1beta1.ReasonReconcileFailed {
+		t.Fatalf("permission condition = %+v, want ReconcileFailed", condition)
+	}
+}
+
+func TestGarageKeyReconcileKeepsReferenceGrantReadErrorsFatal(t *testing.T) {
+	const (
+		keyNamespace     = "keys"
+		bucketNamespace  = "buckets"
+		clusterNamespace = "storage"
+		clusterName      = "garage"
+		keyID            = "GKgrant-error"
+	)
+	scheme := runtimeGrantScheme(t)
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "key", Namespace: keyNamespace},
+		Spec: garagev1beta1.GarageKeySpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName, Namespace: clusterNamespace},
+		},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: keyID},
+	}
+	bucket := &garagev1beta1.GarageBucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign-bucket", Namespace: bucketNamespace},
+		Spec: garagev1beta1.GarageBucketSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: clusterName, Namespace: clusterNamespace},
+			KeyPermissions: []garagev1beta1.KeyPermission{{
+				KeyRef: garagev1beta1.KeyRef{Name: key.Name, Namespace: key.Namespace},
+				Read:   true,
+			}},
+		},
+		Status: garagev1beta1.GarageBucketStatus{BucketID: "foreign-bucket-id"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(key, bucket).
+		WithStatusSubresource(&garagev1beta1.GarageKey{}).Build()
+	r := &GarageKeyReconciler{
+		Client:              c,
+		AuthorizationReader: errorReferenceGrantReader{Reader: c, err: stderrors.New("injected grant list failure")},
+		Scheme:              scheme,
+	}
+
+	err := r.reconcileManagedBucketPermissions(t.Context(), key, garage.NewClient("http://127.0.0.1:1", "token"),
+		&garage.Key{AccessKeyID: keyID})
+	if err == nil || !strings.Contains(err.Error(), "failed to list GarageReferenceGrants") {
+		t.Fatalf("error = %v, want fatal grant-evaluation error", err)
+	}
+	condition := meta.FindStatusCondition(key.Status.Conditions, garagev1beta1.ConditionPermissionsConfigured)
+	if condition == nil || condition.Reason != garagev1beta1.ReasonReconcileFailed {
+		t.Fatalf("permission condition = %+v, want ReconcileFailed", condition)
 	}
 }
 


### PR DESCRIPTION
## Summary

Treat an unauthorized cross-namespace `GarageBucket -> GarageKey` reverse
reference as a per-key authorization result instead of failing the referenced
GarageKey. The key's own bucket permissions continue to reconcile, and the
skipped reverse reference is surfaced in `PermissionsConfigured=False` with
reason `ReferenceGrantDenied`.

Grant read/evaluation errors and explicit `spec.bucketPermissions` denials
remain fatal.

## Related issue or design

Fixes #366. Mirrors the behavior merged for #360 in #365
(commit `14e93635`).

## Compatibility and operational impact

No CRD schema or API-version changes. This changes only reconciliation of new
or existing objects with denied reverse references: the referenced key remains
healthy, while the declaring bucket's authorization result remains visible.

## Validation

Completed successfully:

- `CGO_ENABLED=0 go test ./internal/controller -run 'TestGarageKeyReconcile(SkipsDeniedCrossNamespaceBucket|KeepsExplicitBucketDenialFatal|KeepsReferenceGrantReadErrorsFatal)$' -count=1 -timeout 900s`
- `CGO_ENABLED=0 GOFLAGS=-timeout=900s make test`
  (all non-E2E packages; controller 120.5s)
- `CGO_ENABLED=1 GOFLAGS=-timeout=900s make test-race`
  (all non-E2E packages; controller 108.7s)
- `CGO_ENABLED=0 make lint` (0 issues)
- `CGO_ENABLED=0 make verify-generate` (generated files in sync)
- `CGO_ENABLED=0 go mod tidy -diff` (clean)
- `gofmt` and `git diff --check`

The exact `CGO_ENABLED=0 make test-race` invocation was also attempted and
cannot run because Go reports `-race requires cgo; enable cgo by setting
CGO_ENABLED=1`. The completed cgo-enabled race run is the required race
coverage; all ordinary tests and builds use `CGO_ENABLED=0`.

## Checklist

- [x] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [x] Tests cover denied reverse references, explicit denials, and grant
      evaluation errors.
- [x] User-facing docs and samples are updated where needed.
- [x] Generated files were regenerated and verified in sync.
- [x] Release-only chart version fields are unchanged.