### PR TITLE
fix: ensure generate metadata does not overwrite existing and unmanaged labels and annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -730,6 +730,7 @@ Import test: `go get git.deuxfleurs.fr/garage-sdk/garage-admin-sdk-golang` succe
 5. **Single-node clusters** - Supported for multi-cluster federation (1 replica per K8s cluster)
 6. **Node identity in metadata_dir** - Garage stores `node_key` (Ed25519 private key) in `metadata_dir`. This file determines the node ID. Both storage and gateway clusters need persistent metadata to preserve node identity across restarts (see `garage/src/rpc/system.rs:gen_node_key`)
 7. **No operator-internal S3 key** - Since v2.3.0, lifecycle rules are managed via the Admin API (`UpdateBucket`), so the operator no longer needs an internal S3 access key. The `--operator-namespace` flag is kept for backward-compat CLI parsing only and has no effect.
+8. **Owned metadata is merged, never replaced** - Every update path for an operator-managed object (Secrets, ConfigMaps, Services, StatefulSets, DaemonSets, PDBs, ServiceMonitors, generated GarageNodes) goes through `mergeOwnedMetadata` (`internal/controller/helpers.go`). It overlays only the keys the operator sets and reports whether anything changed, so labels/annotations stamped by other controllers survive and a converged object is not rewritten. Replacing the maps wholesale looped forever against Kyverno (`generate.kyverno.io/clone-source`) because the operator `Owns()` the object and every rewrite re-triggered both controllers. Stale operator-set keys are intentionally not tracked or removed.
 
 ### Port Defaults
 

