### PR TITLE
fix: converge managed resource drift and cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          version: v2.13.2
           args: --timeout=5m
 
   workflows:

--- a/Makefile
+++ b/Makefile
@@ -642,7 +642,7 @@ ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; 
 ENVTEST_K8S_VERSION ?= 1.36.2
 
 SETUP_ENVTEST_VERSION ?= v0.24.0
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/internal/controller/finalization_identity_test.go
+++ b/internal/controller/finalization_identity_test.go
@@ -710,17 +710,17 @@ func failingFinalizationServer() *httptest.Server {
 
 func finalizationRetryHandle(endpoint string) (*garagev1beta2.GarageCluster, *corev1.Secret) {
 	return &garagev1beta2.GarageCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "handle", Namespace: "garage", UID: "handle-uid"},
-			Spec: garagev1beta2.GarageClusterSpec{ConnectTo: &garagev1beta2.ConnectToConfig{
-				AdminAPIEndpoint: endpoint,
-				AdminTokenSecretRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "admin-token"}, Key: "token",
-				},
-			}},
-		}, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "admin-token", Namespace: "garage"},
-			Data:       map[string][]byte{"token": []byte("prefix.secret")},
-		}
+		ObjectMeta: metav1.ObjectMeta{Name: "handle", Namespace: "garage", UID: "handle-uid"},
+		Spec: garagev1beta2.GarageClusterSpec{ConnectTo: &garagev1beta2.ConnectToConfig{
+			AdminAPIEndpoint: endpoint,
+			AdminTokenSecretRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "admin-token"}, Key: "token",
+			},
+		}},
+	}, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-token", Namespace: "garage"},
+		Data:       map[string][]byte{"token": []byte("prefix.secret")},
+	}
 }
 
 func TestGarageBucketFinalizationRetryAnnotationSurvivesStatusConflict(t *testing.T) {

--- a/internal/controller/garageadmintoken_controller.go
+++ b/internal/controller/garageadmintoken_controller.go
@@ -122,7 +122,7 @@ func (r *GarageAdminTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err := r.Update(ctx, token); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	// Reconcile the admin token secret

--- a/internal/controller/garagebucket_controller.go
+++ b/internal/controller/garagebucket_controller.go
@@ -216,7 +216,7 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				return ctrl.Result{}, fmt.Errorf("failed to update bucket with owner reference: %w", err)
 			}
 			// Re-enqueue so we continue with the updated object.
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 		}
 	} else if clusterNamespace != bucket.Namespace {
 		log.V(1).Info("Skipping owner reference: bucket and cluster are in different namespaces",
@@ -340,7 +340,7 @@ func (r *GarageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err := r.Update(ctx, bucket); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	if err := r.handleBucketAnnotations(ctx, bucket, garageClient); err != nil {

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -244,7 +244,7 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.Update(ctx, cluster); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 	prerequisiteBlocked, prerequisiteRetryAfter, err := r.blockForNodeLocalPoolPrerequisites(ctx, cluster)
 	if err != nil {
@@ -270,7 +270,7 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if err := r.Update(ctx, cluster); err != nil {
 				return ctrl.Result{}, fmt.Errorf("removing processed skip-dead-nodes annotations: %w", err)
 			}
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 		}
 	}
 	if referencedLayoutBoundaryActive {
@@ -426,7 +426,7 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.completeLegacyRPCEnvironmentMigration(ctx, cluster); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 	// Create or update ConfigMap(s) and get config hashes for pod restart triggering.
 	// Storage and gateway tiers may use different rpc_public_addr values when both
@@ -696,7 +696,7 @@ func (r *GarageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				// Cross an immediate reconciliation boundary after the status write.
 				// Durability comes from the persisted actor, not from sleeping for the
 				// periodic safety interval before deleting its old Pod.
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 			}
 			return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 		}
@@ -3580,12 +3580,11 @@ func (r *GarageClusterReconciler) reconcilePerNodeLoadBalancerServices(ctx conte
 		}
 	}
 
-	serviceList := &corev1.ServiceList{}
-	if err := r.List(ctx, serviceList, client.InNamespace(cluster.Namespace), client.MatchingLabels(r.labelsForCluster(cluster))); err != nil {
+	services, err := r.listPerNodeRPCServices(ctx, cluster)
+	if err != nil {
 		return err
 	}
-	for i := range serviceList.Items {
-		svc := &serviceList.Items[i]
+	for _, svc := range services {
 		if !isClusterPerNodeRPCServiceName(cluster.Name, svc.Name) {
 			continue
 		}
@@ -3610,12 +3609,11 @@ func (r *GarageClusterReconciler) deletePublicEndpointServices(ctx context.Conte
 		return err
 	}
 
-	serviceList := &corev1.ServiceList{}
-	if err := r.List(ctx, serviceList, client.InNamespace(cluster.Namespace), client.MatchingLabels(r.labelsForCluster(cluster))); err != nil {
+	services, err := r.listPerNodeRPCServices(ctx, cluster)
+	if err != nil {
 		return err
 	}
-	for i := range serviceList.Items {
-		svc := &serviceList.Items[i]
+	for _, svc := range services {
 		if !isClusterPerNodeRPCServiceName(cluster.Name, svc.Name) {
 			continue
 		}
@@ -3628,6 +3626,38 @@ func (r *GarageClusterReconciler) deletePublicEndpointServices(ctx context.Conte
 		}
 	}
 	return nil
+}
+
+// listPerNodeRPCServices keeps the label selector as the fast path while also
+// inspecting convention-named Services whose labels have drifted. The latter
+// is necessary because a stale Service hidden by label filtering would survive
+// forever when the desired ordinal set shrinks.
+func (r *GarageClusterReconciler) listPerNodeRPCServices(ctx context.Context, cluster *garagev1beta2.GarageCluster) ([]*corev1.Service, error) {
+	byName := make(map[string]*corev1.Service)
+	add := func(list *corev1.ServiceList) {
+		for i := range list.Items {
+			svc := &list.Items[i]
+			byName[svc.Name] = svc
+		}
+	}
+
+	labelled := &corev1.ServiceList{}
+	if err := r.List(ctx, labelled, client.InNamespace(cluster.Namespace), client.MatchingLabels(r.labelsForCluster(cluster))); err != nil {
+		return nil, err
+	}
+	add(labelled)
+
+	all := &corev1.ServiceList{}
+	if err := r.List(ctx, all, client.InNamespace(cluster.Namespace)); err != nil {
+		return nil, err
+	}
+	add(all)
+
+	services := make([]*corev1.Service, 0, len(byName))
+	for _, svc := range byName {
+		services = append(services, svc)
+	}
+	return services, nil
 }
 
 func (r *GarageClusterReconciler) deletePublicEndpointService(ctx context.Context, cluster *garagev1beta2.GarageCluster, name string) error {

--- a/internal/controller/garagecluster_controller_test.go
+++ b/internal/controller/garagecluster_controller_test.go
@@ -434,6 +434,50 @@ var _ = Describe("GarageCluster Controller", func() {
 				To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
 			Expect(sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled).
 				To(Equal(appsv1.RetainPersistentVolumeClaimRetentionPolicyType))
+
+			By("reverting to Delete/Delete when the explicit policy is removed")
+			cluster.Spec.Gateway.PVCRetentionPolicy = nil
+			Expect(reconciler.reconcileGatewayStatefulSet(ctx, cluster, "test-config-hash")).To(Succeed())
+			Expect(k8sClient.Get(ctx, key, sts)).To(Succeed())
+			Expect(sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted).
+				To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+			Expect(sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled).
+				To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+		})
+
+		It("repairs gateway StatefulSet metadata drift without recreating the StatefulSet", func() {
+			cluster := &garagev1beta2.GarageCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: testNamespace},
+				Spec: garagev1beta2.GarageClusterSpec{
+					Gateway:     &garagev1beta2.GatewaySpec{Replicas: 0},
+					Replication: &garagev1beta2.ReplicationConfig{Factor: 1},
+					ConnectTo:   &garagev1beta2.ConnectToConfig{BootstrapPeers: []string{testBootstrapPeer}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			reconciler := &GarageClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			Expect(reconciler.reconcileGatewayStatefulSet(ctx, cluster, "test-config-hash")).To(Succeed())
+			key := types.NamespacedName{Name: resourceName + "-gateway", Namespace: testNamespace}
+			before := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, key, before)).To(Succeed())
+			podSpecHash := before.Spec.Template.Annotations[annotationPodSpecHash]
+			configHash := before.Spec.Template.Annotations[annotationConfigHash]
+
+			delete(before.Spec.Template.Labels, labelCluster)
+			delete(before.Spec.Template.Annotations, annotationGatewayDataMarker)
+			before.Labels[labelAppManagedBy] = "drifted"
+			Expect(k8sClient.Update(ctx, before)).To(Succeed())
+
+			Expect(reconciler.reconcileGatewayStatefulSet(ctx, cluster, "test-config-hash")).To(Succeed())
+			after := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, key, after)).To(Succeed())
+			Expect(after.UID).To(Equal(before.UID))
+			Expect(after.Spec.Template.Labels).To(HaveKeyWithValue(labelCluster, resourceName))
+			Expect(after.Spec.Template.Annotations).To(HaveKeyWithValue(annotationGatewayDataMarker, gatewayDataMarkerLegacyContent))
+			Expect(after.Spec.Template.Annotations[annotationPodSpecHash]).To(Equal(podSpecHash))
+			Expect(after.Spec.Template.Annotations[annotationConfigHash]).To(Equal(configHash))
+			Expect(after.Labels).To(Equal(reconciler.labelsForTier(cluster, tierGateway)))
 		})
 
 		It("should honor a user-supplied gateway metadata size", func() {

--- a/internal/controller/garagecluster_factor_migration.go
+++ b/internal/controller/garagecluster_factor_migration.go
@@ -140,7 +140,7 @@ func (r *GarageClusterReconciler) reconcileFactorMigration(ctx context.Context, 
 		r.setFactorMigration(ctx, cluster, func(m *garagev1beta2.FactorMigrationStatus) {
 			*m = garagev1beta2.FactorMigrationStatus{Phase: fmPhaseValidating, ToFactor: toFactor, Force: force, StartedAt: &now}
 		})
-		return ctrl.Result{Requeue: true}, r.removeAnnotations(ctx, cluster, garagev1beta1.AnnotationPurgeClusterLayout)
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, r.removeAnnotations(ctx, cluster, garagev1beta1.AnnotationPurgeClusterLayout)
 	}
 
 	// In-flight: the annotation should already be consumed; remove it defensively
@@ -246,7 +246,7 @@ func (r *GarageClusterReconciler) fmValidate(ctx context.Context, cluster *garag
 		m.PurgeID = purgeIDFromStart(m)
 		m.Message = fmt.Sprintf("validated; reducing/setting replication factor to %d across %d storage nodes", toFactor, len(nodes))
 	})
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 }
 
 // fmScaleDown suspends the per-node controllers and scales every storage
@@ -294,7 +294,7 @@ func (r *GarageClusterReconciler) fmScaleDown(ctx context.Context, cluster *gara
 		m.Phase = fmPhasePurging
 		m.Message = "all storage pods terminated; deleting on-disk cluster_layout"
 	})
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 }
 
 // fmPurge prepares every storage StatefulSet while the entire tier remains at
@@ -349,7 +349,7 @@ func (r *GarageClusterReconciler) fmPurge(ctx context.Context, cluster *garagev1
 		m.Phase = fmPhaseVerifying
 		m.Message = "storage pods restarting with purged layout at the new factor"
 	})
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 }
 
 // patchSTSConfigRevisionForFactorMigration moves a quiesced, suspended
