### PR TITLE
fix: repair node-local-pool Pod routing labels

### DIFF
--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -144,7 +144,7 @@ func (r *GarageNodeReconciler) nodeLocalPoolReader() client.Reader {
 // +kubebuilder:rbac:groups=garage.rajsingh.info,resources=garagenodes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=garage.rajsingh.info,resources=garagenodes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 
@@ -646,6 +646,22 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	// Clear Suspended condition when not suspended.
 	meta.RemoveStatusCondition(&node.Status.Conditions, "Suspended")
+
+	// A node-local-pool DaemonSet cannot put the Kubernetes Node name in its
+	// template: one template produces Pods for multiple Nodes. The cluster
+	// lifecycle normally repairs that per-Pod routing label, but the
+	// GarageNode controller is the component that continues reconciling and
+	// discovering each generated identity. Repair the exact current Pod here as
+	// a backstop before any identity or layout work. This makes a missed create
+	// event self-healing and preserves the Service endpoint across the Pod's
+	// lifetime without changing Garage state.
+	if isNodeLocalPoolBacked(node) {
+		if err := r.reconcileNodeLocalPoolPodNodeLabel(ctx, node, cluster); err != nil &&
+			!stderrors.Is(err, errManagedPodAbsent) {
+			return r.updateStatus(ctx, node, PhasePending,
+				fmt.Errorf("repairing node-local-pool Pod routing label: %w", err))
+		}
+	}
 
 	// Graceful node cycle (#231): the garage.rajsingh.info/cycle annotation does an
 	// add-before-remove swap — provision a sibling, wait for it to sync, then drain
@@ -3489,9 +3505,44 @@ func (r *GarageNodeReconciler) managedPodForNode(
 		return nil, fmt.Errorf("external nodes have no operator-managed Pod")
 	}
 	if isNodeLocalPoolBacked(node) {
-		return r.daemonSetPodForNode(ctx, node, cluster)
+		pod, err := r.daemonSetPodForNode(ctx, node, cluster)
+		if err != nil {
+			return nil, err
+		}
+		if err := r.repairNodeLocalPoolPodNodeLabel(ctx, pod); err != nil {
+			return nil, err
+		}
+		return pod, nil
 	}
 	return r.statefulSetPodForNode(ctx, node)
+}
+
+// reconcileNodeLocalPoolPodNodeLabel repairs the routing label on the exact
+// current DaemonSet Pod for this GarageNode. A missing Pod is a normal
+// workload gap and remains the caller's responsibility; any other read or
+// patch error is surfaced so the next reconcile retries it.
+func (r *GarageNodeReconciler) reconcileNodeLocalPoolPodNodeLabel(
+	ctx context.Context,
+	node *garagev1beta1.GarageNode,
+	cluster *garagev1beta2.GarageCluster,
+) error {
+	pod, err := r.daemonSetPodForNode(ctx, node, cluster)
+	if err != nil {
+		return err
+	}
+	return r.repairNodeLocalPoolPodNodeLabel(ctx, pod)
+}
+
+func (r *GarageNodeReconciler) repairNodeLocalPoolPodNodeLabel(ctx context.Context, pod *corev1.Pod) error {
+	changed, err := ensureNodeLocalPoolPodNodeLabel(ctx, r.Client, pod)
+	if err != nil {
+		return fmt.Errorf("patching Pod %s/%s node-local routing label: %w", pod.Namespace, pod.Name, err)
+	}
+	if changed {
+		logf.FromContext(ctx).Info("Repaired node-local-pool Pod routing label",
+			"pod", pod.Name, "kubernetesNode", pod.Spec.NodeName)
+	}
+	return nil
 }
 
 func (r *GarageNodeReconciler) getPodIPs(ctx context.Context, node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster) ([]string, error) {

--- a/internal/controller/garagenode_daemonset_backed_test.go
+++ b/internal/controller/garagenode_daemonset_backed_test.go
@@ -346,6 +346,35 @@ var _ = Describe("GarageNode DaemonSet-backed node_id discovery", func() {
 		Expect(fakeLayout.hasRole(idWorker2)).To(BeFalse())
 	})
 
+	It("repairs the per-Pod node routing label from the GarageNode reconcile backstop", func() {
+		cluster, daemonSet := mkClusterAndDaemonSet()
+		pod := mkDSPod("ds-disc-cluster-storage-label-repair", dsWorker1, "")
+		pod.Annotations = nil
+		pod.Status = corev1.PodStatus{Phase: corev1.PodRunning, PodIP: testStoragePodIP}
+		capacity := resource.MustParse("100Gi")
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "ds-node-label-repair", Namespace: ns},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef:         garagev1beta1.ClusterReference{Name: dsCluster},
+				Zone:               testNodeZone,
+				Capacity:           &capacity,
+				Backing:            garagev1beta1.NodeBackingNodeLocalPool,
+				KubernetesNodeName: dsWorker1,
+				NodeLocalPoolName:  dsPool,
+			},
+		}
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, daemonSet, pod).Build()
+		r := &GarageNodeReconciler{Client: fc, Scheme: scheme}
+
+		_, err := r.managedPodForNode(bctx, node, cluster)
+		Expect(err).NotTo(HaveOccurred())
+
+		got := &corev1.Pod{}
+		Expect(fc.Get(bctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, got)).To(Succeed())
+		Expect(got.Labels).To(HaveKeyWithValue(labelKubernetesNode, dsWorker1))
+		Expect(got.Annotations).To(HaveKeyWithValue(annotationKubernetesNode, dsWorker1))
+	})
+
 	It("accepts a cold-recovery identity only after direct discovery and an exact committed role proof", func() {
 		capacity := resource.MustParse("100Gi")
 		cluster, daemonSet := mkClusterAndDaemonSet()

--- a/internal/controller/node_local_pool_activation.go
+++ b/internal/controller/node_local_pool_activation.go
@@ -341,10 +341,27 @@ func (r *GarageClusterReconciler) markNodeLocalPoolClaimRetiring(
 	return nil
 }
 
-func (r *GarageClusterReconciler) ensureDaemonSetPodNodeLabel(ctx context.Context, pod *corev1.Pod) error {
+// ensureNodeLocalPoolPodNodeLabel repairs the routing identity on a scheduled
+// node-local-pool Pod. The DaemonSet template cannot carry this value because
+// it is different for every Node selected by the same DaemonSet; the operator
+// therefore owns both the selector label and its audit annotation.
+//
+// Return whether a patch was needed so callers that run outside the cluster
+// lifecycle can make the repair visible without turning an idempotent check
+// into a noisy log on every reconcile.
+func ensureNodeLocalPoolPodNodeLabel(ctx context.Context, c client.Client, pod *corev1.Pod) (bool, error) {
+	if c == nil {
+		return false, fmt.Errorf("node-local-pool Pod label repair requires a Kubernetes client")
+	}
+	if pod == nil {
+		return false, fmt.Errorf("node-local-pool Pod label repair requires a Pod")
+	}
+	if pod.Spec.NodeName == "" {
+		return false, fmt.Errorf("node-local-pool Pod %s/%s is not scheduled", pod.Namespace, pod.Name)
+	}
 	value := kubernetesNodeLabelValue(pod.Spec.NodeName)
 	if pod.Labels[labelKubernetesNode] == value && pod.Annotations[annotationKubernetesNode] == pod.Spec.NodeName {
-		return nil
+		return false, nil
 	}
 	before := pod.DeepCopy()
 	if pod.Labels == nil {
@@ -355,7 +372,15 @@ func (r *GarageClusterReconciler) ensureDaemonSetPodNodeLabel(ctx context.Contex
 	}
 	pod.Labels[labelKubernetesNode] = value
 	pod.Annotations[annotationKubernetesNode] = pod.Spec.NodeName
-	return r.Patch(ctx, pod, client.MergeFrom(before))
+	if err := c.Patch(ctx, pod, client.MergeFrom(before)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *GarageClusterReconciler) ensureDaemonSetPodNodeLabel(ctx context.Context, pod *corev1.Pod) error {
+	_, err := ensureNodeLocalPoolPodNodeLabel(ctx, r.Client, pod)
+	return err
 }
 
 func kubernetesNodeLabelValue(nodeName string) string {


### PR DESCRIPTION
## Summary

- Repair `garage.rajsingh.info/kubernetes-node` and its audit annotation on the exact current node-local-pool Pod during every `GarageNode` reconcile.
- Keep the existing cluster lifecycle repair path, but share the idempotent helper with the `GarageNode` controller as a reconciliation backstop.
- Declare the `patch` permission in the `GarageNode` controller RBAC marker.

The shared DaemonSet template intentionally cannot contain a per-node routing label because one template creates Pods on multiple Kubernetes Nodes. Previously, the label repair depended on the cluster lifecycle actor-observation path. A Pod could therefore be discovered successfully by its `GarageNode` every minute and be reachable through both its direct Garage self response and the Admin API, while remaining unlabeled indefinitely and leaving its EndpointSlice empty.

The motivating incident was exactly that silent failure: the recovery Pod was running and discoverable, the routing label and annotation were absent, the operator emitted no effective repair signal, and a manual Pod label was required to restore a federation peer. The repair is now idempotent and retries on the next `GarageNode` reconcile if the Pod patch fails.

This change only patches Kubernetes Pod metadata. It does not mutate Garage layout, node roles, RPC connectivity, or DaemonSet rollout state.

## Verification

- `go test ./internal/controller -run TestControllers -ginkgo.focus "repairs the per-Pod node routing label" -count=1`
- `go test ./internal/controller -count=1`
- `go test ./... -count=1`
- `make verify-generate`
- `git diff --check`

No live cluster mutation, Pod deletion, rollout unstick, node drain, or node retirement was performed.