--- a/internal/controller/garage_config_resource.go
+++ b/internal/controller/garage_config_resource.go
@@ -412,31 +412,17 @@ func reconcileGarageConfigSecret(
 	if existing.Immutable != nil && *existing.Immutable && !equality.Semantic.DeepEqual(existing.Data, desired.Data) {
 		return "", fmt.Errorf("immutable sensitive Garage config Secret %s does not match its content-addressed name", key)
 	}
-	managedAnnotationsMatch := true
-	for key, value := range annotations {
-		if existing.Annotations[key] != value {
-			managedAnnotationsMatch = false
-			break
-		}
-	}
-	if equality.Semantic.DeepEqual(existing.Data, desired.Data) &&
-		equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+	metadataChanged := mergeOwnedMetadata(existing, desired)
+	if equality.Semantic.DeepEqual(existing.Data, desired.Data) && !metadataChanged &&
 		equality.Semantic.DeepEqual(existing.OwnerReferences, desired.OwnerReferences) &&
 		equality.Semantic.DeepEqual(existing.Immutable, desired.Immutable) &&
-		existing.Type == desired.Type && managedAnnotationsMatch {
+		existing.Type == desired.Type {
 		return revision, nil
 	}
 	existing.Data = desired.Data
-	existing.Labels = desired.Labels
 	existing.OwnerReferences = desired.OwnerReferences
 	existing.Immutable = desired.Immutable
 	existing.Type = desired.Type
-	if existing.Annotations == nil {
-		existing.Annotations = make(map[string]string)
-	}
-	for key, value := range annotations {
-		existing.Annotations[key] = value
-	}
 	return revision, c.Update(ctx, existing)
 }
 
@@ -479,28 +465,14 @@ func reconcileGarageConfigMap(
 	if existing.Immutable != nil && *existing.Immutable && !equality.Semantic.DeepEqual(existing.Data, desired.Data) {
 		return "", fmt.Errorf("immutable Garage config ConfigMap %s does not match its content-addressed name", key)
 	}
-	managedAnnotationsMatch := true
-	for key, value := range managedAnnotations {
-		if existing.Annotations[key] != value {
-			managedAnnotationsMatch = false
-			break
-		}
-	}
-	if equality.Semantic.DeepEqual(existing.Data, desired.Data) &&
-		equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+	metadataChanged := mergeOwnedMetadata(existing, desired)
+	if equality.Semantic.DeepEqual(existing.Data, desired.Data) && !metadataChanged &&
 		equality.Semantic.DeepEqual(existing.OwnerReferences, desired.OwnerReferences) &&
-		equality.Semantic.DeepEqual(existing.Immutable, desired.Immutable) && managedAnnotationsMatch {
+		equality.Semantic.DeepEqual(existing.Immutable, desired.Immutable) {
 		return revision, nil
 	}
 	existing.Data = desired.Data
-	existing.Labels = desired.Labels
 	existing.OwnerReferences = desired.OwnerReferences
 	existing.Immutable = desired.Immutable
-	if existing.Annotations == nil {
-		existing.Annotations = make(map[string]string)
-	}
-	for key, value := range managedAnnotations {
-		existing.Annotations[key] = value
-	}
 	return revision, c.Update(ctx, existing)
 }

--- a/internal/controller/garageadmintoken_controller.go
+++ b/internal/controller/garageadmintoken_controller.go
@@ -274,16 +274,14 @@ func (r *GarageAdminTokenReconciler) reconcileSecret(ctx context.Context, token 
 		if existing.Immutable != nil && *existing.Immutable && !equality.Semantic.DeepEqual(existing.Data, secretData) {
 			return fmt.Errorf("immutable static bootstrap Secret %s/%s data differs from its declared contract; create a replacement GarageAdminToken and rotate the GarageCluster reference", secretNamespace, secretName)
 		}
+		metadataChanged := mergeOwnedMetadata(existing, secret)
 		if equality.Semantic.DeepEqual(existing.Data, secretData) &&
-			equality.Semantic.DeepEqual(existing.Labels, labels) &&
-			equality.Semantic.DeepEqual(existing.Annotations, annotations) && existing.Type == secret.Type &&
+			!metadataChanged && existing.Type == secret.Type &&
 			existing.Immutable != nil && *existing.Immutable {
 			token.Status.SecretRef = &corev1.SecretReference{Name: secretName, Namespace: secretNamespace}
 			return nil
 		}
 		existing.Data = secretData
-		existing.Labels = labels
-		existing.Annotations = annotations
 		existing.Type = secret.Type
 		existing.Immutable = ptr.To(true)
 		if err := r.Update(ctx, existing); err != nil {

--- a/internal/controller/garageadmintoken_controller_test.go
+++ b/internal/controller/garageadmintoken_controller_test.go
@@ -112,6 +112,47 @@ func TestGarageAdminTokenRefusesUnownedSecretCollision(t *testing.T) {
 	}
 }
 
+func TestGarageAdminTokenPreservesForeignSecretMetadata(t *testing.T) {
+	token, cluster := garageAdminTokenFixture()
+	r, c := garageAdminTokenTestReconciler(t, cluster)
+	ctx := context.Background()
+	key := types.NamespacedName{Name: token.Spec.SecretTemplate.Name, Namespace: token.Namespace}
+	reconcileAndGet := func() *corev1.Secret {
+		t.Helper()
+		if err := r.reconcileSecret(ctx, token, cluster); err != nil {
+			t.Fatal(err)
+		}
+		secret := &corev1.Secret{}
+		if err := c.Get(ctx, key, secret); err != nil {
+			t.Fatal(err)
+		}
+		return secret
+	}
+
+	// Another controller stamps its own metadata on the generated Secret, as
+	// Kyverno does on every clone source.
+	secret := reconcileAndGet()
+	secret.Labels["example.com/foreign"] = "keep"
+	secret.Annotations["generate.kyverno.io/clone-source"] = ""
+	if err := c.Update(ctx, secret); err != nil {
+		t.Fatal(err)
+	}
+
+	secret = reconcileAndGet()
+	if _, foreignAnnotation := secret.Annotations["generate.kyverno.io/clone-source"]; !foreignAnnotation ||
+		secret.Labels["example.com/foreign"] != "keep" ||
+		secret.Labels[labelAppManagedBy] != "garage-operator" ||
+		secret.Annotations[annotationStaticBootstrapTokenDigest] != token.Status.TokenDigest {
+		t.Fatalf("reconcile did not merge metadata: labels=%v annotations=%v", secret.Labels, secret.Annotations)
+	}
+
+	// A converged Secret must not be rewritten, or the Owns() watch re-fires
+	// and the operator loops against the foreign controller forever.
+	if before := secret.ResourceVersion; reconcileAndGet().ResourceVersion != before {
+		t.Fatalf("no-op reconcile rewrote the Secret (resourceVersion %s)", before)
+	}
+}
+
 func TestGarageAdminTokenLegacySourceMigratesOnceThenFailsClosedOnDrift(t *testing.T) {
 	token, cluster := garageAdminTokenFixture()
 	raw := []byte(strings.Repeat("ab", 32))

--- a/internal/controller/garagecluster_controller.go
+++ b/internal/controller/garagecluster_controller.go
@@ -3304,12 +3304,11 @@ func (r *GarageClusterReconciler) reconcileTierPodDisruptionBudget(ctx context.C
 	if !metav1.IsControlledBy(existing, cluster) {
 		return fmt.Errorf("refusing to mutate PodDisruptionBudget %s/%s because it is not controlled by GarageCluster UID %s", existing.Namespace, existing.Name, cluster.UID)
 	}
-	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) &&
-		equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+	metadataChanged := mergeOwnedMetadata(existing, desired)
+	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) && !metadataChanged &&
 		metav1.IsControlledBy(existing, cluster) {
 		return nil
 	}
-	existing.Labels = desired.Labels
 	existing.OwnerReferences = desired.OwnerReferences
 	existing.Spec = desired.Spec
 	log.Info("Updating PDB", "name", pdbName, "tier", tier)

--- a/internal/controller/garagecluster_gateway.go
+++ b/internal/controller/garagecluster_gateway.go
@@ -245,7 +245,7 @@ func (r *GarageClusterReconciler) reconcileGatewayStatefulSet(ctx context.Contex
 	}
 
 	needsUpdate := existing.Spec.Replicas == nil || *existing.Spec.Replicas != *sts.Spec.Replicas
-	if !equality.Semantic.DeepEqual(existing.Labels, sts.Labels) || !metav1.IsControlledBy(existing, cluster) {
+	if mergeOwnedMetadata(existing, sts) || !metav1.IsControlledBy(existing, cluster) {
 		needsUpdate = true
 	}
 	if existing.Spec.Template.Annotations[annotationConfigHash] != configHash ||
@@ -271,10 +271,9 @@ func (r *GarageClusterReconciler) reconcileGatewayStatefulSet(ctx context.Contex
 	existing.Spec.Replicas = sts.Spec.Replicas
 	existing.Spec.Template = sts.Spec.Template
 	existing.Spec.PersistentVolumeClaimRetentionPolicy = sts.Spec.PersistentVolumeClaimRetentionPolicy
-	// Re-assert operator labels + controllerRef so ownerRef/label drift
-	// self-heals (the STS selector is immutable and is intentionally left
-	// untouched). sts already had SetControllerReference applied above.
-	existing.Labels = sts.Labels
+	// Re-assert the controllerRef so ownerRef drift self-heals (the STS
+	// selector is immutable and is intentionally left untouched). sts already
+	// had SetControllerReference applied above.
 	existing.OwnerReferences = sts.OwnerReferences
 	log.Info("Updating gateway StatefulSet", "name", name)
 	return r.Update(ctx, existing)

--- a/internal/controller/garagekey_controller.go
+++ b/internal/controller/garagekey_controller.go
@@ -1184,19 +1184,6 @@ func secretDataEqual(a, b map[string][]byte) bool {
 	return true
 }
 
-// mapsEqual returns true if two string maps have identical keys and values.
-func mapsEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		if bv, ok := b[k]; !ok || v != bv {
-			return false
-		}
-	}
-	return true
-}
-
 func (r *GarageKeyReconciler) reconcileSecret(ctx context.Context, key *garagev1beta1.GarageKey, cluster *garagev1beta2.GarageCluster, secretAccessKey string) error {
 	log := logf.FromContext(ctx)
 	var previousRef *corev1.SecretReference
@@ -1276,18 +1263,15 @@ func (r *GarageKeyReconciler) reconcileSecret(ctx context.Context, key *garagev1
 	// secret access key is preserved during an ordinary reconciliation.
 	writeCredentialsFile(secretData, cfg, key.Status.AccessKeyID, string(secretData[cfg.secretAccessKeyKey]))
 
+	metadataChanged := mergeOwnedMetadata(existing, secret)
+
 	// Skip update if nothing changed — avoids triggering Owns() watch and re-reconciliation
-	if secretDataEqual(existing.Data, secretData) &&
-		mapsEqual(existing.Labels, cfg.labels) &&
-		mapsEqual(existing.Annotations, cfg.annotations) &&
-		existing.Type == cfg.secretType {
+	if secretDataEqual(existing.Data, secretData) && !metadataChanged && existing.Type == cfg.secretType {
 		key.Status.SecretRef = &corev1.SecretReference{Name: cfg.name, Namespace: cfg.namespace}
 		return r.finishGarageKeySecretHandoff(ctx, key, previousRef)
 	}
 
 	existing.Data = secretData
-	existing.Labels = cfg.labels
-	existing.Annotations = cfg.annotations
 	existing.Type = cfg.secretType
 	if err := r.Update(ctx, existing); err != nil {
 		return fmt.Errorf("failed to update secret: %w", err)

--- a/internal/controller/garagekey_controller_test.go
+++ b/internal/controller/garagekey_controller_test.go
@@ -29,13 +29,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	garagev1beta1 "github.com/rajsinghtech/garage-operator/api/v1beta1"
+	garagev1beta2 "github.com/rajsinghtech/garage-operator/api/v1beta2"
 	"github.com/rajsinghtech/garage-operator/internal/garage"
 )
 
@@ -679,5 +682,58 @@ var _ = Describe("GarageKey server-side apply migration", func() {
 		}
 		Expect(*effective.Spec.AllBuckets).To(Equal(garagev1beta1.AllBucketsPermission{}))
 		Expect(garagev1beta1.ValidateGarageKeySpec(effective)).To(Succeed())
+	})
+})
+
+var _ = Describe("GarageKey generated Secret metadata", func() {
+	It("preserves labels and annotations set by other controllers and skips no-op writes", func() {
+		key := &garagev1beta1.GarageKey{
+			ObjectMeta: metav1.ObjectMeta{Name: "metadata-merge-key", Namespace: testNamespace},
+			Spec: garagev1beta1.GarageKeySpec{
+				ClusterRef: garagev1beta1.ClusterReference{Name: testClusterName},
+				SecretTemplate: &garagev1beta1.SecretTemplate{
+					IncludeEndpoint: boolPtr(false),
+					Labels:          map[string]string{"app": "merge-test"},
+					Annotations:     map[string]string{"example.com/from-template": "yes"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, key)).To(Succeed())
+
+		By("Pre-creating the owned Secret with metadata written by another controller")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        key.Name,
+				Namespace:   testNamespace,
+				Labels:      map[string]string{"example.com/foreign": "keep"},
+				Annotations: map[string]string{"generate.kyverno.io/clone-source": ""},
+			},
+		}
+		Expect(controllerutil.SetControllerReference(key, secret, k8sClient.Scheme())).To(Succeed())
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, secret)
+			_ = k8sClient.Delete(ctx, key)
+		})
+
+		reconciler := &GarageKeyReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconcileAndGet := func() *corev1.Secret {
+			Expect(reconciler.reconcileSecret(ctx, key, &garagev1beta2.GarageCluster{}, "secret")).To(Succeed())
+			got := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), got)).To(Succeed())
+			return got
+		}
+
+		By("Reconciling and checking foreign metadata survives alongside the operator's keys")
+		got := reconcileAndGet()
+		Expect(got.Labels).To(HaveKeyWithValue("example.com/foreign", "keep"))
+		Expect(got.Annotations).To(HaveKeyWithValue("generate.kyverno.io/clone-source", ""))
+		Expect(got.Labels).To(HaveKeyWithValue(labelAppManagedBy, "garage-operator"))
+		Expect(got.Labels).To(HaveKeyWithValue(keyGeneratedSecretOwnerLabel, string(key.UID)))
+		Expect(got.Labels).To(HaveKeyWithValue("app", "merge-test"))
+		Expect(got.Annotations).To(HaveKeyWithValue("example.com/from-template", "yes"))
+
+		By("Reconciling again against the unchanged Secret and checking it is not rewritten")
+		Expect(reconcileAndGet().ResourceVersion).To(Equal(got.ResourceVersion))
 	})
 })

