### PR TITLE
fix(automode): repair drifted GarageNode identity labels

### DIFF
--- a/internal/controller/garagecluster_automode.go
+++ b/internal/controller/garagecluster_automode.go
@@ -168,7 +168,7 @@ func (r *GarageClusterReconciler) reconcileAutoModeStorageNodes(ctx context.Cont
 		// A completed cycle may leave one or more historical -cycle suffixes after
 		// repeated replacements. Keep deleting ancestors out of the parent scale
 		// loop and let the sole live promoted descendant satisfy this ordinal.
-		descendantNames, current, err := resolveAutoModeCycleSlot(existing, desired.Name)
+		descendantNames, current, err := resolveAutoModeCycleSlotForCluster(existing, desired.Name, cluster, tierStorage)
 		if err != nil {
 			return fmt.Errorf("resolving promoted storage cycle for ordinal %d: %w", i, err)
 		}
@@ -176,6 +176,16 @@ func (r *GarageClusterReconciler) reconcileAutoModeStorageNodes(ctx context.Cont
 			desiredByName[name] = true
 		}
 		if current != nil {
+			repaired, labelErr := r.repairAutoModeNodeLabels(ctx, cluster, current,
+				expectedAutoModeNodeLabels(cluster, tierStorage, desired.Name))
+			if labelErr != nil {
+				return fmt.Errorf("repairing Auto storage GarageNode %s labels: %w", current.Name, labelErr)
+			}
+			if repaired {
+				// Keep metadata repair separate from a spec/layout transition. The next
+				// reconcile consumes the fresh labels before doing other work.
+				return nil
+			}
 			changed, handoffErr := r.reconcileCurrentAutoModePVCHandoffs(ctx, cluster, current, desired.Name)
 			if handoffErr != nil {
 				return fmt.Errorf("reconciling retained PVC handoff for storage ordinal %d: %w", i, handoffErr)
@@ -467,31 +477,15 @@ func (r *GarageClusterReconciler) clearStorageTopologyReadyCondition(
 }
 
 // listAutoModeStorageNodes returns operator-owned GarageNodes for the storage
-// tier of this cluster, keyed by name.
+// tier of this cluster, keyed by name. It discovers exact-owned nodes even when
+// one of the mutable generated labels has drifted; unowned label-selected
+// objects remain present so the cycle ownership fence can reject them.
 func (r *GarageClusterReconciler) listAutoModeStorageNodes(ctx context.Context, cluster *garagev1beta2.GarageCluster) (map[string]*garagev1beta1.GarageNode, error) {
-	nodeList := &garagev1beta1.GarageNodeList{}
-	if err := r.List(ctx, nodeList,
-		client.InNamespace(cluster.Namespace),
-		client.MatchingLabels(map[string]string{
-			labelCluster:      cluster.Name,
-			labelTier:         tierStorage,
-			labelAppManagedBy: managedByOperatorValue,
-		}),
-	); err != nil {
-		return nil, err
+	canonicalNames := make([]string, 0, cluster.StorageReplicas())
+	for ordinal := int32(0); ordinal < cluster.StorageReplicas(); ordinal++ {
+		canonicalNames = append(canonicalNames, autoModeGarageNodeName(cluster.Name, ordinal))
 	}
-	out := make(map[string]*garagev1beta1.GarageNode, len(nodeList.Items))
-	for i := range nodeList.Items {
-		n := &nodeList.Items[i]
-		// Named node-local pools are operator-owned too, but their lifecycle is
-		// independent of the default Auto/Manual pool. Never scale or eject
-		// them through the default-pool ordinal reconciler.
-		if n.Spec.Backing == garagev1beta1.NodeBackingNodeLocalPool {
-			continue
-		}
-		out[n.Name] = n
-	}
-	return out, nil
+	return r.listAutoModeNodes(ctx, cluster, tierStorage, canonicalNames)
 }
 
 // buildAutoModeStorageNode constructs the desired GarageNode for a given ordinal.

--- a/internal/controller/garagecluster_automode_gateway.go
+++ b/internal/controller/garagecluster_automode_gateway.go
@@ -106,7 +106,7 @@ func (r *GarageClusterReconciler) reconcileAutoModeGatewayNodes(ctx context.Cont
 		// Repeated cycles accumulate exact -cycle suffixes. Keep deleting
 		// ancestors out of the parent scale loop and let the sole live promoted
 		// descendant satisfy this ordinal.
-		descendantNames, current, err := resolveAutoModeCycleSlot(existing, desired.Name)
+		descendantNames, current, err := resolveAutoModeCycleSlotForCluster(existing, desired.Name, cluster, tierGateway)
 		if err != nil {
 			return fmt.Errorf("resolving promoted gateway cycle for ordinal %d: %w", i, err)
 		}
@@ -114,6 +114,16 @@ func (r *GarageClusterReconciler) reconcileAutoModeGatewayNodes(ctx context.Cont
 			desiredByName[name] = true
 		}
 		if current != nil {
+			repaired, labelErr := r.repairAutoModeNodeLabels(ctx, cluster, current,
+				expectedAutoModeNodeLabels(cluster, tierGateway, desired.Name))
+			if labelErr != nil {
+				return fmt.Errorf("repairing Auto gateway GarageNode %s labels: %w", current.Name, labelErr)
+			}
+			if repaired {
+				// Keep metadata repair separate from a spec/layout transition. The next
+				// reconcile consumes the fresh labels before doing other work.
+				return nil
+			}
 			changed, handoffErr := r.reconcileCurrentAutoModePVCHandoffs(ctx, cluster, current, desired.Name)
 			if handoffErr != nil {
 				return fmt.Errorf("reconciling retained PVC handoff for gateway ordinal %d: %w", i, handoffErr)
@@ -224,25 +234,15 @@ func (r *GarageClusterReconciler) reconcileAutoModeGatewayNodes(ctx context.Cont
 }
 
 // listAutoModeGatewayNodes returns operator-owned gateway GarageNodes for this
-// cluster, keyed by name.
+// cluster, keyed by name. It discovers exact-owned nodes even when one of the
+// mutable generated labels has drifted; unowned label-selected objects remain
+// present so the cycle ownership fence can reject them.
 func (r *GarageClusterReconciler) listAutoModeGatewayNodes(ctx context.Context, cluster *garagev1beta2.GarageCluster) (map[string]*garagev1beta1.GarageNode, error) {
-	nodeList := &garagev1beta1.GarageNodeList{}
-	if err := r.List(ctx, nodeList,
-		client.InNamespace(cluster.Namespace),
-		client.MatchingLabels(map[string]string{
-			labelCluster:      cluster.Name,
-			labelTier:         tierGateway,
-			labelAppManagedBy: managedByOperatorValue,
-		}),
-	); err != nil {
-		return nil, err
+	canonicalNames := make([]string, 0, cluster.GatewayReplicas())
+	for ordinal := int32(0); ordinal < cluster.GatewayReplicas(); ordinal++ {
+		canonicalNames = append(canonicalNames, autoModeGatewayNodeName(cluster.Name, ordinal))
 	}
-	out := make(map[string]*garagev1beta1.GarageNode, len(nodeList.Items))
-	for i := range nodeList.Items {
-		n := &nodeList.Items[i]
-		out[n.Name] = n
-	}
-	return out, nil
+	return r.listAutoModeNodes(ctx, cluster, tierGateway, canonicalNames)
 }
 
 func (r *GarageClusterReconciler) prepareRetainedAutoModePVCHandoffs(

--- a/internal/controller/garagecluster_automode_labels.go
+++ b/internal/controller/garagecluster_automode_labels.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+// expectedAutoModeNodeLabels returns the labels the GarageCluster controller
+// owns on a generated Auto-mode GarageNode. The slot is the canonical ordinal,
+// not the name of a promoted cycle descendant.
+func expectedAutoModeNodeLabels(cluster *garagev1beta2.GarageCluster, tier, slot string) map[string]string {
+	return map[string]string{
+		labelCluster:      cluster.Name,
+		labelTier:         tier,
+		labelAppManagedBy: managedByOperatorValue,
+		labelAutoNodeSlot: slot,
+	}
+}
+
+// repairAutoModeNodeLabels restores only the generated Auto-mode labels after
+// the caller has proved exact ownership and an unambiguous slot. It deliberately
+// does not use Update: a MergeFrom patch cannot overwrite the node's spec,
+// annotations, finalizers, or owner references. The optimistic-lock option
+// makes a concurrent owner change fail instead of applying labels to a new
+// identity at the old resourceVersion.
+func (r *GarageClusterReconciler) repairAutoModeNodeLabels(
+	ctx context.Context,
+	cluster *garagev1beta2.GarageCluster,
+	node *garagev1beta1.GarageNode,
+	expected map[string]string,
+) (bool, error) {
+	if !hasExactGarageClusterControllerReference(node, cluster) {
+		return false, fmt.Errorf("refusing to repair Auto-mode GarageNode %s/%s labels without exact GarageCluster ownership", node.Namespace, node.Name)
+	}
+	if node.Spec.External != nil || isNodeLocalPoolBacked(node) {
+		return false, fmt.Errorf("refusing to repair non-Auto GarageNode %s/%s labels", node.Namespace, node.Name)
+	}
+
+	before := node.DeepCopy()
+	if node.Labels == nil {
+		node.Labels = make(map[string]string, len(expected))
+	}
+	changed := false
+	for key, value := range expected {
+		if node.Labels[key] == value {
+			continue
+		}
+		node.Labels[key] = value
+		changed = true
+	}
+	if !changed {
+		return false, nil
+	}
+
+	if err := r.Patch(ctx, node, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func autoModeNodeTier(node *garagev1beta1.GarageNode) string {
+	if node != nil && node.Spec.Gateway {
+		return tierGateway
+	}
+	return tierStorage
+}
+
+func autoModeTierMatchesNode(node *garagev1beta1.GarageNode, tier string) bool {
+	return autoModeNodeTier(node) == tier
+}
+
+func autoModeCanonicalSlotForName(name, clusterName, tier string) string {
+	if ancestor := cycleCanonicalAncestorName(name); ancestor != "" {
+		name = ancestor
+	}
+	if tier == tierGateway {
+		if _, ok := parseAutoModeGatewayOrdinal(name, clusterName); ok {
+			return name
+		}
+		return ""
+	}
+	if _, ok := parseAutoModeOrdinal(name, clusterName); ok {
+		return name
+	}
+	return ""
+}
+
+// autoModeNodeSlotForCluster resolves the stable membership slot for an exact
+// Auto-owned node. Canonical and parseable -cycle names are stronger than their
+// mutable slot label, so a wrong slot label on those objects is repairable. A
+// hash-bounded promoted name has no reversible name-based decoding; its valid
+// persisted slot label is therefore mandatory.
+func autoModeNodeSlotForCluster(
+	node *garagev1beta1.GarageNode,
+	cluster *garagev1beta2.GarageCluster,
+	tier string,
+) (string, error) {
+	if node == nil || cluster == nil || !hasExactGarageClusterControllerReference(node, cluster) {
+		return "", fmt.Errorf("cannot resolve Auto-mode slot without exact GarageCluster ownership")
+	}
+	refNamespace := node.Spec.ClusterRef.Namespace
+	if refNamespace == "" {
+		refNamespace = node.Namespace
+	}
+	if node.Spec.ClusterRef.Name != cluster.Name || refNamespace != cluster.Namespace {
+		return "", fmt.Errorf("auto-mode GarageNode %s/%s has clusterRef %s/%s, expected %s/%s", node.Namespace, node.Name, refNamespace, node.Spec.ClusterRef.Name, cluster.Namespace, cluster.Name)
+	}
+	if !autoModeTierMatchesNode(node, tier) {
+		return "", fmt.Errorf("auto-mode GarageNode %s/%s is %s, not %s", node.Namespace, node.Name, autoModeNodeTier(node), tier)
+	}
+
+	if nameSlot := autoModeCanonicalSlotForName(node.Name, cluster.Name, tier); nameSlot != "" {
+		return nameSlot, nil
+	}
+	persisted := node.Labels[labelAutoNodeSlot]
+	if autoModeCanonicalSlotForName(persisted, cluster.Name, tier) == persisted && persisted != "" {
+		return persisted, nil
+	}
+	if persisted == "" {
+		return "", fmt.Errorf("auto-mode GarageNode %s/%s has no canonical name or persisted Auto slot; refusing to guess a bounded cycle identity", node.Namespace, node.Name)
+	}
+	return "", fmt.Errorf("auto-mode GarageNode %s/%s has invalid persisted Auto slot %q", node.Namespace, node.Name, persisted)
+}
+
+func hasAutoModeManagedLabels(node *garagev1beta1.GarageNode, cluster *garagev1beta2.GarageCluster, tier string) bool {
+	return node != nil && node.Labels[labelCluster] == cluster.Name &&
+		node.Labels[labelTier] == tier &&
+		node.Labels[labelAppManagedBy] == managedByOperatorValue
+}
+
+// listAutoModeNodes discovers both normally labelled nodes and exact-owned
+// nodes whose generated labels have drifted. The authoritative scan is small
+// (GarageNodes in one namespace) and is required because a label-filtered List
+// cannot discover the object whose selector label was removed.
+//
+// Non-owned objects carrying the managed label set remain in the result so
+// ensureAutoModeCycleOwnership can apply its existing fail-closed foreign-owner
+// and legacy-adoption checks. Exact-owned objects must have a provable slot;
+// otherwise they are rejected before the parent can place them in a delete set.
+func (r *GarageClusterReconciler) listAutoModeNodes(
+	ctx context.Context,
+	cluster *garagev1beta2.GarageCluster,
+	tier string,
+	canonicalNames []string,
+) (map[string]*garagev1beta1.GarageNode, error) {
+	nodeList := &garagev1beta1.GarageNodeList{}
+	if err := r.safetyReader().List(ctx, nodeList, client.InNamespace(cluster.Namespace)); err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]*garagev1beta1.GarageNode, len(nodeList.Items))
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		byName[node.Name] = node
+	}
+
+	out := make(map[string]*garagev1beta1.GarageNode, len(nodeList.Items))
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		// Named node-local pools have an independent identity/lifecycle path.
+		if isNodeLocalPoolBacked(node) {
+			continue
+		}
+		if hasExactGarageClusterControllerReference(node, cluster) {
+			// External GarageNodes are not Auto-mode generated identities. A
+			// canonical-name collision is checked below; otherwise leave them out.
+			if node.Spec.External != nil || !autoModeTierMatchesNode(node, tier) {
+				continue
+			}
+			if _, err := autoModeNodeSlotForCluster(node, cluster, tier); err != nil {
+				return nil, err
+			}
+			out[node.Name] = node
+			continue
+		}
+		if hasAutoModeManagedLabels(node, cluster, tier) {
+			out[node.Name] = node
+		}
+	}
+
+	// A desired canonical name must never be silently occupied by an object
+	// whose ownership proof is absent or foreign. This closes the old
+	// Create/AlreadyExists loop even when that object has no labels at all.
+	for _, name := range canonicalNames {
+		node, found := byName[name]
+		if !found {
+			continue
+		}
+		if !hasExactGarageClusterControllerReference(node, cluster) {
+			return nil, fmt.Errorf("canonical Auto-mode %s GarageNode %s/%s is occupied without the exact GarageCluster controller UID; refusing to adopt or overwrite it", tier, node.Namespace, node.Name)
+		}
+		if node.Spec.External != nil || isNodeLocalPoolBacked(node) || !autoModeTierMatchesNode(node, tier) {
+			return nil, fmt.Errorf("canonical Auto-mode %s GarageNode %s/%s has an incompatible identity; refusing to create or overwrite it", tier, node.Namespace, node.Name)
+		}
+		if _, err := autoModeNodeSlotForCluster(node, cluster, tier); err != nil {
+			return nil, err
+		}
+		out[node.Name] = node
+	}
+
+	return out, nil
+}
+
+// resolveAutoModeCycleSlotForCluster is the cluster-aware counterpart to the
+// legacy resolver. It treats a canonical/parseable cycle name as the stable
+// identity even when its slot label is wrong, while requiring a valid slot for
+// hash-bounded promoted names. The caller has already run
+// ensureAutoModeCycleOwnership, so an unowned candidate is still an error here
+// rather than a candidate to adopt.
+func resolveAutoModeCycleSlotForCluster(
+	existing map[string]*garagev1beta1.GarageNode,
+	canonicalName string,
+	cluster *garagev1beta2.GarageCluster,
+	tier string,
+) ([]string, *garagev1beta1.GarageNode, error) {
+	var (
+		descendants []string
+		active      []*garagev1beta1.GarageNode
+	)
+	for name, node := range existing {
+		if name == canonicalName || node == nil || isCycleSibling(node) {
+			continue
+		}
+		slot, err := autoModeNodeSlotForCluster(node, cluster, tier)
+		if err != nil {
+			return descendants, nil, err
+		}
+		if slot != canonicalName {
+			continue
+		}
+		descendants = append(descendants, name)
+		if node.DeletionTimestamp.IsZero() {
+			active = append(active, node)
+		}
+	}
+	sort.Strings(descendants)
+	sort.Slice(active, func(i, j int) bool { return active[i].Name < active[j].Name })
+	if len(active) > 1 {
+		activeNames := make([]string, 0, len(active))
+		for _, node := range active {
+			activeNames = append(activeNames, node.Name)
+		}
+		return descendants, nil, fmt.Errorf("canonical Auto-mode GarageNode %s has ambiguous promoted cycle descendants: %s", canonicalName, strings.Join(activeNames, ", "))
+	}
+
+	canonical := existing[canonicalName]
+	if len(active) == 1 {
+		if canonical != nil && canonical.DeletionTimestamp.IsZero() {
+			return descendants, nil, fmt.Errorf("canonical GarageNode %s and promoted cycle descendant %s are both live", canonicalName, active[0].Name)
+		}
+		return descendants, active[0], nil
+	}
+	return descendants, canonical, nil
+}

--- a/internal/controller/garagecluster_automode_labels_test.go
+++ b/internal/controller/garagecluster_automode_labels_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2026 Raj Singh.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
+)
+
+type autoModeLabelRecordingClient struct {
+	client.Client
+	patches int
+	updates int
+	deletes int
+}
+
+func (c *autoModeLabelRecordingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	c.patches++
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *autoModeLabelRecordingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updates++
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func (c *autoModeLabelRecordingClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	c.deletes++
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func autoModeLabelTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := garagev1beta1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := garagev1beta2.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func autoModeLabelTestFixture(t *testing.T, tier string, clusterName, nodeName string) (*garagev1beta2.GarageCluster, *garagev1beta1.GarageNode, *runtime.Scheme) {
+	t.Helper()
+	s := autoModeLabelTestScheme(t)
+	cluster := &garagev1beta2.GarageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            clusterName,
+			Namespace:       "labels-ns",
+			UID:             types.UID(clusterName + "-uid"),
+			ResourceVersion: "1",
+		},
+		Spec: garagev1beta2.GarageClusterSpec{
+			LayoutPolicy: LayoutPolicyAuto,
+			Zone:         "test-zone",
+			Storage: &garagev1beta2.StorageSpec{
+				Replicas: 1,
+				Metadata: &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+				Data:     &garagev1beta2.VolumeConfig{Size: ptrQuantity(resource.MustParse("10Gi"))},
+			},
+			Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+		},
+	}
+	if tier == tierGateway {
+		cluster.Spec.Gateway = &garagev1beta2.GatewaySpec{Replicas: 1}
+	}
+
+	capacity := resource.MustParse("10Gi")
+	metadataSize := resource.MustParse("1Gi")
+	node := &garagev1beta1.GarageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            nodeName,
+			Namespace:       cluster.Namespace,
+			UID:             types.UID(nodeName + "-uid"),
+			ResourceVersion: "2",
+			Annotations:     map[string]string{"example.com/keep": "annotation"},
+			Finalizers:      []string{"example.com/keep-finalizer"},
+			Labels: map[string]string{
+				labelCluster:       cluster.Name,
+				labelTier:          tier,
+				labelAppManagedBy:  managedByOperatorValue,
+				labelAutoNodeSlot:  nodeName,
+				"example.com/keep": "label",
+			},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(
+				cluster, garagev1beta2.GroupVersion.WithKind(kindGarageCluster),
+			)},
+		},
+		Spec: garagev1beta1.GarageNodeSpec{
+			ClusterRef: garagev1beta1.ClusterReference{Name: cluster.Name},
+			Zone:       "test-zone",
+			Capacity:   &capacity,
+			Storage: &garagev1beta1.NodeStorageConfig{
+				Metadata: &garagev1beta1.NodeVolumeConfig{Size: &metadataSize},
+				Data:     &garagev1beta1.NodeVolumeConfig{Size: &capacity},
+			},
+		},
+		Status: garagev1beta1.GarageNodeStatus{
+			NodeID:             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ObservedPodUID:     "pod-uid-before-label-repair",
+			ObservedGeneration: 7,
+			Connected:          true,
+			InLayout:           true,
+		},
+	}
+	if tier == tierGateway {
+		node.Spec.Gateway = true
+		node.Spec.Capacity = nil
+		node.Spec.Storage.Data = nil
+	}
+	return cluster, node, s
+}
+
+func TestAutoModeReconcileRepairsEveryGeneratedLabelInPlace(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name string
+		tier string
+	}{
+		{name: "storage", tier: tierStorage},
+		{name: "gateway", tier: tierGateway},
+	} {
+		for _, labelKey := range []string{labelCluster, labelTier, labelAppManagedBy, labelAutoNodeSlot} {
+			t.Run(fmt.Sprintf("%s/missing-%s", tc.name, strings.ReplaceAll(labelKey, "/", "_")), func(t *testing.T) {
+				g := gomega.NewWithT(t)
+				clusterName := "auto-label-" + tc.name
+				nodeName := clusterName + "-" + tc.tier + "-0"
+				cluster, node, s := autoModeLabelTestFixture(t, tc.tier, clusterName, nodeName)
+				delete(node.Labels, labelKey)
+
+				beforeSpec := node.Spec.DeepCopy()
+				beforeStatus := node.Status.DeepCopy()
+				beforeAnnotations := mapsClone(node.Annotations)
+				beforeFinalizers := append([]string(nil), node.Finalizers...)
+				beforeOwners := append([]metav1.OwnerReference(nil), node.OwnerReferences...)
+				beforeUID := node.UID
+				base := fake.NewClientBuilder().WithScheme(s).WithObjects(cluster, node).Build()
+				recording := &autoModeLabelRecordingClient{Client: base}
+				reconciler := &GarageClusterReconciler{Client: recording, APIReader: base, Scheme: s}
+
+				var err error
+				if tc.tier == tierGateway {
+					err = reconciler.reconcileAutoModeGatewayNodes(ctx, cluster)
+				} else {
+					err = reconciler.reconcileAutoModeStorageNodes(ctx, cluster)
+				}
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(recording.patches).To(gomega.Equal(1), "label convergence must use one metadata PATCH")
+				g.Expect(recording.updates).To(gomega.Equal(0))
+				g.Expect(recording.deletes).To(gomega.Equal(0))
+
+				got := &garagev1beta1.GarageNode{}
+				g.Expect(base.Get(ctx, client.ObjectKeyFromObject(node), got)).To(gomega.Succeed())
+				expectedLabels := expectedAutoModeNodeLabels(cluster, tc.tier, nodeName)
+				expectedLabels["example.com/keep"] = "label"
+				g.Expect(got.Labels).To(gomega.Equal(expectedLabels))
+				g.Expect(got.Labels).To(gomega.HaveKeyWithValue("example.com/keep", "label"))
+				g.Expect(got.Annotations).To(gomega.Equal(beforeAnnotations))
+				g.Expect(got.Finalizers).To(gomega.Equal(beforeFinalizers))
+				g.Expect(got.OwnerReferences).To(gomega.Equal(beforeOwners))
+				g.Expect(got.UID).To(gomega.Equal(beforeUID))
+				g.Expect(got.Spec).To(gomega.Equal(*beforeSpec))
+				g.Expect(got.Status).To(gomega.Equal(*beforeStatus))
+
+				statefulSets := &appsv1.StatefulSetList{}
+				g.Expect(base.List(ctx, statefulSets, client.InNamespace(cluster.Namespace))).To(gomega.Succeed())
+				g.Expect(statefulSets.Items).To(gomega.BeEmpty())
+				pods := &corev1.PodList{}
+				g.Expect(base.List(ctx, pods, client.InNamespace(cluster.Namespace))).To(gomega.Succeed())
+				g.Expect(pods.Items).To(gomega.BeEmpty())
+			})
+		}
+	}
+}
+
+func TestAutoModeReconcileRepairsParseablePromotedName(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	clusterName := "auto-label-cycle"
+	canonicalName := clusterName + "-storage-0"
+	cluster, node, s := autoModeLabelTestFixture(t, tierStorage, clusterName, canonicalName+cycleSiblingSuffix)
+	delete(node.Labels, labelAutoNodeSlot)
+
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(cluster, node).Build()
+	reconciler := &GarageClusterReconciler{Client: base, APIReader: base, Scheme: s}
+	g.Expect(reconciler.reconcileAutoModeStorageNodes(ctx, cluster)).To(gomega.Succeed())
+
+	got := &garagev1beta1.GarageNode{}
+	g.Expect(base.Get(ctx, client.ObjectKeyFromObject(node), got)).To(gomega.Succeed())
+	g.Expect(got.Labels).To(gomega.HaveKeyWithValue(labelAutoNodeSlot, canonicalName))
+	g.Expect(got.Labels).To(gomega.HaveKeyWithValue(labelCluster, clusterName))
+	g.Expect(got.Labels).To(gomega.HaveKeyWithValue(labelTier, tierStorage))
+	g.Expect(got.Labels).To(gomega.HaveKeyWithValue(labelAppManagedBy, managedByOperatorValue))
+}
+
+func TestAutoModeReconcileFailsClosedForBoundedPromotedNameWithoutSlot(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	clusterName := strings.Repeat("a", 50)
+	canonicalName := clusterName + "-storage-0"
+	promotedName := boundedGarageNodeName(canonicalName + cycleSiblingSuffix)
+	cluster, node, s := autoModeLabelTestFixture(t, tierStorage, clusterName, promotedName)
+	delete(node.Labels, labelAutoNodeSlot)
+
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(cluster, node).Build()
+	reconciler := &GarageClusterReconciler{Client: base, APIReader: base, Scheme: s}
+	err := reconciler.reconcileAutoModeStorageNodes(ctx, cluster)
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("refusing to guess a bounded cycle identity")))
+
+	got := &garagev1beta1.GarageNode{}
+	g.Expect(base.Get(ctx, client.ObjectKeyFromObject(node), got)).To(gomega.Succeed())
+	g.Expect(got.Labels).NotTo(gomega.HaveKey(labelAutoNodeSlot))
+	g.Expect(got.UID).To(gomega.Equal(node.UID))
+	nodes := &garagev1beta1.GarageNodeList{}
+	g.Expect(base.List(ctx, nodes, client.InNamespace(cluster.Namespace))).To(gomega.Succeed())
+	g.Expect(nodes.Items).To(gomega.HaveLen(1))
+}
+
+func TestAutoModeReconcileRepairsBoundedPromotedNameWithPersistedSlot(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	clusterName := strings.Repeat("b", 50)
+	canonicalName := clusterName + "-storage-0"
+	promotedName := boundedGarageNodeName(canonicalName + cycleSiblingSuffix)
+	cluster, node, s := autoModeLabelTestFixture(t, tierStorage, clusterName, promotedName)
+	node.Labels[labelAutoNodeSlot] = canonicalName
+	delete(node.Labels, labelCluster)
+	delete(node.Labels, labelTier)
+	delete(node.Labels, labelAppManagedBy)
+
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(cluster, node).Build()
+	reconciler := &GarageClusterReconciler{Client: base, APIReader: base, Scheme: s}
+	g.Expect(reconciler.reconcileAutoModeStorageNodes(ctx, cluster)).To(gomega.Succeed())
+
+	got := &garagev1beta1.GarageNode{}
+	g.Expect(base.Get(ctx, client.ObjectKeyFromObject(node), got)).To(gomega.Succeed())
+	expectedLabels := expectedAutoModeNodeLabels(cluster, tierStorage, canonicalName)
+	expectedLabels["example.com/keep"] = "label"
+	g.Expect(got.Labels).To(gomega.Equal(expectedLabels))
+}
+
+func TestAutoModeReconcileRejectsUnownedCanonicalCollision(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		foreignUID types.UID
+	}{
+		{name: "ownerless"},
+		{name: "foreign-owner", foreignUID: "different-cluster-uid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			ctx := context.Background()
+			clusterName := "auto-label-collision-" + tc.name
+			canonicalName := clusterName + "-storage-0"
+			cluster, node, s := autoModeLabelTestFixture(t, tierStorage, clusterName, canonicalName)
+			if tc.foreignUID == "" {
+				node.OwnerReferences = nil
+			} else {
+				foreign := &garagev1beta2.GarageCluster{ObjectMeta: metav1.ObjectMeta{
+					Name: "foreign", Namespace: cluster.Namespace, UID: tc.foreignUID,
+				}}
+				node.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(
+					foreign, garagev1beta2.GroupVersion.WithKind(kindGarageCluster),
+				)}
+			}
+			beforeLabels := mapsClone(node.Labels)
+			base := fake.NewClientBuilder().WithScheme(s).WithObjects(cluster, node).Build()
+			recording := &autoModeLabelRecordingClient{Client: base}
+			reconciler := &GarageClusterReconciler{Client: recording, APIReader: base, Scheme: s}
+
+			err := reconciler.reconcileAutoModeStorageNodes(ctx, cluster)
+			g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("occupied without the exact GarageCluster controller UID")))
+			g.Expect(recording.patches).To(gomega.Equal(0))
+			g.Expect(recording.updates).To(gomega.Equal(0))
+			g.Expect(recording.deletes).To(gomega.Equal(0))
+
+			got := &garagev1beta1.GarageNode{}
+			g.Expect(base.Get(ctx, client.ObjectKeyFromObject(node), got)).To(gomega.Succeed())
+			g.Expect(got.Labels).To(gomega.Equal(beforeLabels))
+		})
+	}
+}
+
+func mapsClone(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3517,7 +3517,7 @@ func (r *GarageClusterReconciler) reconcilePerNodeLoadBalancerServices(ctx conte
 		for i := int32(0); i < replicas; i++ {
 			canonicalName := autoModeGarageNodeName(cluster.Name, i)
 			nodeName := canonicalName
-			_, current, err := resolveAutoModeCycleSlot(existing, canonicalName)
+			_, current, err := resolveAutoModeCycleSlotForCluster(existing, canonicalName, cluster, tierStorage)
 			if err != nil {
 				return fmt.Errorf("resolving Auto storage ordinal %d for per-node RPC Service: %w", i, err)
 			}

--- a/internal/controller/garagenode_cycle_test.go
+++ b/internal/controller/garagenode_cycle_test.go
@@ -788,8 +788,9 @@ var _ = Describe("GarageNode graceful cycle", func() {
 		Expect(names).To(ConsistOf("garage-storage-0-cycle", "bounded-hash-replacement"))
 		Expect(active).NotTo(BeNil())
 		Expect(active.Name).To(Equal("bounded-hash-replacement"))
-		_, current, err := resolveAutoModeCycleSlot(existing, canonical)
+		names, current, err := resolveAutoModeCycleSlot(existing, canonical)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(names).To(ConsistOf("garage-storage-0-cycle", "bounded-hash-replacement"))
 		Expect(current).NotTo(BeNil())
 		Expect(current.Name).To(Equal("bounded-hash-replacement"),
 			"a deleting canonical is an ancestor, while the promoted identity remains updateable")


### PR DESCRIPTION
Fixes #387

## Summary

Auto-mode GarageNode membership currently depends on mutable generated labels. If a `cluster`, `tier`, `app.kubernetes.io/managed-by`, or `auto-node-slot` label is removed or changed, the parent can lose the node from its managed set and repeatedly ignore an `AlreadyExists` result for the canonical name. The node can remain healthy while topology membership, cleanup, or future convergence silently stops.

This is the same apply-once-without-a-reconcile-backstop failure that caused the nineteen-hour Robbinsdale Garage outage: a missing routing label became permanent because no reconcile repaired it.

## Change

- Discover GarageNodes with an authoritative namespace scan in addition to the mutable label selection.
- Admit a repair only with the exact `GarageCluster` controller reference (API version, kind, name, namespace, and UID), a non-external/non-node-local identity, and an unambiguous Auto slot.
- Repair exactly four operator-owned labels with an optimistic-lock metadata PATCH, then return so a later reconcile handles any ordinary spec convergence.
- Resolve canonical and parseable `-cycle` names from their stable name even when the slot label drifted.
- Require the persisted slot label for a hash-bounded promoted cycle. If that label is missing or invalid, reconciliation fails closed rather than guessing the slot.
- Reject an unowned or foreign object occupying a canonical name; never adopt it or overwrite its metadata.

The patch does not modify owner references, specs, annotations, finalizers, status, PVCs, StatefulSets, Pods, or Garage layout state. It cannot initiate a workload restart or layout operation.

## Validation

- `flock -o -w3600 /workspace/briefs/cos-heavy-build.lock env CGO_ENABLED=0 make test`
- `flock -o -w3600 /workspace/briefs/cos-heavy-build.lock env CGO_ENABLED=0 make lint`
- Focused fake-client tests cover storage and unified gateway nodes, all four missing labels, promoted-cycle resolution, bounded-cycle fail-closed behavior, valid persisted-slot repair, canonical collisions, metadata preservation, unchanged GarageNode UID, and no StatefulSet/Pod mutation.

## Post-release canary plan

Run only after the PR is merged and a release is explicitly approved. Do not use this PR as authorization to change a live cluster.

1. Select one existing Auto-mode storage or unified-gateway GarageNode with an exact owner reference and a canonical or valid persisted cycle slot. Record its GarageNode UID, all four generated labels, unrelated labels/annotations/finalizers, owner references, child StatefulSet UID/generation, serving Pod UID/readiness, Garage health/layout status, and Service/EndpointSlice membership.
2. Induce one controlled generated-label drift, starting with `app.kubernetes.io/managed-by` or `garage.rajsingh.info/cluster`. Do not delete the GarageNode, StatefulSet, Pod, PVC, or any Garage data.
3. Wait for one normal parent reconcile and verify that the expected label is restored by an in-place PATCH, the GarageNode UID is unchanged, and no second same-slot GarageNode exists.
4. Verify the child StatefulSet UID and generation and the serving Pod UID/readiness remain unchanged; verify Garage layout/health and Service/EndpointSlice membership have no unintended changes.
5. Repeat for slot drift only on a canonical or parseable-cycle node. Do not attempt to reconstruct a missing slot on a hash-bounded promoted name; confirm the explicit fail-closed log/error instead.
6. If the repair is wrong, restore the prior label values with an equally narrow metadata patch; do not delete/recreate the node or alter its owner reference.

This PR is intentionally not a merge or release request. The operator rollout and live canary remain for maintainer approval.
