### PR TITLE
fix(status): fail closed when GarageNode inputs are unavailable

### DIFF
--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3947,6 +3947,9 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 	var nodeLocalPoolNodeCount int32
 	if err := r.List(ctx, gnList, client.InNamespace(cluster.Namespace)); err != nil {
 		log.Error(err, "Failed to list child GarageNodes for status aggregation")
+		return r.updateStatus(ctx, cluster, "Unknown", fmt.Errorf(
+			"listing child GarageNodes for status aggregation: %w", err,
+		))
 	} else {
 		for i := range gnList.Items {
 			node := &gnList.Items[i]

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3923,7 +3923,9 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 	log := logf.FromContext(ctx)
 	scale, err := r.observeGarageClusterScale(ctx, cluster)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("observe GarageCluster scale status: %w", err)
+		return r.updateStatus(ctx, cluster, PhaseUnknown, fmt.Errorf(
+			"observe GarageCluster scale status: %w", err,
+		))
 	}
 
 	// Get workload status
@@ -3990,7 +3992,9 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		client.InNamespace(cluster.Namespace),
 		client.MatchingLabels(map[string]string{labelCluster: cluster.Name, labelTier: tierStorage}),
 	); err != nil {
-		return ctrl.Result{}, err
+		return r.updateStatus(ctx, cluster, PhaseUnknown, fmt.Errorf(
+			"list child node-local-pool DaemonSets for status aggregation: %w", err,
+		))
 	}
 	for i := range daemonSets.Items {
 		ds := &daemonSets.Items[i]
@@ -4014,7 +4018,9 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 		gwSts := &appsv1.StatefulSet{}
 		if err := r.Get(ctx, types.NamespacedName{Name: gatewayWorkloadName(cluster), Namespace: cluster.Namespace}, gwSts); err != nil {
 			if !errors.IsNotFound(err) {
-				return ctrl.Result{}, err
+				return r.updateStatus(ctx, cluster, PhaseUnknown, fmt.Errorf(
+					"get gateway StatefulSet for status aggregation: %w", err,
+				))
 			}
 		} else {
 			gatewayReady = gwSts.Status.ReadyReplicas
@@ -4280,6 +4286,9 @@ func (r *GarageClusterReconciler) updateStatusFromCluster(ctx context.Context, c
 			}),
 		); err != nil {
 			log.V(1).Info("Failed to list gateway GarageNodes for layout-degraded check", "error", err)
+			return r.updateStatus(ctx, cluster, PhaseUnknown, fmt.Errorf(
+				"list gateway GarageNodes for status aggregation: %w", err,
+			))
 		} else {
 			for i := range gwNodes.Items {
 				n := &gwNodes.Items[i]

--- a/internal/controller/garagecluster_status_aggregation_test.go
+++ b/internal/controller/garagecluster_status_aggregation_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+func garageClusterStatusTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps/v1 scheme: %v", err)
+	}
+	if err := garagev1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+	if err := garagev1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1beta2 scheme: %v", err)
+	}
+	return scheme
+}
+
+func newZeroReplicaGarageCluster(name string) *garagev1beta2.GarageCluster {
+	return &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "status-test"},
+	}
+}
+
+func TestGarageClusterStatusListFailureDoesNotPublishCompleteAggregation(t *testing.T) {
+	scheme := garageClusterStatusTestScheme(t)
+	cluster := newZeroReplicaGarageCluster("list-failure")
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&garagev1beta2.GarageCluster{}).
+		WithObjects(cluster).
+		Build()
+
+	listErr := errors.New("synthetic GarageNode list failure")
+	kubeClient := interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*garagev1beta1.GarageNodeList); ok {
+				return listErr
+			}
+			return c.List(ctx, list, opts...)
+		},
+	})
+
+	current := &garagev1beta2.GarageCluster{}
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(cluster), current); err != nil {
+		t.Fatalf("get cluster: %v", err)
+	}
+
+	result, err := (&GarageClusterReconciler{Client: kubeClient, Scheme: scheme}).updateStatusFromCluster(context.Background(), current)
+	if err != nil {
+		t.Fatalf("updateStatusFromCluster returned error: %v", err)
+	}
+	if result.RequeueAfter != RequeueAfterError {
+		t.Fatalf("requeue delay = %s, want %s", result.RequeueAfter, RequeueAfterError)
+	}
+
+	updated := &garagev1beta2.GarageCluster{}
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(cluster), updated); err != nil {
+		t.Fatalf("get updated cluster: %v", err)
+	}
+	if updated.Status.Phase != "Unknown" {
+		t.Fatalf("phase = %q, want Unknown after an incomplete node list", updated.Status.Phase)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, PhaseReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse {
+		t.Fatalf("Ready condition = %#v, want False after an incomplete node list", ready)
+	}
+	if !strings.Contains(ready.Message, listErr.Error()) {
+		t.Fatalf("Ready condition message = %q, want list failure", ready.Message)
+	}
+}
+
+func TestGarageClusterStatusEmptyNodeListRemainsNormal(t *testing.T) {
+	scheme := garageClusterStatusTestScheme(t)
+	cluster := newZeroReplicaGarageCluster("empty-list")
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&garagev1beta2.GarageCluster{}).
+		WithObjects(cluster).
+		Build()
+
+	current := &garagev1beta2.GarageCluster{}
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(cluster), current); err != nil {
+		t.Fatalf("get cluster: %v", err)
+	}
+
+	result, err := (&GarageClusterReconciler{Client: base, Scheme: scheme}).updateStatusFromCluster(context.Background(), current)
+	if err != nil {
+		t.Fatalf("updateStatusFromCluster returned error: %v", err)
+	}
+	if result.RequeueAfter != RequeueAfterLong {
+		t.Fatalf("requeue delay = %s, want %s", result.RequeueAfter, RequeueAfterLong)
+	}
+
+	updated := &garagev1beta2.GarageCluster{}
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(cluster), updated); err != nil {
+		t.Fatalf("get updated cluster: %v", err)
+	}
+	if updated.Status.Phase != PhasePending {
+		t.Fatalf("phase = %q, want %s for a successful empty node list", updated.Status.Phase, PhasePending)
+	}
+	if ready := meta.FindStatusCondition(updated.Status.Conditions, PhaseReady); ready != nil && ready.Status == metav1.ConditionFalse {
+		t.Fatalf("Ready condition = %#v, want no degraded failure for an empty node list", ready)
+	}
+}