--- a/internal/controller/garagenode_controller.go
+++ b/internal/controller/garagenode_controller.go
@@ -1527,8 +1527,8 @@ func (r *GarageNodeReconciler) reconcileStatefulSetWithRecoveryFence(
 		log.Info("StatefulSet template metadata drifted, updating")
 		needsUpdate = true
 	}
-	if !needsUpdate && !equality.Semantic.DeepEqual(existing.Labels, sts.Labels) {
-		log.Info("StatefulSet labels drifted, updating")
+	if mergeOwnedMetadata(existing, sts) {
+		log.Info("StatefulSet metadata drifted, updating")
 		needsUpdate = true
 	}
 	if !needsUpdate && !equality.Semantic.DeepEqual(
@@ -1536,10 +1536,6 @@ func (r *GarageNodeReconciler) reconcileStatefulSetWithRecoveryFence(
 		sts.Spec.PersistentVolumeClaimRetentionPolicy,
 	) {
 		log.Info("StatefulSet PVC retention policy changed")
-		needsUpdate = true
-	}
-	if !needsUpdate && existing.Annotations[annotationStorageRolloutInput] != sts.Annotations[annotationStorageRolloutInput] {
-		log.Info("StatefulSet storage rollout input acknowledgment changed")
 		needsUpdate = true
 	}
 	// Restore replicas if the STS was scaled to 0 externally (e.g. during maintenance).
@@ -1556,12 +1552,7 @@ func (r *GarageNodeReconciler) reconcileStatefulSetWithRecoveryFence(
 	existing.Spec.Replicas = &replicas
 	existing.Spec.UpdateStrategy = sts.Spec.UpdateStrategy
 	existing.Spec.PersistentVolumeClaimRetentionPolicy = sts.Spec.PersistentVolumeClaimRetentionPolicy
-	existing.Labels = sts.Labels
 	existing.OwnerReferences = sts.OwnerReferences
-	if existing.Annotations == nil {
-		existing.Annotations = make(map[string]string)
-	}
-	existing.Annotations[annotationStorageRolloutInput] = sts.Annotations[annotationStorageRolloutInput]
 	log.Info("Updating StatefulSet for GarageNode", "name", stsName)
 	return r.Update(ctx, existing)
 }

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
 	"reflect"
@@ -1542,9 +1543,6 @@ func buildGaragePodSpec(
 // mergeLabels merges user labels with operator-managed base labels. Base labels take
 // precedence so users cannot overwrite ownership labels.
 func mergeLabels(base, user map[string]string) map[string]string {
-	if len(user) == 0 {
-		return base
-	}
 	out := make(map[string]string, len(base)+len(user))
 	for k, v := range user {
 		out[k] = v
@@ -1553,6 +1551,25 @@ func mergeLabels(base, user map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+// mergeOwnedMetadata overlays desired's labels and annotations onto existing
+// and reports whether that changed anything. The operator asserts only the
+// keys it sets; keys written by other controllers (Kyverno markers,
+// external-dns hints, load-balancer annotations, ...) are preserved. Replacing
+// the maps wholesale made the operator and the foreign controller overwrite
+// each other forever, since the operator Owns() the object and every rewrite
+// re-triggers a reconcile. Call it unconditionally before an unchanged-check
+// so a no-op reconcile leaves the object identical and skips the Update.
+func mergeOwnedMetadata(existing, desired metav1.Object) bool {
+	labels := mergeLabels(desired.GetLabels(), existing.GetLabels())
+	annotations := mergeLabels(desired.GetAnnotations(), existing.GetAnnotations())
+	if maps.Equal(labels, existing.GetLabels()) && maps.Equal(annotations, existing.GetAnnotations()) {
+		return false
+	}
+	existing.SetLabels(labels)
+	existing.SetAnnotations(annotations)
+	return true
 }
 
 // reconcileService creates or updates a Service. On update, only mutable fields are
@@ -1575,8 +1592,7 @@ func reconcileService(ctx context.Context, c client.Client, desired *corev1.Serv
 		return fmt.Errorf("refusing to mutate Service %s/%s because it is not controlled by exact %T UID %s", existing.Namespace, existing.Name, owner, owner.GetUID())
 	}
 
-	existing.Labels = desired.Labels
-	existing.Annotations = desired.Annotations
+	mergeOwnedMetadata(existing, desired)
 	existing.OwnerReferences = desired.OwnerReferences
 	existing.Spec.Type = desired.Spec.Type
 	existing.Spec.Selector = desired.Spec.Selector

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -1975,5 +1976,32 @@ func TestUpdateStatusWithRetryPreservesDesiredStatusWithoutCallback(t *testing.T
 	}
 	if updates != 2 {
 		t.Fatalf("status updates = %d, want 2", updates)
+	}
+}
+
+func TestMergeOwnedMetadataPreservesForeignKeysAndReportsChange(t *testing.T) {
+	existing := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Labels:      map[string]string{"foreign": "keep", "owned": "stale"},
+		Annotations: map[string]string{"generate.kyverno.io/clone-source": ""},
+	}}
+	desired := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Labels:      map[string]string{"owned": "fresh"},
+		Annotations: map[string]string{"owned": "yes"},
+	}}
+	if !mergeOwnedMetadata(existing, desired) {
+		t.Fatal("drifted owned label was not reported as a change")
+	}
+	wantLabels := map[string]string{"foreign": "keep", "owned": "fresh"}
+	wantAnnotations := map[string]string{"generate.kyverno.io/clone-source": "", "owned": "yes"}
+	if !maps.Equal(existing.Labels, wantLabels) || !maps.Equal(existing.Annotations, wantAnnotations) {
+		t.Fatalf("merge = labels %v annotations %v, want %v / %v", existing.Labels, existing.Annotations, wantLabels, wantAnnotations)
+	}
+	if mergeOwnedMetadata(existing, desired) {
+		t.Fatal("converged metadata was reported as a change")
+	}
+
+	// Empty on both sides must stay a no-op so nil maps are never rewritten as {}.
+	if mergeOwnedMetadata(&corev1.Secret{}, &corev1.Secret{}) {
+		t.Fatal("empty metadata was reported as a change")
 	}
 }

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -106,10 +106,10 @@ func (r *GarageClusterReconciler) reconcileMonitoring(ctx context.Context, clust
 		}
 	}
 