@@ -571,7 +571,7 @@ func (r *GarageClusterReconciler) fmVerify(ctx context.Context, cluster *garagev
 		m.Phase = fmPhaseRebuildingLayout
 		m.Message = "all storage pods Ready; rebuilding the layout from scratch"
 	})
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 }
 
 // fmRebuildLayout re-stages EVERY node role (purging cluster_layout wiped them
@@ -682,7 +682,7 @@ func (r *GarageClusterReconciler) fmRebuildLayout(ctx context.Context, cluster *
 		m.Phase = fmPhaseConverging
 		m.Message = fmt.Sprintf("layout rebuilt at factor %d with %d storage roles", m.ToFactor, len(changes))
 	})
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 }
 
 // fmConverge resumes the per-node controllers and finalizes. A Tables repair is

--- a/internal/controller/garagecluster_factor_migration_test.go
+++ b/internal/controller/garagecluster_factor_migration_test.go
@@ -207,8 +207,8 @@ func fmDrive(t *testing.T, r *GarageClusterReconciler, name string) (*garagev1be
 				break
 			}
 		}
-		if res.RequeueAfter > 0 {
-			break // grace requeue — settled for test purposes
+		if res.RequeueAfter >= time.Second {
+			break // grace requeue — settled for test purposes; nanosecond requeues are immediate boundaries
 		}
 	}
 	out := &garagev1beta2.GarageCluster{}

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -252,7 +252,11 @@ func (r *GarageClusterReconciler) reconcileGatewayStatefulSet(ctx context.Contex
 		existing.Spec.Template.Annotations[annotationPodSpecHash] != podSpecHashStr {
 		needsUpdate = true
 	}
-	if gw.PVCRetentionPolicy != nil && !equality.Semantic.DeepEqual(
+	if !equality.Semantic.DeepEqual(existing.Spec.Template.Labels, sts.Spec.Template.Labels) ||
+		!equality.Semantic.DeepEqual(existing.Spec.Template.Annotations, sts.Spec.Template.Annotations) {
+		needsUpdate = true
+	}
+	if !equality.Semantic.DeepEqual(
 		existing.Spec.PersistentVolumeClaimRetentionPolicy,
 		sts.Spec.PersistentVolumeClaimRetentionPolicy,
 	) {
@@ -266,9 +270,7 @@ func (r *GarageClusterReconciler) reconcileGatewayStatefulSet(ctx context.Contex
 	}
 	existing.Spec.Replicas = sts.Spec.Replicas
 	existing.Spec.Template = sts.Spec.Template
-	if gw.PVCRetentionPolicy != nil {
-		existing.Spec.PersistentVolumeClaimRetentionPolicy = sts.Spec.PersistentVolumeClaimRetentionPolicy
-	}
+	existing.Spec.PersistentVolumeClaimRetentionPolicy = sts.Spec.PersistentVolumeClaimRetentionPolicy
 	// Re-assert operator labels + controllerRef so ownerRef/label drift
 	// self-heals (the STS selector is immutable and is intentionally left
 	// untouched). sts already had SetControllerReference applied above.

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -224,7 +224,7 @@ func (r *GarageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err := r.Update(ctx, key); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	// Reconcile the key
@@ -1279,7 +1279,8 @@ func (r *GarageKeyReconciler) reconcileSecret(ctx context.Context, key *garagev1
 	// Skip update if nothing changed — avoids triggering Owns() watch and re-reconciliation
 	if secretDataEqual(existing.Data, secretData) &&
 		mapsEqual(existing.Labels, cfg.labels) &&
-		mapsEqual(existing.Annotations, cfg.annotations) {
+		mapsEqual(existing.Annotations, cfg.annotations) &&
+		existing.Type == cfg.secretType {
 		key.Status.SecretRef = &corev1.SecretReference{Name: cfg.name, Namespace: cfg.namespace}
 		return r.finishGarageKeySecretHandoff(ctx, key, previousRef)
 	}
@@ -1287,6 +1288,7 @@ func (r *GarageKeyReconciler) reconcileSecret(ctx context.Context, key *garagev1
 	existing.Data = secretData
 	existing.Labels = cfg.labels
 	existing.Annotations = cfg.annotations
+	existing.Type = cfg.secretType
 	if err := r.Update(ctx, existing); err != nil {
 		return fmt.Errorf("failed to update secret: %w", err)
 	}
@@ -1628,7 +1630,7 @@ func (r *GarageKeyReconciler) updateStatusFromGarage(ctx context.Context, key *g
 			if err := UpdateStatusWithRetry(ctx, r.Client, key); err != nil {
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 		}
 		return r.updateStatus(ctx, key, PhaseFailed, fmt.Errorf("failed to get key info: %w", err))
 	}

--- a/internal/controller/garagekey_permissions_test.go
+++ b/internal/controller/garagekey_permissions_test.go
@@ -138,6 +138,101 @@ func TestReconcileSecret_RefusesForeignExistingSecret(t *testing.T) {
 	}
 }
 
+func TestReconcileSecret_RepairsSecretTypeWithoutChangingData(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = garagev1beta1.AddToScheme(scheme)
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "key", Namespace: testNamespace, UID: types.UID("key-uid")},
+		Spec: garagev1beta1.GarageKeySpec{SecretTemplate: &garagev1beta1.SecretTemplate{
+			IncludeEndpoint: boolPtr(false),
+			IncludeRegion:   boolPtr(false),
+			Type:            corev1.SecretTypeDockerConfigJson,
+		}},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: "GKowned"},
+	}
+	cfg := resolveSecretConfig(key)
+	cfg.labels[keyGeneratedSecretOwnerLabel] = string(key.UID)
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.Name, Namespace: key.Namespace,
+			Labels: cfg.labels, Annotations: cfg.annotations,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			defaultAccessKeyIDKey:     []byte("GKowned"),
+			defaultSecretAccessKeyKey: []byte("secret"),
+		},
+	}
+	if err := controllerutil.SetControllerReference(key, existing, scheme); err != nil {
+		t.Fatal(err)
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&garagev1beta1.GarageKey{}).
+		WithObjects(key, existing).Build()
+	r := &GarageKeyReconciler{Client: fc, Scheme: scheme, ClusterDomain: "cluster.local"}
+
+	if err := r.reconcileSecret(t.Context(), key, &garagev1beta2.GarageCluster{}, "secret"); err != nil {
+		t.Fatal(err)
+	}
+	got := &corev1.Secret{}
+	if err := fc.Get(t.Context(), client.ObjectKeyFromObject(existing), got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != corev1.SecretTypeDockerConfigJson {
+		t.Fatalf("secret type = %q, want %q", got.Type, corev1.SecretTypeDockerConfigJson)
+	}
+	if string(got.Data[defaultAccessKeyIDKey]) != "GKowned" || string(got.Data[defaultSecretAccessKeyKey]) != "secret" {
+		t.Fatalf("secret data changed while repairing type: %#v", got.Data)
+	}
+}
+
+func TestReconcileSecret_DataUpdateAlsoRepairsSecretType(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = garagev1beta1.AddToScheme(scheme)
+	key := &garagev1beta1.GarageKey{
+		ObjectMeta: metav1.ObjectMeta{Name: "key", Namespace: testNamespace, UID: types.UID("key-uid")},
+		Spec: garagev1beta1.GarageKeySpec{SecretTemplate: &garagev1beta1.SecretTemplate{
+			IncludeEndpoint: boolPtr(false),
+			IncludeRegion:   boolPtr(false),
+			Type:            corev1.SecretTypeTLS,
+		}},
+		Status: garagev1beta1.GarageKeyStatus{AccessKeyID: "GKowned"},
+	}
+	cfg := resolveSecretConfig(key)
+	cfg.labels[keyGeneratedSecretOwnerLabel] = string(key.UID)
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.Name, Namespace: key.Namespace,
+			Labels: cfg.labels, Annotations: cfg.annotations,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			defaultAccessKeyIDKey:     []byte("GKowned"),
+			defaultSecretAccessKeyKey: []byte("old-secret"),
+		},
+	}
+	if err := controllerutil.SetControllerReference(key, existing, scheme); err != nil {
+		t.Fatal(err)
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&garagev1beta1.GarageKey{}).
+		WithObjects(key, existing).Build()
+	r := &GarageKeyReconciler{Client: fc, Scheme: scheme, ClusterDomain: "cluster.local"}
+
+	if err := r.reconcileSecret(t.Context(), key, &garagev1beta2.GarageCluster{}, "new-secret"); err != nil {
+		t.Fatal(err)
+	}
+	got := &corev1.Secret{}
+	if err := fc.Get(t.Context(), client.ObjectKeyFromObject(existing), got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != corev1.SecretTypeTLS || string(got.Data[defaultSecretAccessKeyKey]) != "new-secret" {
+		t.Fatalf("secret type/data = %q/%q, want TLS/new-secret", got.Type, got.Data[defaultSecretAccessKeyKey])
+	}
+}
+
 func TestReconcileSecret_RetryCleansOldSecretAfterPersistedHandoff(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -188,7 +188,7 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := UpdateStatusWithRetry(ctx, r.Client, node, apply); err != nil {
 			return ctrl.Result{}, fmt.Errorf("canonicalizing GarageNode status.nodeId: %w", err)
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	// Get the cluster reference
@@ -486,7 +486,7 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := r.Update(ctx, node); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 	if err := validateGarageClusterRuntimeSafety(cluster); err != nil {
 		return r.updateStatus(ctx, node, PhaseFailed,
@@ -541,7 +541,7 @@ func (r *GarageNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := UpdateStatusWithRetry(ctx, r.Client, node, apply); err != nil {
 			return ctrl.Result{}, fmt.Errorf("clearing stale parent-owned GarageNode deletion intent: %w", err)
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	// garage.rajsingh.info/drain is a reversible prepare operation, not an
@@ -1522,6 +1522,15 @@ func (r *GarageNodeReconciler) reconcileStatefulSetWithRecoveryFence(
 		log.Info("StatefulSet update strategy changed", "old", existing.Spec.UpdateStrategy.Type, "new", sts.Spec.UpdateStrategy.Type)
 		needsUpdate = true
 	}
+	if !needsUpdate && (!equality.Semantic.DeepEqual(existing.Spec.Template.Labels, sts.Spec.Template.Labels) ||
+		!equality.Semantic.DeepEqual(existing.Spec.Template.Annotations, sts.Spec.Template.Annotations)) {
+		log.Info("StatefulSet template metadata drifted, updating")
+		needsUpdate = true
+	}
+	if !needsUpdate && !equality.Semantic.DeepEqual(existing.Labels, sts.Labels) {
+		log.Info("StatefulSet labels drifted, updating")
+		needsUpdate = true
+	}
 	if !needsUpdate && !equality.Semantic.DeepEqual(
 		existing.Spec.PersistentVolumeClaimRetentionPolicy,
 		sts.Spec.PersistentVolumeClaimRetentionPolicy,
@@ -1547,6 +1556,8 @@ func (r *GarageNodeReconciler) reconcileStatefulSetWithRecoveryFence(
 	existing.Spec.Replicas = &replicas
 	existing.Spec.UpdateStrategy = sts.Spec.UpdateStrategy
 	existing.Spec.PersistentVolumeClaimRetentionPolicy = sts.Spec.PersistentVolumeClaimRetentionPolicy
+	existing.Labels = sts.Labels
+	existing.OwnerReferences = sts.OwnerReferences
 	if existing.Annotations == nil {
 		existing.Annotations = make(map[string]string)
 	}

--- a/internal/controller/garagenode_controller_test.go
+++ b/internal/controller/garagenode_controller_test.go
@@ -1676,6 +1676,7 @@ var _ = Describe("GarageNode per-node env/envFrom/logging/snapshots", func() {
 		}
 		_ = deleteTestGarageConfigResourcesForCluster(ctx, k8sClient, clusterName)
 		_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace}})
+		_ = k8sClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-0", Namespace: testNamespace}})
 		_ = deleteTestManagedNodePVCs(ctx, k8sClient, testNamespace, nodeName)
 	}
 
@@ -1755,6 +1756,70 @@ var _ = Describe("GarageNode per-node env/envFrom/logging/snapshots", func() {
 		Expect(markerVolume.DownwardAPI).NotTo(BeNil())
 		Expect(markerVolume.DownwardAPI.Items).To(HaveLen(1))
 		Expect(markerVolume.DownwardAPI.Items[0].FieldRef.FieldPath).To(Equal(gatewayDataMarkerFieldPath))
+	})
+
+	It("repairs StatefulSet template metadata drift without replacing the OnDelete Pod", func() {
+		cluster := makeCluster(ctx, nil, nil)
+		node := &garagev1beta1.GarageNode{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: testNamespace},
+			Spec: garagev1beta1.GarageNodeSpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: clusterName},
+				Zone:       testNodeZone,
+				Gateway:    true,
+				Storage: &garagev1beta1.NodeStorageConfig{
+					Metadata: &garagev1beta1.NodeVolumeConfig{Size: ptrQuantity(resource.MustParse("1Gi"))},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+
+		r := &GarageNodeReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		Expect(r.reconcileStatefulSet(ctx, node, cluster)).To(Succeed())
+		key := types.NamespacedName{Name: nodeName, Namespace: testNamespace}
+		before := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, key, before)).To(Succeed())
+		podSpecHash := before.Spec.Template.Annotations[annotationPodSpecHash]
+		configHash := before.Spec.Template.Annotations[annotationConfigHash]
+
+		podLabels := make(map[string]string, len(before.Spec.Template.Labels))
+		for k, v := range before.Spec.Template.Labels {
+			podLabels[k] = v
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName + "-0",
+				Namespace: testNamespace,
+				Labels:    podLabels,
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(
+					before, appsv1.SchemeGroupVersion.WithKind("StatefulSet"),
+				)},
+			},
+			Spec: *before.Spec.Template.Spec.DeepCopy(),
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: "metadata", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		podUID := pod.UID
+
+		delete(before.Spec.Template.Labels, labelCluster)
+		delete(before.Spec.Template.Annotations, annotationGatewayDataMarker)
+		before.Labels[labelAppManagedBy] = "drifted"
+		Expect(k8sClient.Update(ctx, before)).To(Succeed())
+
+		Expect(r.reconcileStatefulSet(ctx, node, cluster)).To(Succeed())
+		after := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, key, after)).To(Succeed())
+		Expect(after.UID).To(Equal(before.UID))
+		Expect(after.Spec.Template.Labels).To(HaveKeyWithValue(labelCluster, clusterName))
+		Expect(after.Spec.Template.Annotations).To(HaveKeyWithValue(annotationGatewayDataMarker, gatewayDataMarkerLegacyContent))
+		Expect(after.Spec.Template.Annotations[annotationPodSpecHash]).To(Equal(podSpecHash))
+		Expect(after.Spec.Template.Annotations[annotationConfigHash]).To(Equal(configHash))
+		Expect(after.Labels).To(HaveKeyWithValue(labelAppManagedBy, operatorName))
+
+		unchangedPod := &corev1.Pod{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, unchangedPod)).To(Succeed())
+		Expect(unchangedPod.UID).To(Equal(podUID))
 	})
 
 	It("uses per-node logging override over cluster logging", func() {

--- a/internal/controller/garagenode_cycle.go
+++ b/internal/controller/garagenode_cycle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -311,7 +312,7 @@ func (r *GarageNodeReconciler) reconcileCycle(
 				return ctrl.Result{}, err
 			}
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	siblingName := boundedGarageNodeName(node.Name + cycleSiblingSuffix)
@@ -650,7 +651,7 @@ func (r *GarageNodeReconciler) reconcileCycleCancellation(
 	if err := UpdateStatusWithRetry(ctx, r.Client, node, apply); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
 }
 
 func validateCycleSiblingActor(

--- a/internal/controller/garagenode_daemonset_backed_test.go
+++ b/internal/controller/garagenode_daemonset_backed_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -120,7 +121,7 @@ var _ = Describe("GarageNode DaemonSet-backed mode", func() {
 		By("first reconcile adds the finalizer and requeues")
 		res, err := r.Reconcile(ctx, req)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(Equal(reconcile.Result{Requeue: true}))
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: time.Nanosecond}))
 
 		By("second reconcile runs the workload phase; the Garage admin API is unreachable in envtest, which is fine — workload objects are created before that point")
 		_, _ = r.Reconcile(ctx, req)

--- a/internal/controller/publicendpoint_test.go
+++ b/internal/controller/publicendpoint_test.go
@@ -289,6 +289,33 @@ var _ = Describe("publicEndpoint reconciliation", func() {
 			cond := findCondition(updated.Status.Conditions, garagev1beta1.ConditionPublicEndpointReady)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+			By("deleting an operator-owned stale Service even after its labels drift")
+			stale := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-1-rpc", Namespace: peNamespace}, stale)).To(Succeed())
+			stale.Labels = nil
+			Expect(k8sClient.Update(ctx, stale)).To(Succeed())
+			updated.Spec.Storage.Replicas = 1
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+			Expect(reconciler.reconcilePerNodeLoadBalancerServices(
+				ctx, updated, 3901, updated.Spec.PublicEndpoint.LoadBalancer.ServiceMeta,
+			)).To(Succeed())
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: peClusterName + "-1-rpc", Namespace: peNamespace}, &corev1.Service{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+			By("leaving a foreign same-name Service untouched")
+			foreign := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: peClusterName + "-2-rpc", Namespace: peNamespace},
+				Spec: corev1.ServiceSpec{
+					Type:  corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{{Name: rpcPortName, Port: 3901}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, foreign)).To(Succeed())
+			Expect(reconciler.reconcilePerNodeLoadBalancerServices(
+				ctx, updated, 3901, updated.Spec.PublicEndpoint.LoadBalancer.ServiceMeta,
+			)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: foreign.Name, Namespace: foreign.Namespace}, &corev1.Service{})).To(Succeed())
 		})
 
 		It("creates per-node LoadBalancer RPC services for gateway-only (edge-gateway) cluster", func() {

--- a/internal/cosi/bucket_controller.go
+++ b/internal/cosi/bucket_controller.go
@@ -182,7 +182,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rec
 		if err := r.Update(ctx, bucket); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	result, err := r.Provisioner.EnsureBucket(ctx, bucket.Name, params)

--- a/internal/cosi/bucketaccess_controller.go
+++ b/internal/cosi/bucketaccess_controller.go
@@ -106,7 +106,7 @@ func (r *BucketAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if !done {
 			return reconcile.Result{RequeueAfter: time.Second}, nil
 		}
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 	accessIdentity := identity.Identity
 	ownsLegacyAccount := identity.OwnsLegacyAccount
@@ -170,7 +170,7 @@ func (r *BucketAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err := r.Update(ctx, access); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: time.Nanosecond}, nil
 	}
 
 	// Reserve secrets first — any race condition fails before we mutate Garage state.

--- a/internal/cosi/cancellation_integration_test.go
+++ b/internal/cosi/cancellation_integration_test.go
@@ -61,17 +61,17 @@ func cancellationScheme(t *testing.T) *runtime.Scheme {
 
 func cancellationHandle(endpoint string) (*garagev1beta2.GarageCluster, *corev1.Secret) {
 	return &garagev1beta2.GarageCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: cancellationCluster, Namespace: cancellationNamespace, UID: "handle-uid"},
-			Spec: garagev1beta2.GarageClusterSpec{ConnectTo: &garagev1beta2.ConnectToConfig{
-				AdminAPIEndpoint: endpoint,
-				AdminTokenSecretRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "admin-token"}, Key: "token",
-				},
-			}},
-		}, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "admin-token", Namespace: cancellationNamespace},
-			Data:       map[string][]byte{"token": []byte("prefix.secret")},
-		}
+		ObjectMeta: metav1.ObjectMeta{Name: cancellationCluster, Namespace: cancellationNamespace, UID: "handle-uid"},
+		Spec: garagev1beta2.GarageClusterSpec{ConnectTo: &garagev1beta2.ConnectToConfig{
+			AdminAPIEndpoint: endpoint,
+			AdminTokenSecretRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "admin-token"}, Key: "token",
+			},
+		}},
+	}, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-token", Namespace: cancellationNamespace},
+		Data:       map[string][]byte{"token": []byte("prefix.secret")},
+	}
 }
 
 func TestPendingCOSIParentCancellationWaitsForExactRemoteCleanup(t *testing.T) {

--- a/internal/cosi/shadow.go
+++ b/internal/cosi/shadow.go
@@ -190,7 +190,8 @@ func (m *ShadowManager) ReserveShadowBucket(ctx context.Context, cosiName, clust
 		return nil, false, fmt.Errorf("GarageBucket reservation %s/%s has unknown provisioning state %q", existing.Namespace, existing.Name, state)
 	}
 	needsFinalizer := !containsString(existing.Finalizers, garagev1beta1.GarageBucketFinalizer)
-	if owner == "" || needsFinalizer {
+	needsCorrelationLabel := existing.Labels[LabelCOSIBucketClaim] != truncateLabelValue(cosiName)
+	if owner == "" || needsFinalizer || needsCorrelationLabel {
 		patch := client.MergeFrom(existing.DeepCopy())
 		if existing.Annotations == nil {
 			existing.Annotations = map[string]string{}
@@ -200,6 +201,12 @@ func (m *ShadowManager) ReserveShadowBucket(ctx context.Context, cosiName, clust
 		}
 		if needsFinalizer {
 			existing.Finalizers = append(existing.Finalizers, garagev1beta1.GarageBucketFinalizer)
+		}
+		if needsCorrelationLabel {
+			if existing.Labels == nil {
+				existing.Labels = map[string]string{}
+			}
+			existing.Labels[LabelCOSIBucketClaim] = truncateLabelValue(cosiName)
 		}
 		if err := m.client.Patch(ctx, existing, patch); err != nil {
 			return nil, false, err
@@ -243,6 +250,13 @@ func (m *ShadowManager) BindShadowBucket(ctx context.Context, bucket *garagev1be
 	if bucketID == "" {
 		return nil, fmt.Errorf("cannot bind an empty Garage bucket ID")
 	}
+	if bucket.Labels[LabelCOSIManaged] != paramTrue {
+		return nil, fmt.Errorf("refusing to bind non-COSI GarageBucket %s/%s", bucket.Namespace, bucket.Name)
+	}
+	owner := bucket.Annotations[annotationCOSIReservationOwner]
+	if owner == "" {
+		return nil, fmt.Errorf("refusing to bind GarageBucket %s/%s without a COSI reservation owner", bucket.Namespace, bucket.Name)
+	}
 	trackedID := bucket.Annotations[AnnotationCOSIBucketID]
 	state := bucket.Annotations[garagev1beta1.AnnotationCOSIProvisioningState]
 	if trackedID != "" && trackedID != bucketID {
@@ -260,11 +274,12 @@ func (m *ShadowManager) BindShadowBucket(ctx context.Context, bucket *garagev1be
 			return nil, fmt.Errorf("persist COSI bucket ownership status before handoff: %w", err)
 		}
 	}
-	desired := shadowBucket(bucket.Annotations[annotationCOSIReservationOwner], bucket.Spec.ClusterRef.Name, bucket.Spec.ClusterRef.Namespace, params)
+	desired := shadowBucket(owner, bucket.Spec.ClusterRef.Name, bucket.Spec.ClusterRef.Namespace, params)
 	bucket.Spec = desired.Spec
 	if bucket.Labels == nil {
 		bucket.Labels = map[string]string{}
 	}
+	bucket.Labels[LabelCOSIBucketClaim] = truncateLabelValue(owner)
 	bucket.Labels[LabelCOSIBucketID] = truncateLabelValue(bucketID)
 	if bucket.Annotations == nil {
 		bucket.Annotations = map[string]string{}
@@ -599,7 +614,8 @@ func (m *ShadowManager) ReserveShadowKey(ctx context.Context, cosiName, clusterR
 		return nil, false, fmt.Errorf("GarageKey reservation %s/%s has unknown provisioning state %q", existing.Namespace, existing.Name, state)
 	}
 	needsFinalizer := !containsString(existing.Finalizers, garagev1beta1.GarageKeyFinalizer)
-	if owner == "" || needsFinalizer {
+	needsCorrelationLabel := existing.Labels[LabelCOSIBucketAccess] != truncateLabelValue(cosiName)
+	if owner == "" || needsFinalizer || needsCorrelationLabel {
 		patch := client.MergeFrom(existing.DeepCopy())
 		if existing.Annotations == nil {
 			existing.Annotations = map[string]string{}
@@ -609,6 +625,12 @@ func (m *ShadowManager) ReserveShadowKey(ctx context.Context, cosiName, clusterR
 		}
 		if needsFinalizer {
 			existing.Finalizers = append(existing.Finalizers, garagev1beta1.GarageKeyFinalizer)
+		}
+		if needsCorrelationLabel {
+			if existing.Labels == nil {
+				existing.Labels = map[string]string{}
+			}
+			existing.Labels[LabelCOSIBucketAccess] = truncateLabelValue(cosiName)
 		}
 		if err := m.client.Patch(ctx, existing, patch); err != nil {
 			return nil, false, err
@@ -859,18 +881,25 @@ func (m *ShadowManager) BindShadowKey(ctx context.Context, key *garagev1beta1.Ga
 	if accountID == "" {
 		return nil, fmt.Errorf("cannot bind an empty Garage account ID")
 	}
+	if key.Labels[LabelCOSIManaged] != paramTrue {
+		return nil, fmt.Errorf("refusing to bind non-COSI GarageKey %s/%s", key.Namespace, key.Name)
+	}
+	owner := key.Annotations[annotationCOSIReservationOwner]
+	if owner == "" {
+		return nil, fmt.Errorf("refusing to bind GarageKey %s/%s without a COSI reservation owner", key.Namespace, key.Name)
+	}
 	if tracked := key.Annotations[AnnotationCOSIAccountID]; tracked != "" && tracked != accountID {
 		return nil, fmt.Errorf("shadow key %s/%s belongs to account %q, not %q", key.Namespace, key.Name, tracked, accountID)
 	}
 	if err := m.persistShadowKeyStatusID(ctx, key, "", accountID); err != nil {
 		return nil, err
 	}
-	owner := key.Annotations[annotationCOSIReservationOwner]
 	desired := shadowKey(owner, key.Spec.ClusterRef.Name, key.Spec.ClusterRef.Namespace, permissions, serviceAccountName)
 	key.Spec = desired.Spec
 	if key.Labels == nil {
 		key.Labels = map[string]string{}
 	}
+	key.Labels[LabelCOSIBucketAccess] = truncateLabelValue(owner)
 	key.Labels[LabelCOSIAccountID] = truncateLabelValue(accountID)
 	if key.Annotations == nil {
 		key.Annotations = map[string]string{}

--- a/internal/cosi/shadow_test.go
+++ b/internal/cosi/shadow_test.go
@@ -344,6 +344,66 @@ func TestReservationsInstallCleanupFinalizersOnInitialCreate(t *testing.T) {
 	assert.Contains(t, key.Finalizers, garagev1beta1.GarageKeyFinalizer)
 }
 
+func TestShadowReservationsRestoreMissingCorrelationLabels(t *testing.T) {
+	t.Run("bucket reservation and bind", func(t *testing.T) {
+		bucket := shadowBucket("claim", testMyCluster, testGarageSystem, nil)
+		bucket.Namespace = testGarageSystem
+		bucket.Labels["example.com/keep"] = "yes"
+		delete(bucket.Labels, LabelCOSIBucketClaim)
+		client := newCOSIClientBuilder().WithScheme(newTestScheme()).WithObjects(bucket).Build()
+		mgr := NewShadowManager(client, testGarageSystem)
+
+		reserved, created, err := mgr.ReserveShadowBucket(t.Context(), "claim", testMyCluster, testGarageSystem, nil)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.Equal(t, "claim", reserved.Labels[LabelCOSIBucketClaim])
+		require.Equal(t, "yes", reserved.Labels["example.com/keep"])
+
+		delete(reserved.Labels, LabelCOSIBucketClaim)
+		bound, err := mgr.BindShadowBucket(t.Context(), reserved, testBucketID, nil)
+		require.NoError(t, err)
+		require.Equal(t, "claim", bound.Labels[LabelCOSIBucketClaim])
+		require.Equal(t, "yes", bound.Labels["example.com/keep"])
+	})
+
+	t.Run("key reservation and bind", func(t *testing.T) {
+		key := shadowKey("access", testMyCluster, testGarageSystem, nil, "")
+		key.Namespace = testGarageSystem
+		key.Labels["example.com/keep"] = "yes"
+		delete(key.Labels, LabelCOSIBucketAccess)
+		client := newCOSIClientBuilder().WithScheme(newTestScheme()).WithObjects(key).Build()
+		mgr := NewShadowManager(client, testGarageSystem)
+
+		reserved, created, err := mgr.ReserveShadowKey(t.Context(), "access", testMyCluster, testGarageSystem, nil, "")
+		require.NoError(t, err)
+		require.False(t, created)
+		require.Equal(t, "access", reserved.Labels[LabelCOSIBucketAccess])
+		require.Equal(t, "yes", reserved.Labels["example.com/keep"])
+
+		delete(reserved.Labels, LabelCOSIBucketAccess)
+		bound, err := mgr.BindShadowKey(t.Context(), reserved, testGKTestKey, nil, "")
+		require.NoError(t, err)
+		require.Equal(t, "access", bound.Labels[LabelCOSIBucketAccess])
+		require.Equal(t, "yes", bound.Labels["example.com/keep"])
+	})
+}
+
+func TestShadowBucketCleanupRefusesOutOfScopeCorrelation(t *testing.T) {
+	bucket := shadowBucket("claim", testMyCluster, testGarageSystem, nil)
+	bucket.Namespace = testGarageSystem
+	bucket.Status.BucketID = testBucketID
+	bucket.Annotations[AnnotationCOSIBucketID] = testBucketID
+	bucket.Labels[LabelCOSIManaged] = paramTrue
+	bucket.Labels[LabelCOSIBucketID] = truncateLabelValue(testBucketID)
+	bucket.Labels[LabelCOSIBucketClaim] = "other-claim"
+	client := newCOSIClientBuilder().WithScheme(newTestScheme()).WithObjects(bucket).Build()
+	mgr := NewShadowManager(client, testGarageSystem)
+
+	owned, err := mgr.OwnsShadowBucket(t.Context(), "claim", testBucketID)
+	require.NoError(t, err)
+	require.False(t, owned)
+}
+
 func TestForgetShadowBucketUpgradesLegacyExactIdentityBeforeRetain(t *testing.T) {
 	legacy := shadowBucket("claim", testMyCluster, testGarageSystem, nil)
 	legacy.Namespace = testGarageSystem


### PR DESCRIPTION
## Summary
- converge generated Secret types during GarageKey reconciliation
- restore COSI shadow correlation labels only after exact reservation proof, while preserving fail-closed ownership checks
- converge gateway and GarageNode StatefulSet metadata, PVC retention, and template drift without unnecessary GarageNode Pod restarts
- discover and clean stale per-node RPC Services by exact convention name plus verified controller ownership, even when cluster labels are damaged
- migrate deprecated reconcile requeue fields and update lint tooling to golangci-lint v2.13.2

## Verification
- `make test`
- `make test-race`
- `make verify-generate`
- golangci-lint v2.13.2: 0 issues
- `git diff --check`

## Issues
Fixes #392
Fixes #391
Fixes #390
Fixes #389
Fixes #388
Fixes #369

#370 is intentionally not closed: this PR does not claim to reproduce or resolve the separate multi-cluster layout-version inconsistency investigation.