--- a/internal/controller/garagecluster_status_aggregation_test.go
+++ b/internal/controller/garagecluster_status_aggregation_test.go
@@ -58,6 +58,14 @@ func newZeroReplicaGarageCluster(name string) *garagev1beta2.GarageCluster {
 func TestGarageClusterStatusListFailureDoesNotPublishCompleteAggregation(t *testing.T) {
 	scheme := garageClusterStatusTestScheme(t)
 	cluster := newZeroReplicaGarageCluster("list-failure")
+	cluster.Status.Phase = PhaseRunning
+	cluster.Status.Conditions = []metav1.Condition{{
+		Type:               PhaseReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "ClusterReady",
+		Message:            "All replicas are ready",
+		ObservedGeneration: cluster.Generation,
+	}}
 	base := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&garagev1beta2.GarageCluster{}).

--- a/internal/controller/garagecluster_status_aggregation_test.go
+++ b/internal/controller/garagecluster_status_aggregation_test.go
@@ -99,8 +99,8 @@ func TestGarageClusterStatusListFailureDoesNotPublishCompleteAggregation(t *test
 	if err := base.Get(context.Background(), client.ObjectKeyFromObject(cluster), updated); err != nil {
 		t.Fatalf("get updated cluster: %v", err)
 	}
-	if updated.Status.Phase != "Unknown" {
-		t.Fatalf("phase = %q, want Unknown after an incomplete node list", updated.Status.Phase)
+	if updated.Status.Phase != PhaseUnknown {
+		t.Fatalf("phase = %q, want %s after an incomplete node list", updated.Status.Phase, PhaseUnknown)
 	}
 	ready := meta.FindStatusCondition(updated.Status.Conditions, PhaseReady)
 	if ready == nil || ready.Status != metav1.ConditionFalse {

--- a/internal/controller/garagecluster_status_aggregation_test.go
+++ b/internal/controller/garagecluster_status_aggregation_test.go
@@ -106,6 +106,9 @@ func TestGarageClusterStatusListFailureDoesNotPublishCompleteAggregation(t *test
 	if ready == nil || ready.Status != metav1.ConditionFalse {
 		t.Fatalf("Ready condition = %#v, want False after an incomplete node list", ready)
 	}
+	if ready.Reason != garagev1beta1.ReasonReconcileFailed {
+		t.Fatalf("Ready condition reason = %q, want %s", ready.Reason, garagev1beta1.ReasonReconcileFailed)
+	}
 	if !strings.Contains(ready.Message, listErr.Error()) {
 		t.Fatalf("Ready condition message = %q, want list failure", ready.Message)
 	}

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -100,6 +100,7 @@ const (
 	PhasePending  = "Pending"
 	PhaseRunning  = "Running"
 	PhaseFailed   = "Failed"
+	PhaseUnknown  = "Unknown"
 	PhaseDeleting = "Deleting"
 	PhaseExpired  = "Expired"
 )


### PR DESCRIPTION
## Summary

Fixes #367 by failing closed when the GarageCluster status aggregator cannot
list its child GarageNodes. The controller now persists `status.phase:
Unknown`, marks `Ready=False` with the existing reconcile-failure condition,
and requeues on the error cadence instead of computing a confident aggregate
from an incomplete list.

A successful empty GarageNode list is still treated as a legitimate empty
cluster and follows the existing normal `Pending` path.

## Validation

Failing-first: the injected GarageNode list-error regression test observed the
old behavior (a normal 5-minute requeue and no degraded status).

Passing after:

- `CGO_ENABLED=0 go test -timeout 1200s ./internal/controller -run 'TestGarageClusterStatus(ListFailure|EmptyNodeList)' -count=1`

The change is limited to `internal/controller/garagecluster_controller.go` and
its regression tests. No CRD or API-version change is needed; `Unknown` is
already an allowed GarageCluster status phase. This PR does not touch the COSI
bucket controller and does not include a release or tag.
