### PR TITLE
fix(deps): pin Garage v2.4.0 with matching digest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,7 +645,7 @@ path pays the extra read; a converged bucket short-circuits on
 `adminLifecycleEqual`.
 
 CI runs two Garage versions on purpose (this is what backs the "v2.x" range
-claim): the Ginkgo suite on v2.3.0 — also `defaultGarageImage` — and the
+claim): the Ginkgo suite on v2.4.0 — also `defaultGarageImage` — and the
 topology suites (`hack/e2e-*.sh`) on v2.2.0. Keep it that way; collapsing to one
 version silently narrows what "supported" means.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,7 +10,7 @@ coexist with pools in the same physical-site GarageCluster.
 
 Pools follow the operator-wide Garage v2.0.0 minimum because the layout-history,
 repair-worker, and block-error endpoints they use are present in Admin API v2;
-Garage v2.3.0 is the tested default. Pools also require a cluster-scoped
+Garage v2.4.0 is the tested default. Pools also require a cluster-scoped
 operator installation and the validating and conversion webhooks. The shipped
 webhook configurations use `failurePolicy: Fail`; disabling them is unsupported
 because prepared storage deletion, immutable identity/path rules, topology-only

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ The Garage version is yours to choose — `GarageCluster.spec.image`, `GarageNod
 
 | Operator | Garage minimum | Garage tested in CI | Notes |
 |---|---|---|---|
-| 0.7.x | **v2.0.0** | v2.3.0, v2.2.0 | Admin API v2; node-local pools require Kubernetes 1.27+ |
+| 0.7.x | **v2.0.0** | v2.4.0, v2.2.0 | Admin API v2; node-local pools require Kubernetes 1.27+ |
 | 0.6.x | **v2.0.0** | v2.3.0, v2.2.0 | Admin API v2 only |
 
-`dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690` is the built-in default when `spec.image` is unset, so default deployments use the exact tested multi-platform image index. CI exercises two versions on purpose: the Ginkgo suite runs the pinned v2.3.0 index and the topology suites (multi-cluster, external gateway, IPv6, single-cluster) run the pinned v2.2.0 index, which is what backs the "v2.x range" claim rather than a single number.
+`dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137` is the built-in default when `spec.image` is unset, so default deployments use the exact tested multi-platform image index. CI exercises two versions on purpose: the Ginkgo suite runs the pinned v2.4.0 index and the topology suites (multi-cluster, external gateway, IPv6, single-cluster) run the pinned v2.2.0 index, which is what backs the "v2.x range" claim rather than a single number.
 
 **Garage 0.x and 1.x are not supported.** The operator drives buckets, keys, layout, and repair exclusively through the `/v2/...` admin API, which first shipped in Garage v2.0.0. Against an older node every admin call 404s and no cluster will reconcile.
 
@@ -570,7 +570,7 @@ before finalizer convergence. A parent `GarageCluster` may foreground-cascade
 its children only after its terminal Drain handoff, or as part of explicit
 whole-store `Destroy` cleanup.
 
-Pools use the operator-wide Garage v2.0.0+ Admin API v2 floor; v2.3.0 is the
+Pools use the operator-wide Garage v2.0.0+ Admin API v2 floor; v2.4.0 is the
 tested default. They also require a cluster-scoped install, enabled validating
 and conversion webhooks, and an Admin API token. One workload-owning
 `GarageCluster` is one Garage store/site lifecycle and ownership boundary,

--- a/api/v1beta1/garagecluster_types.go
+++ b/api/v1beta1/garagecluster_types.go
@@ -44,8 +44,8 @@ type GarageClusterSpec struct {
 
 	// ImageRepository overrides just the repository portion of the default Garage image,
 	// preserving the default tag for automatic version upgrades.
-	// For example, setting this to "my-mirror/garage" with the default tag v2.3.0
-	// produces "my-mirror/garage:v2.3.0".
+	// For example, setting this to "my-mirror/garage" with the default tag v2.4.0
+	// produces "my-mirror/garage:v2.4.0".
 	// Ignored if image is set.
 	// +optional
 	ImageRepository string `json:"imageRepository,omitempty"`

--- a/charts/garage-operator/README.md
+++ b/charts/garage-operator/README.md
@@ -9,7 +9,7 @@ A Kubernetes operator for managing [Garage](https://garagehq.deuxfleurs.fr/) - a
   requires Kubernetes 1.27+ for Pod scheduling gates and fails closed on older
   or incompatible servers; clusters that do not use it retain the 1.25 floor.
 - Helm 3.8+
-- Garage **v2.0.0 or newer** (the operator drives the `/v2` admin API exclusively; v2.3.0 is the tested default). See [Garage version compatibility](../../README.md#garage-version-compatibility).
+- Garage **v2.0.0 or newer** (the operator drives the `/v2` admin API exclusively; v2.4.0 is the tested default). See [Garage version compatibility](../../README.md#garage-version-compatibility).
 - cert-manager for admission and conversion webhook certificates, unless
   `webhooks.enabled=false`. That disabled mode is limited to local development
   or simple v1beta2-only installs; it is unsupported for `nodeLocalPools` and

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -1701,8 +1701,8 @@ spec:
                 description: |-
                   ImageRepository overrides just the repository portion of the default Garage image,
                   preserving the default tag for automatic version upgrades.
-                  For example, setting this to "my-mirror/garage" with the default tag v2.3.0
-                  produces "my-mirror/garage:v2.3.0".
+                  For example, setting this to "my-mirror/garage" with the default tag v2.4.0
+                  produces "my-mirror/garage:v2.4.0".
                   Ignored if image is set.
                 type: string
               k2vApi:

--- a/charts/garage-operator/values.yaml
+++ b/charts/garage-operator/values.yaml
@@ -17,7 +17,7 @@ image:
 # -- Default Garage container image for clusters that don't specify one.
 # When set, all GarageCluster/GarageNode CRs that omit spec.image will use this image.
 # Useful for environments that can only pull from a specific registry.
-# Example: "registry.example.com/garage:v2.3.0"
+# Example: "registry.example.com/garage:v2.4.0"
 defaultGarageImage: ""
 
 # -- Image pull secrets for private registries

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,7 +132,7 @@ func main() {
 	var defaultGarageImage string
 	flag.StringVar(&defaultGarageImage, "default-garage-image", "",
 		"Default Garage container image for clusters that don't specify one. "+
-			"If empty, uses the built-in digest-pinned Garage v2.3.0 image.")
+			"If empty, uses the built-in digest-pinned Garage v2.4.0 image.")
 
 	// Cluster domain. See clusterDomainDefault for the CLUSTER_DOMAIN env var
 	// fallback.

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -1701,8 +1701,8 @@ spec:
                 description: |-
                   ImageRepository overrides just the repository portion of the default Garage image,
                   preserving the default tag for automatic version upgrades.
-                  For example, setting this to "my-mirror/garage" with the default tag v2.3.0
-                  produces "my-mirror/garage:v2.3.0".
+                  For example, setting this to "my-mirror/garage" with the default tag v2.4.0
+                  produces "my-mirror/garage:v2.4.0".
                   Ignored if image is set.
                 type: string
               k2vApi:

--- a/config/samples/cosi/garagecluster-e2e.yaml
+++ b/config/samples/cosi/garagecluster-e2e.yaml
@@ -15,7 +15,7 @@ metadata:
   name: garage
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   replication:
     factor: 1

--- a/config/samples/garage_v1beta1_garagecluster.yaml
+++ b/config/samples/garage_v1beta1_garagecluster.yaml
@@ -12,7 +12,7 @@ metadata:
   name: garage
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   replicas: 3
 

--- a/config/samples/garage_v1beta1_garagecluster_gateway.yaml
+++ b/config/samples/garage_v1beta1_garagecluster_gateway.yaml
@@ -12,7 +12,7 @@ metadata:
   name: garage-gateway
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   replicas: 2
   gateway: true

--- a/config/samples/garage_v1beta2_garagecluster.yaml
+++ b/config/samples/garage_v1beta2_garagecluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: garage
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   replication:
     factor: 3
@@ -73,7 +73,7 @@ metadata:
   name: garage-federated
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   # Zone identifies this cluster in the federation.
   zone: us-east-1

--- a/config/samples/garage_v1beta2_garagecluster_auto_per_node.yaml
+++ b/config/samples/garage_v1beta2_garagecluster_auto_per_node.yaml
@@ -20,7 +20,7 @@ metadata:
   name: garage-auto
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   # Auto is the default; spelled out here for clarity.
   layoutPolicy: Auto

--- a/config/samples/garage_v1beta2_garagecluster_eject_to_manual.yaml
+++ b/config/samples/garage_v1beta2_garagecluster_eject_to_manual.yaml
@@ -36,7 +36,7 @@ metadata:
   name: garage-ejectable
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   # Starts as Auto — flip to Manual to eject.
   layoutPolicy: Auto

--- a/config/samples/garage_v1beta2_garagecluster_gateway.yaml
+++ b/config/samples/garage_v1beta2_garagecluster_gateway.yaml
@@ -27,7 +27,7 @@ metadata:
   name: garage-edge-local
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   # Gateway tier only — no storage block. This edge gateway uses one StatefulSet
   # with a persistent metadata PVC per identity; block data stays EmptyDir.
@@ -86,7 +86,7 @@ metadata:
   name: garage-edge-remote
   namespace: edge-namespace
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   gateway:
     # The edge StatefulSet has one shared config. A shared address is safe for

--- a/config/samples/garage_v1beta2_garagecluster_node_local_pools.yaml
+++ b/config/samples/garage_v1beta2_garagecluster_node_local_pools.yaml
@@ -1,7 +1,7 @@
 # Mixed Garage storage: keep a hand-managed SMB GarageNode and add a uniform
 # node-local pool to the same physical-site GarageCluster. The controller's
 # workload implementation is deliberately not part of the public API.
-# Requires Garage v2.0.0+ (v2.3.0 is the tested default), a cluster-scoped
+# Requires Garage v2.0.0+ (v2.4.0 is the tested default), a cluster-scoped
 # operator install, and enabled validating/conversion webhooks.
 #
 # Prerequisites:
@@ -37,7 +37,7 @@ metadata:
   name: garage-mixed
   namespace: garage
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
   zone: site-a
 
   # Whole-store teardown. Use Drain instead when intentionally retiring this

--- a/config/samples/garage_v1beta2_garagecluster_zone_from.yaml
+++ b/config/samples/garage_v1beta2_garagecluster_zone_from.yaml
@@ -24,7 +24,7 @@ metadata:
   name: garage-racks
   namespace: garage-operator-system
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   # Applies to operator-managed default-group and node-local-pool GarageNodes.
   # Set zoneFrom directly on user-owned Manual GarageNodes instead.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ This page installs the operator and its CRDs. It does not create a Garage cluste
 
 - Kubernetes `1.25+` for ordinary workloads; `1.27+` for [node-local pools](../node-local-pools.md).
 - Helm `3.8+`.
-- Garage `v2.0.0+`; the default image is the tested Garage `v2.3.0` digest.
+- Garage `v2.0.0+`; the default image is the tested Garage `v2.4.0` digest.
 - cert-manager for the admission and conversion webhooks. The chart enables webhooks by default.
 
 The operator must be allowed to watch the namespaces in which its `GarageCluster`, `GarageNode`, bucket, key, and token resources live. A cluster-scoped installation is required for `zoneFrom` and node-local pools.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -21,7 +21,7 @@ metadata:
   name: garage
   namespace: garage
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
   zone: lab
   replication:
     factor: 3

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Admission webhooks, leader election, layout coordination, drain barriers, identi
 
 ## Support boundary
 
-The current release line is `v0.7.x`. The operator requires Garage `v2.0.0` or newer and uses Garage's `/v2` Admin API. The built-in Garage image is the digest-pinned, CI-tested `v2.3.0` image; see the [compatibility matrix](reference/compatibility.md) before selecting a different image.
+The current release line is `v0.7.x`. The operator requires Garage `v2.0.0` or newer and uses Garage's `/v2` Admin API. The built-in Garage image is the digest-pinned, CI-tested `v2.4.0` image; see the [compatibility matrix](reference/compatibility.md) before selecting a different image.
 
 Kubernetes `1.25+` is supported for ordinary cluster shapes. Node-local pools require Kubernetes `1.27+`, a cluster-scoped operator installation, enabled admission/conversion webhooks, leader election, and a workload namespace that permits the required HostPath policy.
 

--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -31,7 +31,7 @@ Pin an image explicitly and let the operator coordinate identity-bearing rollout
 
 ```yaml
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 ```
 
 Do not change the image, volume topology, replica count, and replication factor in one unreviewed edit. Watch `StorageRolloutReady`, `StorageTopologyReady`, `NodeLocalPoolsReady`, and the Garage health conditions after each change.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -9,7 +9,7 @@ This matrix describes the current release line and the boundaries verified by th
 | Operator `v0.7.x` | Current release line | Chart and image version `v0.7.8` in this repository |
 | Kubernetes | `1.25+` ordinary shapes | `nodeLocalPools` require `1.27+` scheduling gates |
 | Garage | `v2.0.0+` minimum | `/v2` Admin API only; Garage `0.x` and `1.x` are unsupported |
-| Garage CI images | `v2.3.0`, `v2.2.0` | The exact image digests are pinned in samples/workflows |
+| Garage CI images | `v2.4.0`, `v2.2.0` | The exact image digests are pinned in samples/workflows |
 | Helm | `3.8+` | OCI chart installation |
 | cert-manager | Required by default | Admission/conversion webhook certificates |
 

--- a/hack/test-resources.yaml
+++ b/hack/test-resources.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: garage-operator-system
 spec:
   # Container image
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
 
   # Replication settings
   replication:

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -62,8 +62,8 @@ import (
 
 const (
 	garageClusterFinalizer = "garagecluster.garage.rajsingh.info/finalizer"
-	defaultGarageImage     = "dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690"
-	defaultGarageTag       = "v2.3.0"
+	defaultGarageImage     = "dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137"
+	defaultGarageTag       = "v2.4.0"
 	defaultS3Region        = "garage"
 	defaultAppName         = "garage"
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,20 +10,42 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track dxflrs/garage image version in Go source and YAML files",
+      "description": "Track dxflrs/garage image tag+digest pins across operator defaults, samples, e2e, and docs",
       "fileMatch": [
         "internal/controller/garagecluster_controller\\.go",
         "api/v1beta1/garagecluster_types\\.go",
         "config/samples/.+\\.yaml",
         "hack/test-resources\\.yaml",
         "test/e2e/e2e_test\\.go",
-        "charts/garage-operator/values\\.yaml"
+        "charts/garage-operator/values\\.yaml",
+        "charts/garage-operator/README\\.md",
+        "README\\.md",
+        "docs/getting-started/quickstart\\.md",
+        "docs/getting-started/installation\\.md",
+        "docs/operations/upgrades\\.md",
+        "docs/reference/compatibility\\.md",
+        "docs/index\\.md",
+        "cmd/main\\.go"
       ],
       "matchStrings": [
-        "dxflrs/garage:(?<currentValue>v[\\d.]+)"
+        "dxflrs/garage:(?<currentValue>v[\\d.]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
       "depNameTemplate": "dxflrs/garage",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track defaultGarageTag so repository-only imageRepository defaults stay aligned",
+      "fileMatch": [
+        "internal/controller/garagecluster_controller\\.go"
+      ],
+      "matchStrings": [
+        "defaultGarageTag\\s*=\\s*\"(?<currentValue>v[\\d.]+)\""
+      ],
+      "depNameTemplate": "dxflrs/garage",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -66,7 +88,8 @@
       "matchManagers": ["regex"],
       "matchPackageNames": ["dxflrs/garage"],
       "groupName": "garage",
-      "description": "Group all Garage image version bumps into a single PR"
+      "pinDigests": true,
+      "description": "Group Garage image bumps; keep tag and digest pins in the same PR"
     }
   ]
 }

--- a/schemas/garagecluster_v1beta1.json
+++ b/schemas/garagecluster_v1beta1.json
@@ -1465,7 +1465,7 @@
           "type": "array"
         },
         "imageRepository": {
-          "description": "ImageRepository overrides just the repository portion of the default Garage image,\npreserving the default tag for automatic version upgrades.\nFor example, setting this to \"my-mirror/garage\" with the default tag v2.3.0\nproduces \"my-mirror/garage:v2.3.0\".\nIgnored if image is set.",
+          "description": "ImageRepository overrides just the repository portion of the default Garage image,\npreserving the default tag for automatic version upgrades.\nFor example, setting this to \"my-mirror/garage\" with the default tag v2.4.0\nproduces \"my-mirror/garage:v2.4.0\".\nIgnored if image is set.",
           "type": "string"
         },
         "k2vApi": {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,9 +39,9 @@ import (
 )
 
 // namespace where the project is deployed in
-// e2eGarageImage is the upstream Garage the suite runs. Kept at v2.3.0 to match
+// e2eGarageImage is the upstream Garage the suite runs. Kept at v2.4.0 to match
 // the operator's defaultGarageImage; the topology suites cover v2.2.0.
-const e2eGarageImage = "dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690"
+const e2eGarageImage = "dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137"
 
 const e2eCurlImage = "curlimages/curl:8.14.1@sha256:9a1ed35addb45476afa911696297f8e115993df459278ed036182dd2cd22b67b"
 
@@ -4678,7 +4678,7 @@ metadata:
   name: %s
   namespace: %s
 spec:
-  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
   gateway:
     replicas: 1
     resources:
@@ -6477,7 +6477,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: garage
-          image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+          image: dxflrs/garage:v2.4.0@sha256:715d176efc35384bf72cf6052fd61b74b3e27a1e31a9dfedabe646bd1e92f137
           command: ["/garage", "server"]
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Pins the operator default, samples, Ginkgo e2e, and docs to real Garage **v2.4.0** (`sha256:715d176…`), not the v2.3.0 digest under a new tag.
- Updates `defaultGarageTag` and regenerates CRD/schema comments for `imageRepository`.
- Hardens `renovate.json` so the garage custom manager captures `currentDigest` and `defaultGarageTag`, with `pinDigests: true` on the garage group.
- Leaves topology suites on the intentional v2.2.0 pin.

Supersedes #382, which only changed the tag text and left `@sha256:866bd13…` (still v2.3.0).

## Test plan
- [x] `go test ./api/v1beta1 ./api/v1beta2 ./internal/controller -run 'TestResolveGarageImage|TestMergeNodeImage|TestBuild'`
- [x] Confirmed no leftover `866bd13…` digest outside ignored `site/`
- [x] Confirmed `hack/e2e-*.sh` still pin v2.2.0
- [ ] CI: Ginkgo core + layout on the new digest
- [ ] Close #382 after this merges (or once CI is green)