### PR TITLE
fix(renovate): keep COSI client pinned to v1alpha2 API

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,12 @@
     },
     {
       "matchManagers": ["gomod"],
+      "matchPackageNames": ["sigs.k8s.io/container-object-storage-interface/client"],
+      "enabled": false,
+      "description": "Pinned to a pseudo-version with the required v1alpha2 API; tagged v0.2.2 only contains v1alpha1"
+    },
+    {
+      "matchManagers": ["gomod"],
       "groupName": "k8s",
       "matchPackageNames": [
         "/k8s.io/*/",


### PR DESCRIPTION
## Summary

Keep the COSI client module pinned to the pseudo-version that contains the
operator's required `apis/objectstorage/v1alpha2` API. The existing Renovate
rule already does this for the matching COSI `proto` module, but its broad
`sigs.k8s.io/*` Kubernetes group still allowed the client module to move to
tagged `v0.2.2`.

That update is the current failure in Renovate PR #165: Renovate's artifact
update reports that `go get -t ./...` cannot find
`sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2`.
The extracted `v0.2.2` module contains only `apis/objectstorage/v1alpha1`.

This is a durable configuration fix, not a commit to Renovate's
`renovate/k8s` branch. The repository has no `gitIgnoredAuthors` configuration,
so an agent-authored commit there would stop Renovate managing that branch.
Once this is merged, Renovate can recreate/rebase #165 with only compatible
updates. Main-based PR #376 separately carries the generated artifacts for the
Kubernetes 0.37 update.

## Validation

- `jq empty renovate.json`
- Verified the downloaded `v0.2.2` module has `apis/objectstorage/v1alpha1`
  and no `apis/objectstorage/v1alpha2` directory.

No application code, CRD, chart version, or release metadata is changed.