-	if equality.Semantic.DeepEqual(sm.Labels, desired.Labels) && equality.Semantic.DeepEqual(sm.Spec, desired.Spec) {
+	metadataChanged := mergeOwnedMetadata(sm, desired)
+	if !metadataChanged && equality.Semantic.DeepEqual(sm.Spec, desired.Spec) {
 		return nil
 	}
-	sm.Labels = desired.Labels
 	sm.Spec = desired.Spec
 	return r.Update(ctx, sm)
 }

--- a/internal/controller/node_local_pool_daemonset.go
+++ b/internal/controller/node_local_pool_daemonset.go
@@ -257,8 +257,7 @@ func (r *GarageClusterReconciler) reconcileNodeLocalPoolDaemonSetWithRecoveryFen
 	if !equality.Semantic.DeepEqual(existing.Spec.Selector, ds.Spec.Selector) {
 		return fmt.Errorf("existing DaemonSet %s has an incompatible immutable selector; delete the stale resource after confirming its GarageNodes are drained", name)
 	}
-	needsUpdate := !equality.Semantic.DeepEqual(existing.Labels, ds.Labels) ||
-		!equality.Semantic.DeepEqual(existing.Annotations, ds.Annotations) ||
+	needsUpdate := mergeOwnedMetadata(existing, ds) ||
 		!equality.Semantic.DeepEqual(existing.Spec.Template, ds.Spec.Template) ||
 		!equality.Semantic.DeepEqual(existing.Spec.UpdateStrategy, ds.Spec.UpdateStrategy)
 	if !needsUpdate {
@@ -271,8 +270,6 @@ func (r *GarageClusterReconciler) reconcileNodeLocalPoolDaemonSetWithRecoveryFen
 	}
 	existing.Spec.Template = ds.Spec.Template
 	existing.Spec.UpdateStrategy = ds.Spec.UpdateStrategy
