### PR TITLE
feature: ensure vmanagedpvcfinalizer.kb.io validating webhook only intercepts PVCs managed by garage-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -630,7 +630,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
-CONTROLLER_TOOLS_VERSION ?= v0.20.1
+CONTROLLER_TOOLS_VERSION ?= v0.22.0
 
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageadmintokens.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageadmintokens.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garageadmintokens.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagebuckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagebuckets.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garageclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garageclusters.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagekeys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagekeys.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagenodes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagenodes.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/charts/garage-operator/crd-bases/garage.rajsingh.info_garagereferencegrants.yaml
+++ b/charts/garage-operator/crd-bases/garage.rajsingh.info_garagereferencegrants.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagereferencegrants.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/charts/garage-operator/templates/webhooks.yaml
+++ b/charts/garage-operator/templates/webhooks.yaml
@@ -209,6 +209,10 @@ webhooks:
     resources:
     - persistentvolumeclaims
   sideEffects: None
+  # Keep failurePolicy: Fail from gating unrelated PVCs when the operator is down.
+  objectSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: garage-operator
   {{- include "garage-operator.webhookNamespaceSelector" . | nindent 2 }}
 - name: vgarageadmintoken.kb.io
   admissionReviewVersions:

--- a/config/crd/bases/garage.rajsingh.info_garageadmintokens.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageadmintokens.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garageadmintokens.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagebuckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagebuckets.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garageclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garageclusters.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagekeys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagekeys.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagenodes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagenodes.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/config/crd/bases/garage.rajsingh.info_garagereferencegrants.yaml
+++ b/config/crd/bases/garage.rajsingh.info_garagereferencegrants.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: garagereferencegrants.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -283,6 +283,9 @@ webhooks:
       path: /validate-core-v1-managed-pvc-finalizer
   failurePolicy: Fail
   name: vmanagedpvcfinalizer.kb.io
+  objectSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: garage-operator
   rules:
   - apiGroups:
     - ""

--- a/internal/controller/garagecluster_node_local_rollout_test.go
+++ b/internal/controller/garagecluster_node_local_rollout_test.go
@@ -2641,8 +2641,8 @@ func TestStorageRolloutSelectsStatefulSetActorWithoutNodeLocalPools(t *testing.T
 		t.Fatal(err)
 	}
 	finalizer := storageRolloutPVCFinalizer(cluster)
-	if finalizer == "" || !controllerutil.ContainsFinalizer(claim, finalizer) {
-		t.Fatalf("exact PVC was not protected before Pod DELETE: finalizers=%v", claim.Finalizers)
+	if finalizer == "" || !controllerutil.ContainsFinalizer(claim, finalizer) || claim.Labels[labelAppManagedBy] != operatorName {
+		t.Fatalf("exact PVC was not protected before Pod DELETE: finalizers=%v labels=%v", claim.Finalizers, claim.Labels)
 	}
 	// Model an administrator overriding the transaction protection so the
 	// same-name recreation defense is exercised independently of the finalizer.

--- a/internal/controller/managed_pvc_webhook.go
+++ b/internal/controller/managed_pvc_webhook.go
@@ -59,7 +59,7 @@ func SetupManagedPVCFinalizerWebhook(server webhook.Server, controllerUsername s
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-core-v1-managed-pvc-finalizer,mutating=false,failurePolicy=fail,sideEffects=None,groups="",resources=persistentvolumeclaims,verbs=update,versions=v1,name=vmanagedpvcfinalizer.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-core-v1-managed-pvc-finalizer,mutating=false,failurePolicy=fail,sideEffects=None,groups="",resources=persistentvolumeclaims,verbs=update,versions=v1,name=vmanagedpvcfinalizer.kb.io,admissionReviewVersions=v1,patch=`{"objectSelector":{"matchLabels":{"app.kubernetes.io/managed-by":"garage-operator"}}}`
 
 type managedPVCFinalizerValidator struct {
 	controllerUsername string

--- a/internal/controller/storage_rollout.go
+++ b/internal/controller/storage_rollout.go
@@ -208,10 +208,12 @@ func (r *GarageClusterReconciler) protectStorageRolloutPersistentVolumeClaims(
 		if string(claim.UID) != expected.UID || !claim.DeletionTimestamp.IsZero() {
 			return fmt.Errorf("PVC %s changed UID or began deletion before storage rollout protection", key.String())
 		}
-		if controllerutil.ContainsFinalizer(claim, finalizer) {
+		if controllerutil.ContainsFinalizer(claim, finalizer) && claim.Labels[labelAppManagedBy] == operatorName {
 			continue
 		}
 		before := claim.DeepCopy()
+		// The finalizer is only enforced by the webhook on claims carrying this label.
+		metav1.SetMetaDataLabel(&claim.ObjectMeta, labelAppManagedBy, operatorName)
 		controllerutil.AddFinalizer(claim, finalizer)
 		if err := r.Patch(ctx, claim, client.MergeFrom(before)); err != nil {
 			return fmt.Errorf("adding storage rollout protection to exact PVC %s UID %s: %w", key.String(), claim.UID, err)


### PR DESCRIPTION
# Pull request

## Summary

The garage-operator's `vmanagedpvcfinalizer.kb.io` validating webhook intercepts **every** `PersistentVolumeClaim` `UPDATE` across the **entire cluster**. This means that if garage operator is broken or this is somehow hanging, no PVC can be changed.

## Related issue or design

N.A

## Compatibility and operational impact

None as the `objectSelector` is a GA field of `admissionregistration.k8s.io/v1`, which is the API the chart and kustomize manifests already use for every webhook. The chart requires Kubernetes 1.25 or newer and the field has been in v1 since 1.16. The only behavioural difference is that PVCs without the operator's label no longer reach the webhook, which is the point.

## Validation

Commands run:

- `make manifests generate` — regenerated with controller-gen v0.22.0; only diff is the
  version stamp on each CRD and the new `objectSelector` in
  `config/webhook/manifests.yaml`
- `make helm-verify-crd-bases` — chart CRDs in sync
- `make helm-lint` and `make helm-template` — `objectSelector` rendered on
  `vmanagedpvcfinalizer.kb.io` only; the 14 `namespaceSelector` entries in scoped mode
  are unchanged
- `kustomize build config/default` — selector present without any kustomize patch
- `make lint` — 0 issues
- `go test $(go list ./... | grep -v /e2e$) -count=1` with envtest assets — all packages pass,
  including the existing storage-rollout test which now also asserts the
  `app.kubernetes.io/managed-by` label is set alongside the rollout finalizer

Not run:

- `make test` as-is: fails locally with `go: no such tool "covdata"` from the Go 1.26
  toolchain module (unrelated to this change; the same suite passes without `-coverprofile`).
- End-to-end on a real cluster.
## Checklist

- [X] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [X] Tests cover the changed behavior.
- [X] User-facing docs and samples are updated where needed.
- [X] Generated files were regenerated and committed where needed.
- [X] Release-only chart version fields are unchanged.
