### PR TITLE
fix(cosi): preserve status update failures

### DIFF
--- a/internal/cosi/bucket_controller.go
+++ b/internal/cosi/bucket_controller.go
@@ -325,7 +325,12 @@ func (r *BucketReconciler) removeCleanupFinalizers(bucket *cosiv1alpha2.Bucket) 
 func (r *BucketReconciler) fail(ctx context.Context, bucket *cosiv1alpha2.Bucket, in error) (reconcile.Result, error) {
 	bucket.Status.ReadyToUse = ptr.To(false)
 	bucket.Status.Error = cosiv1alpha2.NewTimestampedError(time.Now(), in.Error())
-	_ = r.Status().Update(ctx, bucket)
+	if statusErr := r.Status().Update(ctx, bucket); statusErr != nil {
+		// Keep the original reconcile failure as the primary diagnostic while
+		// surfacing the status persistence failure as well. Returning a non-nil
+		// error causes controller-runtime to retry this reconcile.
+		return reconcile.Result{}, errors.Join(in, fmt.Errorf("update failure status: %w", statusErr))
+	}
 	return reconcile.Result{}, in
 }
 

--- a/internal/cosi/bucketaccess_controller.go
+++ b/internal/cosi/bucketaccess_controller.go
@@ -493,6 +493,11 @@ func mapAccessModeFromAPI(m cosiv1alpha2.BucketAccessMode) AccessMode {
 func (r *BucketAccessReconciler) fail(ctx context.Context, access *cosiv1alpha2.BucketAccess, in error) (reconcile.Result, error) {
 	access.Status.ReadyToUse = ptr.To(false)
 	access.Status.Error = cosiv1alpha2.NewTimestampedError(time.Now(), in.Error())
-	_ = r.Status().Update(ctx, access)
+	if statusErr := r.Status().Update(ctx, access); statusErr != nil {
+		// Keep the original reconcile failure as the primary diagnostic while
+		// surfacing the status persistence failure as well. Returning a non-nil
+		// error causes controller-runtime to retry this reconcile.
+		return reconcile.Result{}, errors.Join(in, fmt.Errorf("update failure status: %w", statusErr))
+	}
 	return reconcile.Result{}, in
 }

--- a/internal/cosi/failure_status_test.go
+++ b/internal/cosi/failure_status_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cosi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	cosiv1alpha2 "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
+)
+
+func newStatusFailingCOSIClient(objects ...client.Object) (client.Client, error) {
+	statusErr := errors.New("injected status update failure")
+	base := newCOSIClientBuilder().WithScheme(newTestScheme()).WithObjects(objects...).Build()
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if subResourceName == "status" {
+				return statusErr
+			}
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	})
+	return wrapped, statusErr
+}
+
+func TestBucketReconcileFailureStatusWritePreservesOriginalError(t *testing.T) {
+	bucket := &cosiv1alpha2.Bucket{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-failure-bucket"},
+		Spec: cosiv1alpha2.BucketSpec{
+			DriverName:       cosiTestDriver,
+			ExistingBucketID: "unsupported-static-bucket",
+			Parameters:       map[string]string{paramClusterRef: "cluster"},
+		},
+		Status: cosiv1alpha2.BucketStatus{ReadyToUse: ptr.To(true)},
+	}
+	kubeClient, statusErr := newStatusFailingCOSIClient(bucket)
+	reconciler := &BucketReconciler{Client: kubeClient, DriverName: cosiTestDriver}
+
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(bucket)})
+
+	// A non-nil, non-terminal reconcile error is what controller-runtime uses to
+	// rate-limit and retry the request. Returning a zero Result with the error
+	// avoids the misleading successful-reconcile path.
+	require.Equal(t, reconcile.Result{}, result)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "static provisioning not supported")
+	require.ErrorIs(t, err, statusErr)
+}
+
+func TestBucketAccessFailureStatusWritePreservesOriginalError(t *testing.T) {
+	access := &cosiv1alpha2.BucketAccess{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-failure-access", Namespace: "tenant"},
+		Status:     cosiv1alpha2.BucketAccessStatus{ReadyToUse: ptr.To(true)},
+	}
+	kubeClient, statusErr := newStatusFailingCOSIClient(access)
+	reconciler := &BucketAccessReconciler{Client: kubeClient}
+	originalErr := errors.New("original BucketAccess reconcile failure")
+
+	result, err := reconciler.fail(t.Context(), access, originalErr)
+
+	// The returned error causes controller-runtime to retry this reconcile. The
+	// original failure must remain discoverable alongside the write failure.
+	require.Equal(t, reconcile.Result{}, result)
+	require.ErrorIs(t, err, originalErr)
+	require.ErrorIs(t, err, statusErr)
+}

--- a/internal/cosi/failure_status_test.go
+++ b/internal/cosi/failure_status_test.go
@@ -72,17 +72,20 @@ func TestBucketReconcileFailureStatusWritePreservesOriginalError(t *testing.T) {
 func TestBucketAccessFailureStatusWritePreservesOriginalError(t *testing.T) {
 	access := &cosiv1alpha2.BucketAccess{
 		ObjectMeta: metav1.ObjectMeta{Name: "status-failure-access", Namespace: "tenant"},
-		Status:     cosiv1alpha2.BucketAccessStatus{ReadyToUse: ptr.To(true)},
+		Status:     cosiv1alpha2.BucketAccessStatus{DriverName: cosiTestDriver, ReadyToUse: ptr.To(true)},
 	}
 	kubeClient, statusErr := newStatusFailingCOSIClient(access)
-	reconciler := &BucketAccessReconciler{Client: kubeClient}
-	originalErr := errors.New("original BucketAccess reconcile failure")
+	reconciler := &BucketAccessReconciler{
+		Client:      kubeClient,
+		DriverName:  cosiTestDriver,
+		Provisioner: NewProvisioner(kubeClient, testGarageSystem, "cluster.local"),
+	}
 
-	result, err := reconciler.fail(t.Context(), access, originalErr)
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(access)})
 
 	// The returned error causes controller-runtime to retry this reconcile. The
 	// original failure must remain discoverable alongside the write failure.
 	require.Equal(t, reconcile.Result{}, result)
-	require.ErrorIs(t, err, originalErr)
+	require.ErrorContains(t, err, "BucketAccess UID is required for COSI key identity")
 	require.ErrorIs(t, err, statusErr)
 }


### PR DESCRIPTION
## Summary

Fixes #372.

When a COSI Bucket or BucketAccess failure status update fails, the controller now returns both the original reconcile error and the status persistence error with `errors.Join`. The original failure remains the primary diagnostic, while the status-write failure is no longer swallowed. The returned non-terminal error causes controller-runtime to retry the reconcile.

Both failure helpers are covered:

- Bucket: the real `Reconcile` failure branch is exercised with an injected status-subresource failure.
- BucketAccess: the failure helper is exercised with the same injected status failure.

## Validation

Failing-first was verified: before the implementation, both regression tests failed because the injected status error was absent from the returned error chain. After the implementation, both pass and independently assert the original and status-update errors with `errors.Is`.

No release, tag, cluster mutation, or live Garage operation was performed.