-	existing.Labels = ds.Labels
-	existing.Annotations = ds.Annotations
 	existing.OwnerReferences = ds.OwnerReferences
 	log.Info("Updating node-local pool DaemonSet", "name", name, "pool", pool.Name)
 	if err := r.Update(ctx, existing); err != nil {

--- a/internal/controller/node_local_pool_garagenode.go
+++ b/internal/controller/node_local_pool_garagenode.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"maps"
 	"net"
 	"sort"
 	"strconv"
@@ -254,8 +253,7 @@ func nodeLocalPoolStorageNodeNeedsUpdate(current, desired *garagev1beta1.GarageN
 		!equality.Semantic.DeepEqual(current.Spec.Network, desired.Spec.Network) {
 		return true
 	}
-	return !equality.Semantic.DeepEqual(current.Labels, desired.Labels) ||
-		!equality.Semantic.DeepEqual(current.Annotations, desired.Annotations)
+	return false
 }
 
 func nodeLocalPoolCapacityIncreaseWaitsForPodRevision(
@@ -305,7 +303,8 @@ func (r *GarageClusterReconciler) updateNodeLocalPoolGarageNode(
 			fresh.Spec.KubernetesNodeName != desired.Spec.KubernetesNodeName {
 			return fmt.Errorf("garageNode %s no longer represents the expected operator-owned node-local-pool identity", key)
 		}
-		if !nodeLocalPoolStorageNodeNeedsUpdate(fresh, desired) {
+		metadataChanged := mergeOwnedMetadata(fresh, desired)
+		if !metadataChanged && !nodeLocalPoolStorageNodeNeedsUpdate(fresh, desired) {
 			updated = fresh
 			return nil
 		}
@@ -317,8 +316,6 @@ func (r *GarageClusterReconciler) updateNodeLocalPoolGarageNode(
 		fresh.Spec.KubernetesNodeName = desired.Spec.KubernetesNodeName
 		fresh.Spec.NodeLocalPoolName = desired.Spec.NodeLocalPoolName
 		fresh.Spec.Network = desired.Spec.Network
-		fresh.Labels = maps.Clone(desired.Labels)
-		fresh.Annotations = maps.Clone(desired.Annotations)
 		if err := r.Update(ctx, fresh); err != nil {
 			return err
 		}


### PR DESCRIPTION
# Pull request

## Summary

The GarageKey and GarageAdminToken controllers rebuild their generated Secret on every reconcile and replace `metadata.labels` and `metadata.annotations` wholesale before calling `r.Update`. Any label or annotation set on that Secret by another controller is wiped on the next reconcile.

However, this problem is present throughout all objects and such this was all unified in a single merge flow.

## Related issue or design

This PR is just a stopgap measure and using Server Side Apply as described in #399 should be the proper fix. That would also make all of this code redundant.

## Compatibility and operational impact

None

## Validation

None

## Checklist

- [X] The PR addresses one coherent problem and includes its necessary
      robustness fixes.
- [X] Tests cover the changed behavior.
- [X] User-facing docs and samples are updated where needed.
- [X] Generated files were regenerated and committed where needed.
- [X] Release-only chart version fields are unchanged.
