### PR TITLE
fix: deflake multicluster bootstrap

### DIFF
--- a/hack/e2e-multicluster.sh
+++ b/hack/e2e-multicluster.sh
@@ -487,6 +487,51 @@ wait_for_cluster_health_and_nodes() {
     return 1
 }
 
+wait_for_operator_admin_token() {
+    local cluster_name=$1
+    local timeout=$2
+    local ready=""
+
+    log_info "Waiting for GarageCluster/$cluster_name dynamic Admin token proof (timeout: ${timeout}s)..."
+    local end_time=$((SECONDS + timeout))
+    while [ "$SECONDS" -lt "$end_time" ]; do
+        local secrets
+        secrets=$(kubectl get secret -n "$NAMESPACE" \
+            -l 'garage.rajsingh.info/operator-admin-token=true' \
+            -o json --request-timeout=5s 2>/dev/null || true)
+        ready=$(jq -r --arg cluster_name "$cluster_name" '
+            any(.items[]?;
+                (any(.metadata.ownerReferences[]?;
+                    .kind == "GarageCluster" and .name == $cluster_name)) and
+                .metadata.annotations["garage.rajsingh.info/operator-admin-token-ready"] == "true" and
+                (.metadata.annotations["garage.rajsingh.info/operator-admin-token-pod-set"] // "") != ""
+            )
+        ' <<<"$secrets" 2>/dev/null || true)
+        if [ "$ready" = "true" ]; then
+            log_info "GarageCluster/$cluster_name dynamic Admin token is proven on its current Pod set"
+            return 0
+        fi
+        sleep 2
+    done
+
+    log_error "GarageCluster/$cluster_name dynamic Admin token did not become proven (ready=${ready:-unknown})"
+    return 1
+}
+
+wait_for_local_cluster_bootstrap() {
+    local cluster_name=$1
+    local expected_replicas=$2
+    local timeout=$3
+
+    if ! wait_for_cluster_replicas garage "$expected_replicas" "$timeout"; then
+        return 1
+    fi
+    if ! wait_for_cluster_health_and_nodes garage healthy "$expected_replicas" "$timeout"; then
+        return 1
+    fi
+    wait_for_operator_admin_token "$cluster_name" "$timeout"
+}
+
 wait_for_federated_peers() {
     local timeout=${1:-180}
     local minimum=${2:-3}
@@ -513,6 +558,7 @@ wait_for_federated_peers() {
         fi
         sleep 3
     done
+    log_error "Federation did not converge (cluster1 health=${cluster1_health:-unknown}, connected=${cluster1_connected:-unknown}; cluster2 health=${cluster2_health:-unknown}, connected=${cluster2_connected:-unknown})"
     return 1
 }
 
@@ -2801,6 +2847,10 @@ main() {
         kubectl logs deployment/garage-operator -n "$NAMESPACE" --tail=30
         exit 1
     }
+    if ! wait_for_local_cluster_bootstrap "$CLUSTER1_NAME" 2 "$TIMEOUT"; then
+        log_error "Cluster 1: local Garage bootstrap did not converge before federation"
+        exit 1
+    fi
 
     use_cluster "$CLUSTER2_NAME"
     wait_for_pods_ready "garage.rajsingh.info/cluster=garage" 2 "$TIMEOUT" || {
@@ -2808,6 +2858,10 @@ main() {
         kubectl logs deployment/garage-operator -n "$NAMESPACE" --tail=30
         exit 1
     }
+    if ! wait_for_local_cluster_bootstrap "$CLUSTER2_NAME" 2 "$TIMEOUT"; then
+        log_error "Cluster 2: local Garage bootstrap did not converge before federation"
+        exit 1
+    fi
 
     # Step 8: Configure remoteClusters for operator-driven federation
     log_info "=== Step 8: Configuring remoteClusters for operator-driven federation ==="
@@ -2830,9 +2884,11 @@ main() {
     log_info "=== Step 9: Waiting for operator federation ==="
     log_info "  Operator will connect clusters and update layout automatically"
     log_info "  Waiting for federation to establish..."
-    if ! wait_for_federated_peers 180 3; then
-        log_warn "Federation did not reach the expected peer count before the test phase"
+    if ! wait_for_federated_peers "$TIMEOUT" 3; then
+        log_error "Federation did not reach the expected peer count before the test phase"
+        exit 1
     fi
+    log_info "Federation reached the expected peer count on both clusters"
 
     # ========================================================================
     # Run Tests

--- a/hack/e2e-multicluster.sh
+++ b/hack/e2e-multicluster.sh
@@ -519,17 +519,17 @@ wait_for_operator_admin_token() {
 }
 
 wait_for_local_cluster_bootstrap() {
-    local cluster_name=$1
+    local garage_name=$1
     local expected_replicas=$2
     local timeout=$3
 
-    if ! wait_for_cluster_replicas garage "$expected_replicas" "$timeout"; then
+    if ! wait_for_cluster_replicas "$garage_name" "$expected_replicas" "$timeout"; then
         return 1
     fi
-    if ! wait_for_cluster_health_and_nodes garage healthy "$expected_replicas" "$timeout"; then
+    if ! wait_for_cluster_health_and_nodes "$garage_name" healthy "$expected_replicas" "$timeout"; then
         return 1
     fi
-    wait_for_operator_admin_token "$cluster_name" "$timeout"
+    wait_for_operator_admin_token "$garage_name" "$timeout"
 }
 
 wait_for_federated_peers() {
@@ -2847,7 +2847,7 @@ main() {
         kubectl logs deployment/garage-operator -n "$NAMESPACE" --tail=30
         exit 1
     }
-    if ! wait_for_local_cluster_bootstrap "$CLUSTER1_NAME" 2 "$TIMEOUT"; then
+    if ! wait_for_local_cluster_bootstrap garage 2 "$TIMEOUT"; then
         log_error "Cluster 1: local Garage bootstrap did not converge before federation"
         exit 1
     fi
@@ -2858,7 +2858,7 @@ main() {
         kubectl logs deployment/garage-operator -n "$NAMESPACE" --tail=30
         exit 1
     }
-    if ! wait_for_local_cluster_bootstrap "$CLUSTER2_NAME" 2 "$TIMEOUT"; then
+    if ! wait_for_local_cluster_bootstrap garage 2 "$TIMEOUT"; then
         log_error "Cluster 2: local Garage bootstrap did not converge before federation"
         exit 1
     fi

--- a/internal/controller/operator_admin_token.go
+++ b/internal/controller/operator_admin_token.go
@@ -599,7 +599,22 @@ func (r *GarageClusterReconciler) reconcileOperatorAdminToken(
 			return err
 		}
 		if err := verifyDynamicAdminTokenOnPods(ctx, podSet.Pods, getAdminPort(cluster), token); err != nil {
-			return err
+			// The token row and Secret can remain intact while a layout transition
+			// temporarily makes the bearer unavailable on one or more processes. Do
+			// not leave the old Pod-set proof authoritative in that state: shared
+			// clients would keep routing the unproven token through the Service and
+			// turn a retryable 403 into a persistent stale-health snapshot. Keeping
+			// the ready marker while removing its proof makes getReadyOperatorAdminToken
+			// fail closed until this exact live Pod set accepts the token again.
+			if secret.Annotations[annotationOperatorAdminTokenReady] == operatorAdminTokenReadyValue &&
+				secret.Annotations[annotationOperatorAdminTokenPodSet] != "" {
+				before := secret.DeepCopy()
+				delete(secret.Annotations, annotationOperatorAdminTokenPodSet)
+				if err := r.Patch(ctx, secret, client.MergeFrom(before)); err != nil {
+					return fmt.Errorf("dynamic operator token is unproven and clearing its live Pod-set proof: %w", err)
+				}
+			}
+			return fmt.Errorf("%w: %v", errAdminTokenUnproven, err)
 		}
 		if secret.Annotations[annotationOperatorAdminTokenReady] != operatorAdminTokenReadyValue ||
 			secret.Annotations[annotationOperatorAdminTokenPodSet] != podSet.Hash {

--- a/internal/controller/operator_admin_token_pods_test.go
+++ b/internal/controller/operator_admin_token_pods_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -353,6 +354,75 @@ func TestReconcileOperatorAdminTokenRefreshesReplacementPodSetBeforeGarageNodeOb
 	}
 	if got := updatedNode.Status.ObservedPodUID; got != testPreviousPodUID {
 		t.Fatalf("test precondition changed GarageNode observedPodUid to %q", got)
+	}
+}
+
+func TestReconcileOperatorAdminTokenClearsLiveProofAfterVerificationFailure(t *testing.T) {
+	const (
+		staticToken  = "static-token"
+		dynamicID    = "dynamic-id"
+		dynamicToken = dynamicID + ".dynamic-secret"
+	)
+	cluster, objects, _ := unprovenTokenFixture()
+	cluster.Spec.Admin.BindPort = 0
+	for _, object := range objects {
+		if pod, ok := object.(*corev1.Pod); ok {
+			pod.Status.PodIP = "127.0.0.1"
+		}
+	}
+
+	dynamicIDValue := dynamicID
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/v2/GetAdminTokenInfo":
+			if request.Header.Get("Authorization") != "Bearer "+staticToken ||
+				request.URL.Query().Get("id") != dynamicID {
+				http.Error(w, "unexpected bootstrap request", http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(garage.AdminTokenInfo{
+				ID: &dynamicIDValue, Name: operatorAdminTokenName(cluster), Scope: []string{"*"},
+			})
+		case "/v2/GetClusterStatus":
+			if request.Header.Get("Authorization") != "Bearer "+dynamicToken {
+				http.Error(w, "unexpected dynamic request", http.StatusUnauthorized)
+				return
+			}
+			http.Error(w, `{"code":"AccessDenied","message":"Forbidden: Invalid bearer token"}`, http.StatusForbidden)
+		default:
+			http.NotFound(w, request)
+		}
+	}))
+	defer server.Close()
+	cluster.Spec.Admin.BindPort = int32(server.Listener.Addr().(*net.TCPAddr).Port)
+
+	kubeClient := fake.NewClientBuilder().WithScheme(operatorPodSetTestScheme(t)).WithObjects(objects...).Build()
+	reconciler := &GarageClusterReconciler{
+		Client:    kubeClient,
+		APIReader: kubeClient,
+		Scheme:    operatorPodSetTestScheme(t),
+	}
+	if err := reconciler.reconcileOperatorAdminToken(context.Background(), cluster); err == nil ||
+		!stderrors.Is(err, errAdminTokenUnproven) {
+		t.Fatalf("verification failure was not reported as an unproven token: %v", err)
+	}
+
+	updatedSecret := &corev1.Secret{}
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: operatorAdminTokenSecretName(cluster), Namespace: cluster.Namespace},
+	}), updatedSecret); err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSecret.Annotations[annotationOperatorAdminTokenPodSet]; got != "" {
+		t.Fatalf("failed dynamic verification retained live Pod-set proof %q", got)
+	}
+	if got := updatedSecret.Annotations[annotationOperatorAdminTokenReady]; got != operatorAdminTokenReadyValue {
+		t.Fatalf("token intent marker = %q, want %q", got, operatorAdminTokenReadyValue)
+	}
+	if _, ready, err := getReadyOperatorAdminToken(context.Background(), kubeClient, cluster); ready || err == nil ||
+		!stderrors.Is(err, errAdminTokenUnproven) {
+		t.Fatalf("cleared proof was still treated as ready: ready=%t err=%v", ready, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- wait for each local cluster to finish health and dynamic Admin-token proof before enabling federation
- fail closed when a previously proven dynamic token no longer authenticates on the live Pod set
- add a regression test for clearing stale Pod-set proof after a 403 verification failure

## Validation
- `go test ./...`
- `make test-race`
- `./bin/golangci-lint run --new-from-rev=main ./...`
- `bash -n hack/e2e-multicluster.sh`
- `shellcheck -x hack/e2e-multicluster.sh`

The regular lint target remains blocked by two pre-existing gofmt findings outside this change.